### PR TITLE
Remove application name as an init arg.

### DIFF
--- a/src/CommandQueue.ts
+++ b/src/CommandQueue.ts
@@ -19,7 +19,7 @@ export type AwsRumClientInit = {
     q: [];
     n: string;
     i: string;
-    a: string;
+    a?: string; // deprecated
     r: string;
     v: string;
     c?: PartialConfig;
@@ -116,7 +116,6 @@ export class CommandQueue {
     private initCwr(awsRum: AwsRumClientInit) {
         this.orchestration = new Orchestration(
             awsRum.i,
-            awsRum.a,
             awsRum.v,
             awsRum.r,
             awsRum.c

--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -18,6 +18,14 @@ const initArgs: AwsRumClientInit = {
     q: [],
     n: 'cwr',
     i: 'application_id',
+    v: '1.0',
+    r: 'us-west-2'
+};
+
+const initArgsWithAppName: AwsRumClientInit = {
+    q: [],
+    n: 'cwr',
+    i: 'application_id',
     a: 'application_name',
     v: '1.0',
     r: 'us-west-2'
@@ -84,7 +92,7 @@ describe('CommandQueue tests', () => {
 
         expect(getConfigStub).toBeCalledTimes(1);
         expect(Orchestration).toHaveBeenCalledTimes(1);
-        expect((Orchestration as any).mock.calls[0][4]).toEqual(
+        expect((Orchestration as any).mock.calls[0][3]).toEqual(
             mockOtaConfigObject
         );
 
@@ -113,7 +121,7 @@ describe('CommandQueue tests', () => {
         });
         expect(Orchestration).toHaveBeenCalledTimes(1);
 
-        expect((Orchestration as any).mock.calls[0][4]).toEqual(
+        expect((Orchestration as any).mock.calls[0][3]).toEqual(
             mockOtaConfigObject
         );
     });
@@ -140,7 +148,7 @@ describe('CommandQueue tests', () => {
                 'Content-Type': 'application/json'
             }
         });
-        expect((Orchestration as any).mock.calls[0][4]).toEqual(
+        expect((Orchestration as any).mock.calls[0][3]).toEqual(
             mockPartialOtaConfigObject
         );
     });
@@ -162,7 +170,7 @@ describe('CommandQueue tests', () => {
             u: dummyOtaConfigURL
         });
 
-        expect((Orchestration as any).mock.calls[0][4]).toEqual(
+        expect((Orchestration as any).mock.calls[0][3]).toEqual(
             expect.objectContaining({
                 dispatchInterval: 10 * 1000,
                 sessionSampleRate: 0.8,
@@ -304,5 +312,22 @@ describe('CommandQueue tests', () => {
                     'CWR: UnsupportedOperationException: badCommand'
                 )
             );
+    });
+
+    test('when application name is in the initialization object then it is ignored', async () => {
+        const cq: CommandQueue = getCommandQueue();
+        await cq.init({ ...initArgsWithAppName });
+        const result = await cq.push({
+            c: 'disable',
+            p: undefined
+        });
+        expect(Orchestration).toHaveBeenCalled();
+        expect(disable).toHaveBeenCalled();
+        expect((Orchestration as any).mock.calls[0]).toEqual([
+            'application_id',
+            '1.0',
+            'us-west-2',
+            undefined
+        ]);
     });
 });

--- a/src/loader/loader-cookies-disabled.js
+++ b/src/loader/loader-cookies-disabled.js
@@ -1,21 +1,13 @@
 import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        userIdRetentionDays: 1,
-        dispatchInterval: 0,
-        allowCookies: false,
-        eventPluginsToLoad: [],
-        telemetries: [],
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    userIdRetentionDays: 1,
+    dispatchInterval: 0,
+    allowCookies: false,
+    eventPluginsToLoad: [],
+    telemetries: [],
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader-cookies-enabled.js
+++ b/src/loader/loader-cookies-enabled.js
@@ -1,20 +1,12 @@
 import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        dispatchInterval: 0,
-        allowCookies: true,
-        eventPluginsToLoad: [],
-        telemetries: [],
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    dispatchInterval: 0,
+    allowCookies: true,
+    eventPluginsToLoad: [],
+    telemetries: [],
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader-dom-event.js
+++ b/src/loader/loader-dom-event.js
@@ -1,22 +1,14 @@
 import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
 import { DomEventPlugin } from '../plugins/event-plugins/DomEventPlugin';
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        allowCookies: true,
-        dispatchInterval: 0,
-        metaDataPluginsToLoad: [],
-        eventPluginsToLoad: [new DomEventPlugin()],
-        telemetries: [],
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    allowCookies: true,
+    dispatchInterval: 0,
+    metaDataPluginsToLoad: [],
+    eventPluginsToLoad: [new DomEventPlugin()],
+    telemetries: [],
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader-http-fetch-event.js
+++ b/src/loader/loader-http-fetch-event.js
@@ -12,22 +12,14 @@ const config = {
     }
 };
 
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        allowCookies: true,
-        dispatchInterval: 0,
-        metaDataPluginsToLoad: [],
-        eventPluginsToLoad: [new FetchPlugin(config)],
-        telemetries: [],
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    allowCookies: true,
+    dispatchInterval: 0,
+    metaDataPluginsToLoad: [],
+    eventPluginsToLoad: [new FetchPlugin(config)],
+    telemetries: [],
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader-http-xhr-event.js
+++ b/src/loader/loader-http-xhr-event.js
@@ -13,22 +13,14 @@ const config = {
     }
 };
 
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        allowCookies: true,
-        dispatchInterval: 0,
-        metaDataPluginsToLoad: [],
-        eventPluginsToLoad: [new XhrPlugin(config)],
-        telemetries: [],
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    allowCookies: true,
+    dispatchInterval: 0,
+    metaDataPluginsToLoad: [],
+    eventPluginsToLoad: [new XhrPlugin(config)],
+    telemetries: [],
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader-ingestion.js
+++ b/src/loader/loader-ingestion.js
@@ -4,7 +4,6 @@ import { JsErrorPlugin } from '../plugins/event-plugins/JsErrorPlugin';
 loader(
     'cwr',
     '[applicationId]',
-    '[applicationName]',
     '1.0',
     'us-west-2',
     './rum_javascript_telemetry.js',

--- a/src/loader/loader-js-error-event.js
+++ b/src/loader/loader-js-error-event.js
@@ -1,22 +1,14 @@
 import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
 import { JsErrorPlugin } from '../plugins/event-plugins/JsErrorPlugin';
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        allowCookies: true,
-        dispatchInterval: 0,
-        metaDataPluginsToLoad: [],
-        eventPluginsToLoad: [new JsErrorPlugin()],
-        telemetries: [],
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    allowCookies: true,
+    dispatchInterval: 0,
+    metaDataPluginsToLoad: [],
+    eventPluginsToLoad: [new JsErrorPlugin()],
+    telemetries: [],
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader-page-event.js
+++ b/src/loader/loader-page-event.js
@@ -2,24 +2,16 @@ import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
 import { PageViewPlugin } from '../plugins/event-plugins/PageViewPlugin';
 
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        allowCookies: true,
-        dispatchInterval: 0,
-        metaDataPluginsToLoad: [],
-        eventPluginsToLoad: [new PageViewPlugin()],
-        telemetries: [],
-        pagesToInclude: [/\/(page_event.html|page_view_one|page_view_two)/],
-        pagesToExclude: [/\/page_view_do_not_record/],
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    allowCookies: true,
+    dispatchInterval: 0,
+    metaDataPluginsToLoad: [],
+    eventPluginsToLoad: [new PageViewPlugin()],
+    telemetries: [],
+    pagesToInclude: [/\/(page_event.html|page_view_one|page_view_two)/],
+    pagesToExclude: [/\/page_view_do_not_record/],
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader-post-load-command-queue-test.js
+++ b/src/loader/loader-post-load-command-queue-test.js
@@ -1,17 +1,9 @@
 import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        dispatchInterval: 0,
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    dispatchInterval: 0,
+    clientBuilder: showRequestClientBuilder
+});
 setTimeout(() => {
     cwr('unsupported_command', {});
 }, 1000);

--- a/src/loader/loader-pre-load-command-queue-test.js
+++ b/src/loader/loader-pre-load-command-queue-test.js
@@ -1,15 +1,7 @@
 import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        dispatchInterval: 0,
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    dispatchInterval: 0,
+    clientBuilder: showRequestClientBuilder
+});
 cwr('unsupported_command', {});

