### PR TITLE
Add config option to set cookie domain and path.

### DIFF
--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -118,7 +118,7 @@ describe('CommandQueue tests', () => {
         );
     });
 
-    test('when optional parameters are present then it creates nexusConfig with received inputs', async () => {
+    test('when optional parameters are present then create a config with received inputs', async () => {
         (fetch as any).mockReturnValue(
             Promise.resolve(
                 new Response(JSON.stringify(mockPartialOtaConfigFile))

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -1,10 +1,10 @@
-import { CRED_COOKIE_NAME } from '../utils/constants';
 import { CognitoIdentityClient } from './CognitoIdentityClient';
 import { Config } from '../orchestration/Orchestration';
 import { Credentials } from '@aws-sdk/types';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { StsClient } from './StsClient';
 import { storeCookie, getCookie } from '../utils/cookies-utils';
+import { CRED_COOKIE_NAME } from '../utils/constants';
 
 export class Authentication {
     private cognitoIdentityClient: CognitoIdentityClient;
@@ -113,7 +113,7 @@ export class Authentication {
                     storeCookie(
                         CRED_COOKIE_NAME,
                         btoa(JSON.stringify(credentials)),
-                        undefined,
+                        this.config.cookieAttributes,
                         undefined,
                         credentials.expiration
                     );

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -2,11 +2,11 @@ import {
     CognitoIdentityClient,
     fromCognitoIdentityPool
 } from './CognitoIdentityClient';
-import { CRED_COOKIE_NAME } from '../utils/constants';
 import { Config } from '../orchestration/Orchestration';
 import { CredentialProvider, Credentials } from '@aws-sdk/types';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { storeCookie, getCookie } from '../utils/cookies-utils';
+import { CRED_COOKIE_NAME } from '../utils/constants';
 
 export class EnhancedAuthentication {
     private cognitoIdentityClient: CognitoIdentityClient;
@@ -101,7 +101,7 @@ export class EnhancedAuthentication {
                 storeCookie(
                     CRED_COOKIE_NAME,
                     btoa(JSON.stringify(credentials)),
-                    undefined,
+                    this.config.cookieAttributes,
                     undefined,
                     credentials.expiration
                 );

--- a/src/dispatch/__tests__/Authentication.test.ts
+++ b/src/dispatch/__tests__/Authentication.test.ts
@@ -1,7 +1,7 @@
 import { Authentication } from '../Authentication';
 import { CRED_COOKIE_NAME } from '../../utils/constants';
-import { defaultConfig } from '../../orchestration/Orchestration';
 import { removeCookie, storeCookie } from '../../utils/cookies-utils';
+import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
 
 const assumeRole = jest.fn();
 const mockGetId = jest.fn();
@@ -44,20 +44,21 @@ describe('Authentication tests', () => {
             secretAccessKey: 'y',
             sessionToken: 'z'
         });
-        removeCookie(CRED_COOKIE_NAME);
+        removeCookie(CRED_COOKIE_NAME, DEFAULT_CONFIG.cookieAttributes);
     });
 
     // tslint:disable-next-line:max-line-length
     test('when auth cookie is in the store then authentication chain retrieves credentials from cookie', async () => {
         // Init
-        const auth = new Authentication({
-            ...defaultConfig,
+        const config = {
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
                 guestRoleArn: GUEST_ROLE_ARN
             }
-        });
+        };
+        const auth = new Authentication(config);
 
         storeCookie(
             CRED_COOKIE_NAME,
@@ -67,7 +68,8 @@ describe('Authentication tests', () => {
                     secretAccessKey: 'b',
                     sessionToken: 'c'
                 })
-            )
+            ),
+            config.cookieAttributes
         );
 
         // Run
@@ -86,14 +88,15 @@ describe('Authentication tests', () => {
     // tslint:disable-next-line:max-line-length
     test('when auth cookie corrupt then authentication chain retrieves credentials from basic authflow', async () => {
         // Init
-        const auth = new Authentication({
-            ...defaultConfig,
+        const config = {
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
                 guestRoleArn: GUEST_ROLE_ARN
             }
-        });
+        };
+        const auth = new Authentication(config);
 
         storeCookie(
             CRED_COOKIE_NAME,
@@ -101,7 +104,8 @@ describe('Authentication tests', () => {
                 accessKeyId: 'a',
                 secretAccessKey: 'b',
                 sessionToken: 'c'
-            })
+            }),
+            config.cookieAttributes
         );
 
         // Run
@@ -121,7 +125,7 @@ describe('Authentication tests', () => {
     test('when auth cookie is not in the store authentication chain retrieves credentials from basic authflow', async () => {
         // Init
         const auth = new Authentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
@@ -145,15 +149,16 @@ describe('Authentication tests', () => {
     // tslint:disable-next-line:max-line-length
     test('when cookies are not allowed then authentication chain retrieves credentials from basic authflow', async () => {
         // Init
-        const auth = new Authentication({
-            ...defaultConfig,
+        const config = {
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: false,
                 identityPoolId: IDENTITY_POOL_ID,
                 guestRoleArn: GUEST_ROLE_ARN
             }
-        });
-        storeCookie(CRED_COOKIE_NAME, 'a:b:c');
+        };
+        const auth = new Authentication(config);
+        storeCookie(CRED_COOKIE_NAME, 'a:b:c', config.cookieAttributes);
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();
@@ -171,18 +176,19 @@ describe('Authentication tests', () => {
     // tslint:disable-next-line:max-line-length
     test('when cookie expires then authentication chain retrieves credentials from basic authflow', async () => {
         // Init
-        const auth = new Authentication({
-            ...defaultConfig,
+        const config = {
+            ...DEFAULT_CONFIG,
             ...{
-                allowCookies: true,
+                allowCookies: false,
                 identityPoolId: IDENTITY_POOL_ID,
                 guestRoleArn: GUEST_ROLE_ARN
             }
-        });
+        };
+        const auth = new Authentication(config);
         storeCookie(
             CRED_COOKIE_NAME,
             'a:b:c',
-            undefined,
+            config.cookieAttributes,
             undefined,
             new Date(0)
         );
@@ -219,7 +225,7 @@ describe('Authentication tests', () => {
             });
 
         const auth = new Authentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
@@ -248,7 +254,7 @@ describe('Authentication tests', () => {
         });
         // Init
         const auth = new Authentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
@@ -266,7 +272,7 @@ describe('Authentication tests', () => {
         });
         // Init
         const auth = new Authentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
@@ -284,7 +290,7 @@ describe('Authentication tests', () => {
         });
         // Init
         const auth = new Authentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,

--- a/src/dispatch/__tests__/Dispatch.test.ts
+++ b/src/dispatch/__tests__/Dispatch.test.ts
@@ -2,7 +2,7 @@ import { Dispatch } from '../Dispatch';
 import * as Utils from '../../test-utils/test-utils';
 import { DataPlaneClient } from '../DataPlaneClient';
 import { CredentialProvider } from '@aws-sdk/types';
-import { defaultConfig } from '../../orchestration/Orchestration';
+import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
 
 const sendFetch = jest.fn(() => Promise.resolve());
 const sendBeacon = jest.fn(() => Promise.resolve());
@@ -36,7 +36,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF }
             }
         );
@@ -59,7 +59,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF }
             }
         );
@@ -89,7 +89,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF }
             }
         );
@@ -110,7 +110,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF }
             }
         );
@@ -133,7 +133,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF }
             }
         );
@@ -157,7 +157,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: 1 }
             }
         );
@@ -181,7 +181,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF }
             }
         );