--- a/src/loader/loader-remote-config.js
+++ b/src/loader/loader-remote-config.js
@@ -3,7 +3,6 @@ import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
 loader(
     'cwr',
     'abc123',
-    'appname',
     '1.0',
     'us-west-2',
     './rum_javascript_telemetry.js',

--- a/src/loader/loader-standard.js
+++ b/src/loader/loader-standard.js
@@ -1,18 +1,10 @@
 import { loader } from '../loader/loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        allowCookies: true,
-        dispatchInterval: 0,
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    allowCookies: true,
+    dispatchInterval: 0,
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader-web-vital-event.js
+++ b/src/loader/loader-web-vital-event.js
@@ -1,21 +1,13 @@
 import { loader } from './loader';
 import { showRequestClientBuilder } from '../test-utils/mock-http-handler';
 import { WebVitalsPlugin } from '../plugins/event-plugins/WebVitalsPlugin';
-loader(
-    'cwr',
-    'abc123',
-    'appname',
-    '1.0',
-    'us-west-2',
-    './rum_javascript_telemetry.js',
-    {
-        dispatchInterval: 0,
-        metaDataPluginsToLoad: [],
-        eventPluginsToLoad: [new WebVitalsPlugin()],
-        telemetries: [],
-        clientBuilder: showRequestClientBuilder
-    }
-);
+loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
+    dispatchInterval: 0,
+    metaDataPluginsToLoad: [],
+    eventPluginsToLoad: [new WebVitalsPlugin()],
+    telemetries: [],
+    clientBuilder: showRequestClientBuilder
+});
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',
     secretAccessKey: 'b',