@@ -205,7 +205,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: -1 }
             }
         );
@@ -229,7 +229,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: 1 }
             }
         );
@@ -254,7 +254,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: 1 }
             }
         );
@@ -280,7 +280,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: 1 }
             }
         );
@@ -302,7 +302,7 @@ describe('Dispatch tests', () => {
             Utils.AWS_RUM_ENDPOINT,
             Utils.createDefaultEventCacheWithEvents(),
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 ...{ dispatchInterval: 1 }
             }
         );

--- a/src/dispatch/__tests__/EnhancedAuthentication.test.ts
+++ b/src/dispatch/__tests__/EnhancedAuthentication.test.ts
@@ -1,9 +1,9 @@
 import { CRED_COOKIE_NAME } from '../../utils/constants';
 import { Credentials } from '@aws-sdk/types';
 import { EnhancedAuthentication } from '../EnhancedAuthentication';
-import { defaultConfig } from '../../orchestration/Orchestration';
 import { fromCognitoIdentityPool } from '../CognitoIdentityClient';
 import { removeCookie, storeCookie } from '../../utils/cookies-utils';
+import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
 
 const mockGetId = jest.fn();
 const getCredentials = jest.fn();
@@ -48,19 +48,21 @@ describe('EnhancedAuthentication tests', () => {
                     })
                 )
         );
-        removeCookie(CRED_COOKIE_NAME);
+        removeCookie(CRED_COOKIE_NAME, DEFAULT_CONFIG.cookieAttributes);
     });
 
     // tslint:disable-next-line:max-line-length
     test('when auth cookie is in the store then authentication chain retrieves credentials from cookie', async () => {
         // Init
-        const auth = new EnhancedAuthentication({
-            ...defaultConfig,
+        const config = {
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID
             }
-        });
+        };
+
+        const auth = new EnhancedAuthentication(config);
 
         storeCookie(
             CRED_COOKIE_NAME,
@@ -70,7 +72,8 @@ describe('EnhancedAuthentication tests', () => {
                     secretAccessKey: 'b',
                     sessionToken: 'c'
                 })
-            )
+            ),
+            config.cookieAttributes
         );
 
         // Run