--- a/src/loader/loader.js
+++ b/src/loader/loader.js
@@ -1,20 +1,18 @@
 export function loader(
     namespace,
     applicationId,
-    applicationName,
     applicationVersion,
     region,
     clientUri,
     config,
     remoteConfigUri
 ) {
-    (function (n, i, a, v, r, s, c, u, x, z) {
+    (function (n, i, v, r, s, c, u, x, z) {
         // The global object that the AWS RUM client will use to read configuration and commands.
         x = window.AwsRumClient = {
             q: [],
             n: n,
             i: i,
-            a: a,
             v: v,
             r: r,
             c: c,
@@ -37,7 +35,6 @@ export function loader(
     })(
         namespace,
         applicationId,
-        applicationName,
         applicationVersion,
         region,
         clientUri,

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -175,7 +175,6 @@ export class Orchestration {
 
     constructor(
         applicationId: string,
-        applicationName: string,
         applicationVersion: string,
         region: string,
         partialConfig: PartialConfig = {}
@@ -202,14 +201,12 @@ export class Orchestration {
 
         this.eventCache = this.initEventCache(
             applicationId,
-            applicationName,
             applicationVersion
         );
 
         this.dispatchManager = this.initDispatch(region, applicationId);
         this.pluginManager = this.initPluginManager(
             applicationId,
-            applicationName,
             applicationVersion
         );
 
@@ -306,13 +303,11 @@ export class Orchestration {
 
     private initEventCache(
         applicationId: string,
-        applicationName: string,
         applicationVersion: string
     ): EventCache {
         return new EventCache(
             {
                 id: applicationId,
-                name: applicationName,
                 version: applicationVersion
             },
             this.config
@@ -350,7 +345,6 @@ export class Orchestration {
 
     private initPluginManager(
         applicationId: string,
-        applicationName: string,
         applicationVersion: string
     ) {
         const BUILTIN_PLUGINS: Plugin[] = this.constructBuiltinPlugins();
@@ -361,7 +355,6 @@ export class Orchestration {
 
         const pluginContext: PluginContext = {
             applicationId,
-            applicationName,
             applicationVersion,
             config: this.config,
             record: this.eventCache.recordEvent,

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -52,7 +52,7 @@ describe('Orchestration tests', () => {
 
     test('when region is not provided then endpoint region defaults to us-west-2', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', undefined, {});
+        const orchestration = new Orchestration('a', 'c', undefined, {});
 
         // Assert
         expect(Dispatch).toHaveBeenCalledTimes(1);
@@ -63,7 +63,7 @@ describe('Orchestration tests', () => {
 
     test('when region is provided then the endpoint uses that region', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {});
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {});
 
         // Assert
         expect(Dispatch).toHaveBeenCalledTimes(1);
@@ -74,7 +74,7 @@ describe('Orchestration tests', () => {
 
     test('when enable is true in config then orchestration enables dispatch, pluginManager and event cache', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', undefined, {});
+        const orchestration = new Orchestration('a', 'c', undefined, {});
 
         // Assert
         expect(enableDispatch).toHaveBeenCalledTimes(1);
@@ -84,7 +84,7 @@ describe('Orchestration tests', () => {
 
     test('when enable is false in config then orchestration disables dispatch, pluginManager and event cache', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', undefined, {
+        const orchestration = new Orchestration('a', 'c', undefined, {
             enableRumClient: false
         });
 
@@ -97,7 +97,7 @@ describe('Orchestration tests', () => {
     test('when eventPluginsToLoad is provided in config then it is added with default plugins', async () => {
         // Init
         const collections = ['errors', 'performance'];
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {
             eventPluginsToLoad: [new DomEventPlugin(), new JsErrorPlugin()],
             telemetries: collections
         });
@@ -128,7 +128,6 @@ describe('Orchestration tests', () => {
         // Init
         const orchestration = new Orchestration(
             'a',
-            undefined,
             undefined,
             undefined,
             undefined
@@ -164,13 +163,9 @@ describe('Orchestration tests', () => {
 
     test('when cookie attributes are provided then they are merged with defaults', async () => {
         // Init
-        const orchestration = new Orchestration(
-            'a',
-            undefined,
-            undefined,
-            undefined,
-            { cookieAttributes: { path: '/console' } }
-        );
+        const orchestration = new Orchestration('a', undefined, undefined, {
+            cookieAttributes: { path: '/console' }
+        });
 
         // Assert
         expect(EventCache).toHaveBeenCalledTimes(1);
@@ -183,7 +178,7 @@ describe('Orchestration tests', () => {
 
     test('data collection defaults to errors, performance, journey and interaction', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {});
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {});
         const expected = [
             'com.amazonaws.rum.js-error',
             'com.amazonaws.rum.navigation',
@@ -206,7 +201,7 @@ describe('Orchestration tests', () => {
 
     test('when http data collection is set then the http plugins are instantiated', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {
             telemetries: ['http']
         });
         const expected = ['com.amazonaws.rum.xhr', 'com.amazonaws.rum.fetch'];
@@ -224,7 +219,7 @@ describe('Orchestration tests', () => {
 
     test('when performance data collection is set then the performance plugins are instantiated', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {
             telemetries: ['performance']
         });
         const expected = [
@@ -247,7 +242,7 @@ describe('Orchestration tests', () => {
 
     test('when error data collection is set then the error plugins are instantiated', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {
             telemetries: ['errors']
         });
         const expected = ['com.amazonaws.rum.js-error'];
@@ -265,7 +260,7 @@ describe('Orchestration tests', () => {
 
     test('when interaction data collection is set then the interaction plugins are instantiated', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {
             telemetries: ['interaction']
         });
         const expected = ['com.amazonaws.rum.dom-event'];
@@ -283,7 +278,7 @@ describe('Orchestration tests', () => {
 
     test('when single page application views data collection is set then the page event plugin is instantiated', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-east-1', {
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {
             telemetries: [TELEMETRY_TYPES.SINGLE_PAGE_APP_VIEWS]
         });
         const expected = ['com.amazonaws.rum.page-view'];

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -8,7 +8,6 @@ export type GetSession = () => Session;
 
 export type PluginContext = {
     applicationId: string;
-    applicationName: string;
     applicationVersion: string;
     config: Config;
     record: RecordEvent;

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.integ.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.integ.test.ts
@@ -31,7 +31,7 @@ describe('FetchPlugin integ tests', () => {
             recordAllRequests: true
         };
 
-        const orchestration = new Orchestration('a', 'b', 'c', 'us-west-2', {
+        const orchestration = new Orchestration('a', 'c', 'us-west-2', {
             dispatchInterval: 0,
             eventPluginsToLoad: [new FetchPlugin(config)],
             telemetries: []

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -348,7 +348,6 @@ describe('JsErrorPlugin tests', () => {
             eventCount: 0
         }));
         const context: PluginContext = {
-            applicationName: 'a',
             applicationId: 'b',
             applicationVersion: '1.0',
             config: DEFAULT_CONFIG,

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -511,7 +511,6 @@ describe('JsErrorPlugin tests', () => {
             eventCount: 0
         }));
         const context: PluginContext = {
-            applicationName: 'a',
             applicationId: 'b',
             applicationVersion: '1.0',
             config: DEFAULT_CONFIG,

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -108,7 +108,6 @@ export const getSession: jest.MockedFunction<GetSession> = jest.fn(() => ({
     eventCount: 0
 }));
 export const context: PluginContext = {
-    applicationName: 'a',
     applicationId: 'b',
     applicationVersion: '1.0',
     config: DEFAULT_CONFIG,


### PR DESCRIPTION
### Description

Application owners may put internal/private information in the RUM application name (e.g., the stage, internal code names, etc.). Because the RUM web client requires the application name in its configuration, the application name is publicly visible.

This change removes the application name as a parameter of the RUM web client; i.e., it is no longer accepted as an argument to instantiate `Orchestration` and can be omitted from the snippet. The application name is already optional in the collector API.

### Notes
- This change is backwards compatible -- it will work with snippets that already contain the application name.

### Testing
- Smoke tested the web bundle with and without the application name in the the snippet