@@ -89,14 +92,16 @@ describe('EnhancedAuthentication tests', () => {
     // tslint:disable-next-line:max-line-length
     test('when auth cookie corrupt then authentication chain retrieves credentials from basic authflow', async () => {
         // Init
-        const auth = new EnhancedAuthentication({
-            ...defaultConfig,
+        const config = {
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
                 guestRoleArn: GUEST_ROLE_ARN
             }
-        });
+        };
+
+        const auth = new EnhancedAuthentication(config);
 
         storeCookie(
             CRED_COOKIE_NAME,
@@ -104,7 +109,8 @@ describe('EnhancedAuthentication tests', () => {
                 accessKeyId: 'a',
                 secretAccessKey: 'b',
                 sessionToken: 'c'
-            })
+            }),
+            config.cookieAttributes
         );
 
         // Run
@@ -124,7 +130,7 @@ describe('EnhancedAuthentication tests', () => {
     test('when auth cookie is not in the store authentication chain retrieves credentials from basic authflow', async () => {
         // Init
         const auth = new EnhancedAuthentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID
@@ -147,14 +153,17 @@ describe('EnhancedAuthentication tests', () => {
     // tslint:disable-next-line:max-line-length
     test('when cookies are not allowed then authentication chain retrieves credentials from basic authflow', async () => {
         // Init
-        const auth = new EnhancedAuthentication({
-            ...defaultConfig,
+        const config = {
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: false,
                 identityPoolId: IDENTITY_POOL_ID
             }
-        });
-        storeCookie(CRED_COOKIE_NAME, 'a:b:c');
+        };
+
+        const auth = new EnhancedAuthentication(config);
+
+        storeCookie(CRED_COOKIE_NAME, 'a:b:c', config.cookieAttributes);
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();
@@ -172,18 +181,21 @@ describe('EnhancedAuthentication tests', () => {
     // tslint:disable-next-line:max-line-length
     test('when cookie expires then authentication chain retrieves credentials from basic authflow', async () => {
         // Init
-        const auth = new EnhancedAuthentication({
-            ...defaultConfig,
+        const config = {
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
                 guestRoleArn: GUEST_ROLE_ARN
             }
-        });
+        };
+
+        const auth = new EnhancedAuthentication(config);
+
         storeCookie(
             CRED_COOKIE_NAME,
             'a:b:c',
-            undefined,
+            config.cookieAttributes,
             undefined,
             new Date(0)
         );
@@ -231,7 +243,7 @@ describe('EnhancedAuthentication tests', () => {
             );
 
         const auth = new EnhancedAuthentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
@@ -261,7 +273,7 @@ describe('EnhancedAuthentication tests', () => {
         });
 
         const auth = new EnhancedAuthentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,
@@ -280,7 +292,7 @@ describe('EnhancedAuthentication tests', () => {
         });
 
         const auth = new EnhancedAuthentication({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: true,
                 identityPoolId: IDENTITY_POOL_ID,

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -36,15 +36,11 @@ export class EventCache {
      * @param pageManager The pageManager returns page id.
      */
     constructor(applicationDetails: ApplicationDetails, config: Config) {
-        const applicationName = applicationDetails.name
-            ? applicationDetails.name
-            : '';
         this.applicationDetails = applicationDetails;
         this.config = config;
         this.enabled = true;
         this.pageManager = new PageManager(config, this.recordEvent);
         this.sessionManager = new SessionManager(
-            applicationName,
             config,
             this.recordSessionInitEvent,
             this.pageManager

--- a/src/event-cache/__tests__/EventCache.integ.test.ts
+++ b/src/event-cache/__tests__/EventCache.integ.test.ts
@@ -1,8 +1,8 @@
 import { EventCache } from '../EventCache';
 import { advanceTo } from 'jest-date-mock';
 import * as Utils from '../../test-utils/test-utils';
-import { defaultConfig } from '../../orchestration/Orchestration';
 import { Event } from '../../dispatch/dataplane';
+import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
 
 describe('EventCache tests', () => {
     beforeAll(() => {
@@ -13,7 +13,7 @@ describe('EventCache tests', () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const config = {
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: false,
                 sessionLengthSeconds: 0
@@ -35,7 +35,7 @@ describe('EventCache tests', () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const config = {
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 allowCookies: false,
                 sessionLengthSeconds: 0

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -1,9 +1,9 @@
 import { EventCache } from '../EventCache';
 import { advanceTo } from 'jest-date-mock';
 import * as Utils from '../../test-utils/test-utils';
-import { defaultConfig } from '../../orchestration/Orchestration';
 import { SessionManager } from '../../sessions/SessionManager';
 import { EventBatch, Event } from '../../dispatch/dataplane';
+import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
 
 const getSession = jest.fn(() => ({
     sessionId: 'a',
@@ -116,7 +116,7 @@ describe('EventCache tests', () => {
         const EVENT2_SCHEMA = 'com.amazon.rum.event2';
         const BATCH_LIMIT = 1;
         const eventCache: EventCache = Utils.createEventCache({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{ batchLimit: BATCH_LIMIT }
         });
 
@@ -139,7 +139,7 @@ describe('EventCache tests', () => {
         const EVENT2_SCHEMA = 'com.amazon.rum.event2';
         const BATCH_LIMIT = 1;
         const eventCache: EventCache = Utils.createEventCache({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{ batchLimit: BATCH_LIMIT }
         });
 
@@ -165,7 +165,7 @@ describe('EventCache tests', () => {
         const BATCH_LIMIT = 20;
         const EVENT_LIMIT = 2;
         const eventCache: EventCache = Utils.createEventCache({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 batchLimit: BATCH_LIMIT,
                 eventCacheSize: EVENT_LIMIT
@@ -196,7 +196,7 @@ describe('EventCache tests', () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const eventCache: EventCache = Utils.createEventCache({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 pagesToExclude: [/.*/]
             }
@@ -213,7 +213,7 @@ describe('EventCache tests', () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const eventCache: EventCache = Utils.createEventCache({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 pagesToInclude: [/.*/]
             }
@@ -241,7 +241,7 @@ describe('EventCache tests', () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const eventCache: EventCache = Utils.createEventCache({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 pagesToInclude: [/.*/],
                 pagesToExclude: [/.*/]
@@ -330,7 +330,7 @@ describe('EventCache tests', () => {
         }));
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const config = {
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 sessionEventLimit: 1
             }
@@ -362,7 +362,7 @@ describe('EventCache tests', () => {
         }));
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const config = {
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 sessionEventLimit: 0
             }

--- a/src/loader/loader-page-event.js
+++ b/src/loader/loader-page-event.js
@@ -1,7 +1,6 @@
 import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
 import { PageViewPlugin } from '../plugins/event-plugins/PageViewPlugin';
-import { defaultConfig } from '../plugins/utils/http-utils';
 
 loader(
     'cwr',
@@ -14,7 +13,7 @@ loader(
         allowCookies: true,
         dispatchInterval: 0,
         metaDataPluginsToLoad: [],
-        eventPluginsToLoad: [new PageViewPlugin(defaultConfig)],
+        eventPluginsToLoad: [new PageViewPlugin()],
         telemetries: [],
         pagesToInclude: [/\/(page_event.html|page_view_one|page_view_two)/],
         pagesToExclude: [/\/page_view_do_not_record/],

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -56,8 +56,7 @@ describe('Orchestration tests', () => {
 
         // Assert
         expect(Dispatch).toHaveBeenCalledTimes(1);
-        // @ts-ignore
-        expect(Dispatch.mock.calls[0][2]).toEqual(
+        expect((Dispatch as any).mock.calls[0][2]).toEqual(
             'https://dataplane.us-west-2.gamma.rum.aws.dev'
         );
     });
@@ -68,8 +67,7 @@ describe('Orchestration tests', () => {
 
         // Assert
         expect(Dispatch).toHaveBeenCalledTimes(1);
-        // @ts-ignore
-        expect(Dispatch.mock.calls[0][2]).toEqual(
+        expect((Dispatch as any).mock.calls[0][2]).toEqual(
             'https://dataplane.us-east-1.gamma.rum.aws.dev'
         );
     });
@@ -141,6 +139,12 @@ describe('Orchestration tests', () => {
         expect((EventCache as any).mock.calls[0][1]).toEqual({
             allowCookies: false,
             batchLimit: 100,
+            cookieAttributes: {
+                domain: window.location.hostname,
+                path: '/',
+                sameSite: 'Strict',
+                secure: true
+            },
             telemetries: ['errors', 'performance', 'journey', 'interaction'],
             dispatchInterval: 5000,
             endpoint: 'https://dataplane.us-west-2.gamma.rum.aws.dev',
@@ -158,9 +162,27 @@ describe('Orchestration tests', () => {
         });
     });
 
+    test('when cookie attributes are provided then they are merged with defaults', async () => {
+        // Init
+        const orchestration = new Orchestration(
+            'a',
+            undefined,
+            undefined,
+            undefined,
+            { cookieAttributes: { path: '/console' } }
+        );
+
+        // Assert
+        expect(EventCache).toHaveBeenCalledTimes(1);
+        expect((EventCache as any).mock.calls[0][1]).toEqual(
+            expect.objectContaining({
+                cookieAttributes: expect.objectContaining({ path: '/console' })
+            })
+        );
+    });
+
     test('data collection defaults to errors, performance, journey and interaction', async () => {
         // Init
-        // @ts-ignore
         const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {});
         const expected = [
             'com.amazonaws.rum.js-error',
@@ -184,7 +206,6 @@ describe('Orchestration tests', () => {
 
     test('when http data collection is set then the http plugins are instantiated', async () => {
         // Init
-        // @ts-ignore
         const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
             telemetries: ['http']
         });
@@ -203,7 +224,6 @@ describe('Orchestration tests', () => {
 
     test('when performance data collection is set then the performance plugins are instantiated', async () => {
         // Init
-        // @ts-ignore
         const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
             telemetries: ['performance']
         });
@@ -227,7 +247,6 @@ describe('Orchestration tests', () => {
 
     test('when error data collection is set then the error plugins are instantiated', async () => {
         // Init
-        // @ts-ignore
         const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
             telemetries: ['errors']
         });
@@ -246,7 +265,6 @@ describe('Orchestration tests', () => {
 
     test('when interaction data collection is set then the interaction plugins are instantiated', async () => {
         // Init
-        // @ts-ignore
         const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
             telemetries: ['interaction']
         });
@@ -265,7 +283,6 @@ describe('Orchestration tests', () => {
 
     test('when single page application views data collection is set then the page event plugin is instantiated', async () => {
         // Init
-        // @ts-ignore
         const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
             telemetries: [TELEMETRY_TYPES.SINGLE_PAGE_APP_VIEWS]
         });

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -7,8 +7,8 @@ import {
     recordPageView
 } from '../../../test-utils/test-utils';
 import { GetSession, PluginContext } from '../../Plugin';
-import { defaultConfig } from '../../../orchestration/Orchestration';
 import { XRAY_TRACE_EVENT_TYPE, HTTP_EVENT_TYPE } from '../../utils/constant';
+import { DEFAULT_CONFIG } from '../../../test-utils/test-utils';
 
 // Mock getRandomValues -- since it does nothing, the 'random' number will be 0.
 jest.mock('../../../utils/random');
@@ -351,7 +351,7 @@ describe('JsErrorPlugin tests', () => {
             applicationName: 'a',
             applicationId: 'b',
             applicationVersion: '1.0',
-            config: defaultConfig,
+            config: DEFAULT_CONFIG,
             record,
             recordPageView,
             getSession
@@ -585,6 +585,5 @@ describe('JsErrorPlugin tests', () => {
 
         // Assert
         expect(mockFetch).toHaveBeenCalledTimes(2);
-        expect(record).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -8,8 +8,8 @@ import {
 } from '../../../test-utils/test-utils';
 import mock from 'xhr-mock';
 import { GetSession, PluginContext } from '../../Plugin';
-import { defaultConfig } from '../../../orchestration/Orchestration';
 import { XRAY_TRACE_EVENT_TYPE, HTTP_EVENT_TYPE } from '../../utils/constant';
+import { DEFAULT_CONFIG } from '../../../test-utils/test-utils';
 
 // Mock getRandomValues -- since it does nothing, the 'random' number will be 0.
 jest.mock('../../../utils/random');
@@ -172,7 +172,7 @@ describe('JsErrorPlugin tests', () => {
     test('when XHR returns an error code then the plugin adds the error to the trace', async () => {
         // Init
         const config: HttpPluginConfig = {
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             ...{
                 logicalServiceName: 'sample.rum.aws.amazon.com',
                 urlsToInclude: [/response\.json/],
@@ -514,7 +514,7 @@ describe('JsErrorPlugin tests', () => {
             applicationName: 'a',
             applicationId: 'b',
             applicationVersion: '1.0',
-            config: defaultConfig,
+            config: DEFAULT_CONFIG,
             record,
             recordPageView,
             getSession

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -1,8 +1,4 @@
-import {
-    storeCookie,
-    getCookie,
-    getCookieDomain
-} from '../utils/cookies-utils';
+import { storeCookie, getCookie } from '../utils/cookies-utils';
 
 import { v4 } from 'uuid';
 import { Config } from '../orchestration/Orchestration';
@@ -63,7 +59,6 @@ export type Attributes = {
 export class SessionManager {
     private pageManager: PageManager;
 
-    private applicationId: string;
     private userExpiry: Date;
     private sessionExpiry: Date;
     private userId!: string;
@@ -73,12 +68,10 @@ export class SessionManager {
     private attributes: Attributes;
 
     constructor(
-        applicationId: string,
         config: Config,
         record: RecordSessionInitEvent,
         pageManager: PageManager
     ) {
-        this.applicationId = applicationId;
         this.config = config;
         this.record = record;
         this.pageManager = pageManager;
@@ -146,8 +139,8 @@ export class SessionManager {
             storeCookie(
                 SESSION_COOKIE_NAME,
                 btoa(JSON.stringify(session)),
+                this.config.cookieAttributes,
                 undefined,
-                getCookieDomain(),
                 expires
             );
         }
@@ -157,8 +150,8 @@ export class SessionManager {
         storeCookie(
             USER_COOKIE_NAME,
             userId,
+            this.config.cookieAttributes,
             undefined,
-            getCookieDomain(),
             expires
         );
     }

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -1,5 +1,5 @@
 import { PageManager, PAGE_VIEW_TYPE } from '../PageManager';
-import { defaultConfig } from '../../orchestration/Orchestration';
+import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
 
 const EXPECTED_ATTRIBUTES = {
     title: 'Amazon AWS Console',
@@ -52,7 +52,7 @@ describe('PageManager tests', () => {
         // Init
         const pageManager: PageManager = new PageManager(
             {
-                ...defaultConfig
+                ...DEFAULT_CONFIG
             },
             record
         );
@@ -71,7 +71,7 @@ describe('PageManager tests', () => {
         // Init
         const pageManager: PageManager = new PageManager(
             {
-                ...defaultConfig
+                ...DEFAULT_CONFIG
             },
             record
         );
@@ -92,7 +92,7 @@ describe('PageManager tests', () => {
         // Init
         const pageManager: PageManager = new PageManager(
             {
-                ...defaultConfig
+                ...DEFAULT_CONFIG
             },
             record
         );
@@ -111,7 +111,7 @@ describe('PageManager tests', () => {
         // Init
         const pageManager: PageManager = new PageManager(
             {
-                ...defaultConfig
+                ...DEFAULT_CONFIG
             },
             record
         );
@@ -131,7 +131,7 @@ describe('PageManager tests', () => {
         // Init
         const pageManager: PageManager = new PageManager(
             {
-                ...defaultConfig,
+                ...DEFAULT_CONFIG,
                 // @ts-ignore
                 pageIdFormat: 'PAGE_AND_HASH'
             },

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -1,6 +1,10 @@
 import { EventCache } from '../event-cache/EventCache';
 import { Credentials } from '@aws-sdk/types';
-import { Config, defaultConfig } from '../orchestration/Orchestration';
+import {
+    Config,
+    defaultConfig,
+    defaultCookieAttributes
+} from '../orchestration/Orchestration';
 import {
     GetSession,
     PluginContext,
@@ -56,8 +60,10 @@ export const LOG_EVENTS_REQUEST: LogEventsRequest = {
     }
 };
 
+export const DEFAULT_CONFIG: Config = defaultConfig(defaultCookieAttributes());
+
 export const createDefaultEventCache = (): EventCache => {
-    return new EventCache(APPLICATION_DETAILS, defaultConfig);
+    return new EventCache(APPLICATION_DETAILS, DEFAULT_CONFIG);
 };
 
 export const createEventCache = (config: Config): EventCache => {
@@ -67,7 +73,7 @@ export const createEventCache = (config: Config): EventCache => {
 export const createDefaultEventCacheWithEvents = (): EventCache => {
     const EVENT1_SCHEMA = 'com.amazon.rum.event1';
     const EVENT2_SCHEMA = 'com.amazon.rum.event2';
-    const eventCache = new EventCache(APPLICATION_DETAILS, defaultConfig);
+    const eventCache = new EventCache(APPLICATION_DETAILS, DEFAULT_CONFIG);
     eventCache.recordEvent(EVENT1_SCHEMA, {});
     eventCache.recordEvent(EVENT2_SCHEMA, {});
     return eventCache;
@@ -105,7 +111,7 @@ export const context: PluginContext = {
     applicationName: 'a',
     applicationId: 'b',
     applicationVersion: '1.0',
-    config: defaultConfig,
+    config: DEFAULT_CONFIG,
     record,
     recordPageView,
     getSession

--- a/src/utils/__tests__/cookies-utils.test.ts
+++ b/src/utils/__tests__/cookies-utils.test.ts
@@ -1,167 +1,175 @@
 import * as utils from '../../utils/cookies-utils';
 
-const COOKIE_FRE_FIX = 'rum_cookies_util_test';
+const COOKIE_PREFIX = 'rum_cookies_util_test';
+
+const COOKIE_ATTRIBUTES = {
+    domain: 'amazon.com',
+    path: '/',
+    sameSite: 'Strict',
+    secure: true
+};
 
 describe('Cookies utils tests', () => {
     test('storeCookie()', async () => {
         // Init
-        const cookieName = COOKIE_FRE_FIX + '_' + new Date().getTime();
+        const cookieName = COOKIE_PREFIX + '_' + new Date().getTime();
         const cookieValue = new Date().toString();
 
         // Run
-        utils.storeCookie(cookieName, cookieValue);
+        utils.storeCookie(cookieName, cookieValue, COOKIE_ATTRIBUTES);
 
         // Assert
         expect(document.cookie).toEqual(cookieName + '=' + cookieValue);
 
         // Cleanup
-        document.cookie =
-            cookieName + '=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES);
     });
 
     test('when storeCookie() given ttl=0 then cookie immediately expires', async () => {
         // Init
-        const cookieName = COOKIE_FRE_FIX + '_' + new Date().getTime();
+        const cookieName = COOKIE_PREFIX + '_' + new Date().getTime();
         const cookieValue = 'value';
 
         // Run
-        utils.storeCookie(cookieName, cookieValue, 0);
+        utils.storeCookie(cookieName, cookieValue, COOKIE_ATTRIBUTES, 0);
 
         // Assert
         expect(document.cookie).toBeFalsy();
 
         // Cleanup
-        document.cookie =
-            cookieName + '=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES);
     });
 
     test('when storeCookie() given ttl > 0 then cookie does not immediately expire', async () => {
         // Init
-        const cookieName = COOKIE_FRE_FIX + '_' + new Date().getTime();
+        const cookieName = COOKIE_PREFIX + '_' + new Date().getTime();
         const cookieValue = 'value';
 
         // Run
-        utils.storeCookie(cookieName, cookieValue, 3600);
+        utils.storeCookie(cookieName, cookieValue, COOKIE_ATTRIBUTES, 3600);
 
         // Assert
         expect(document.cookie).toBeTruthy();
 
         // Cleanup
-        document.cookie =
-            cookieName + '=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES);
+    });
+
+    test('storeCookie() cookies are stored under the domain', async () => {
+        // Init
+        const cookieName = COOKIE_PREFIX;
+        const cookieValueA = 'valueA';
+        const cookieValueB = 'valueB';
+
+        const COOKIE_ATTRIBUTES_A = {
+            domain: 'amazon.com',
+            path: '/',
+            sameSite: 'Strict',
+            secure: true
+        };
+
+        const COOKIE_ATTRIBUTES_B = {
+            domain: 'aws.amazon.com',
+            path: '/',
+            sameSite: 'Strict',
+            secure: true
+        };
+
+        // Run
+        utils.storeCookie(cookieName, cookieValueA, COOKIE_ATTRIBUTES_A, 3600);
+        utils.storeCookie(cookieName, cookieValueB, COOKIE_ATTRIBUTES_B, 3600);
+
+        // Assert
+        const cookies: string[] = document.cookie.replace(' ', '').split(';');
+        expect(cookies).toContain(`${COOKIE_PREFIX}=${cookieValueA}`);
+        expect(cookies).toContain(`${COOKIE_PREFIX}=${cookieValueB}`);
+
+        // Cleanup
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES_A);
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES_B);
+    });
+
+    test('storeCookie() cookies are stored under the path', async () => {
+        // Init
+        const cookieName = COOKIE_PREFIX;
+        const cookieValueA = 'valueA';
+        const cookieValueB = 'valueB';
+
+        const COOKIE_ATTRIBUTES_A = {
+            domain: 'amazon.com',
+            path: '/',
+            sameSite: 'Strict',
+            secure: true
+        };
+
+        const COOKIE_ATTRIBUTES_B = {
+            domain: 'amazon.com',
+            path: '/console',
+            sameSite: 'Strict',
+            secure: true
+        };
+
+        // Run
+        utils.storeCookie(cookieName, cookieValueA, COOKIE_ATTRIBUTES_A, 3600);
+        utils.storeCookie(cookieName, cookieValueB, COOKIE_ATTRIBUTES_B, 3600);
+
+        // Assert
+        const cookies: string[] = document.cookie.replace(' ', '').split(';');
+        expect(cookies).toContain(`${COOKIE_PREFIX}=${cookieValueA}`);
+        expect(cookies).toContain(`${COOKIE_PREFIX}=${cookieValueB}`);
+
+        // Cleanup
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES_A);
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES_B);
     });
 
     test('getCookie() when document.cookie has only one cookie, return the correct cookie value', async () => {
         // Init
-        const cookieName = COOKIE_FRE_FIX + '_' + new Date().getTime();
-        const cookieValue = new Date().toString();
-        document.cookie = cookieName + '=' + cookieValue;
+        const cookieName = COOKIE_PREFIX + '_' + new Date().getTime();
+        const cookieValue = 'value';
+
+        // Run
+        utils.storeCookie(cookieName, cookieValue, COOKIE_ATTRIBUTES, 3600);
 
         // Assert
         expect(utils.getCookie(cookieName)).toEqual(cookieValue);
 
         // Cleanup
-        document.cookie =
-            cookieName + '=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES);
     });
 
     test('getCookie() when document.cookie has more than one cookie, return the correct cookie value', async () => {
         // Init
-        const cookieName1 = COOKIE_FRE_FIX + '_A';
+        const cookieName1 = COOKIE_PREFIX + '_' + new Date().getTime();
         const cookieValue1 = new Date().toString();
 
-        const cookieName2 = COOKIE_FRE_FIX + '_B';
+        const cookieName2 = COOKIE_PREFIX + '_' + new Date().getTime();
         const cookieValue2 = new Date().toString();
 
-        document.cookie = cookieName1 + '=' + cookieValue1;
-        document.cookie = cookieName2 + '=' + cookieValue2;
-
-        console.log(document.cookie);
+        utils.storeCookie(cookieName1, cookieValue1, COOKIE_ATTRIBUTES, 3600);
+        utils.storeCookie(cookieName2, cookieValue2, COOKIE_ATTRIBUTES, 3600);
 
         // Assert
         expect(utils.getCookie(cookieName1)).toEqual(cookieValue1);
         expect(utils.getCookie(cookieName2)).toEqual(cookieValue2);
 
         // Cleanup
-        document.cookie =
-            cookieName1 + '=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
-        document.cookie =
-            cookieName2 + '=; Expires=Thu, 01 Jan 1970 00:00:01 GMT';
+        utils.removeCookie(cookieName1, COOKIE_ATTRIBUTES);
+        utils.removeCookie(cookieName2, COOKIE_ATTRIBUTES);
     });
 
     test('removeCookie()', async () => {
         // Init
-        const cookieName = COOKIE_FRE_FIX + '_' + new Date().getTime();
-        const cookieValue = new Date().toString();
-        document.cookie = cookieName + '=' + cookieValue;
+        const cookieName = COOKIE_PREFIX + '_' + new Date().getTime();
+        const cookieValue = 'value';
 
         // Run
-        utils.removeCookie(cookieName);
+        utils.storeCookie(cookieName, cookieValue, COOKIE_ATTRIBUTES, 3600);
+
+        // Run
+        utils.removeCookie(cookieName, COOKIE_ATTRIBUTES);
 
         // Assert
         expect(document.cookie).toEqual('');
-    });
-
-    test('getCookieDomain() with root domain returns root domain', async () => {
-        jest.spyOn(utils, 'storeCookie').mockImplementation(
-            (
-                name: string,
-                value: string,
-                expires?: number,
-                domain?: string
-            ) => {
-                if (domain && domain === 'amazon.com') {
-                    document.cookie = name + '=' + value;
-                }
-            }
-        );
-
-        // Init
-        document.domain = 'amazon.com';
-
-        // Assert
-        expect(utils.getCookieDomain()).toEqual('amazon.com');
-    });
-
-    test('getCookieDomain() returns a root domain when given a sub-domain', async () => {
-        jest.spyOn(utils, 'storeCookie').mockImplementation(
-            (
-                name: string,
-                value: string,
-                expires?: number,
-                domain?: string
-            ) => {
-                if (domain && domain === 'amazon.com') {
-                    document.cookie = name + '=' + value;
-                }
-            }
-        );
-
-        // Init
-        document.domain = 'docs.aws.amazon.com';
-
-        // Assert
-        expect(utils.getCookieDomain()).toEqual('amazon.com');
-    });
-
-    test('getCookieDomain() returns localhost when given localhost domain', async () => {
-        jest.spyOn(utils, 'storeCookie').mockImplementation(
-            (
-                name: string,
-                value: string,
-                expires?: number,
-                domain?: string
-            ) => {
-                if (domain && domain === 'localhost') {
-                    document.cookie = name + '=' + value;
-                }
-            }
-        );
-
-        // Init
-        document.domain = 'localhost';
-
-        // Assert
-        expect(utils.getCookieDomain()).toEqual('localhost');
     });
 });

--- a/src/utils/cookies-utils.ts
+++ b/src/utils/cookies-utils.ts
@@ -1,28 +1,31 @@
+import { CookieAttributes } from '../orchestration/Orchestration';
+
 /**
  * Stores a cookie.
  * @param name The cookie's name.
  * @param value The cookie's value.
+ * @param attributes The domain where the cookie will be stored.
  * @param ttl Time to live -- expiry date is current date + ttl (do not use with {@code expires}).
- * @param domain The domain where the cookie will be stored.
  * @param expires The expiry date for the cookie (do not use with {@code ttl})
  */
 export const storeCookie = (
     name: string,
     value: string,
+    attributes: CookieAttributes,
     ttl?: number,
-    domain?: string,
     expires?: Date
 ) => {
     let cookie = name + '=';
     cookie += value || '';
     if (expires !== undefined) {
-        cookie +=
-            expires !== undefined ? '; Expires=' + expires.toUTCString() : '';
+        cookie += `; Expires=${expires.toUTCString()}`;
     } else if (ttl !== undefined) {
-        cookie += '; Expires=' + getExpiryDate(ttl).toUTCString();
+        cookie += `; Expires=${getExpiryDate(ttl).toUTCString()}`;
     }
-    cookie += '; SameSite=Strict; Secure';
-    cookie += domain ? '; Domain=' + domain : '';
+    cookie += `; Domain=${attributes.domain}`;
+    cookie += `; Path=${attributes.path}`;
+    cookie += `; SameSite=${attributes.sameSite}`;
+    cookie += attributes.secure ? '; Secure' : '';
     document.cookie = cookie;
 };
 
@@ -38,13 +41,14 @@ export const getExpiryDate = (ttl: number): Date => {
  * Removes a cookie by setting its expiry in the past.
  * @param name The cookie's name.
  */
-export const removeCookie = (name: string, domain?: string) => {
-    document.cookie =
-        name +
-        '=; Expires=' +
-        new Date(0) +
-        '; SameSite=Strict; Secure' +
-        (domain ? '; Domain=' + domain : '');
+export const removeCookie = (name: string, attributes: CookieAttributes) => {
+    let cookie = name + '=';
+    cookie += `; Expires=${new Date(0)}`;
+    cookie += `; Domain=${attributes.domain}`;
+    cookie += `; Path=${attributes.path}`;
+    cookie += `; SameSite=${attributes.sameSite}`;
+    cookie += attributes.secure ? 'Secure' : '';
+    document.cookie = cookie;
 };
 
 /**
@@ -60,27 +64,4 @@ export const getCookie = (name: string): string => {
         }
     }
     return '';
-};
-
-/**
- * Finds the highest level (non-top-level) domain that can be used to store cookies.
- */
-export const getCookieDomain = (): string => {
-    if (!document.domain) {
-        return '';
-    }
-    const subdomain = document.domain.split('.');
-    for (
-        let i = subdomain.length - 1, ts = Date.now().toString();
-        i >= 0;
-        i--
-    ) {
-        const cookieDomain = subdomain.slice(i).join('.');
-        storeCookie(ts, ts, undefined, cookieDomain);
-        if (getCookie(ts)) {
-            removeCookie(ts, cookieDomain);
-            return cookieDomain;
-        }
-    }
-    return document.domain;
 };


### PR DESCRIPTION
The RUM web client stores cookies on the top level domain of the current page. This produces incorrect behavior if there are multiple applications running on the same domain because multiple applications will read the same RUM cookies.

This change (1) adds configuration options which allow application owners to configure the domain and path of the RUM cookies, and (2) sets the default domain to the domain of the current page (`window.location.hostname`) and sets the default path to the root path (`/`). This is a more sane default because applications on sub-domains will not be able to read each other's RUM cookies, and gives application owners control over the RUM cookie domain, should they need to modify it for their use case.

### Notes
- This feature was copied from the old internal repo. It is being copied so the two repos have feature parity and we can deprecate the internal repo.
- The case where the root domain and subdomains run separate RUM AppMonitors is still unhandled, as there is no way to distinguish between the cookies set by a parent and subdomain (e.g., `amazon.com` vs `aws.amazon.com`). This will be addressed by adding support custom cookie names.