### PR TITLE
Use prod IAM role ARN and S3 bucket for CDN deployment.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,8 +15,6 @@ jobs:
         steps:
             - name: Checkout AWS RUM Web Client Repository
               uses: actions/checkout@v2
-              with:
-                  ref: main
 
             - name: Setup Node
               uses: actions/setup-node@v1


### PR DESCRIPTION
### Description

The deployment workflow publishes the web bundle to a beta stage S3 bucket for distribution over CDN. We now need to publish the web bundle to a prod stage for public distribution.

This change (1) causes new releases to be published to the prod CDN instead of the beta CDN, and (2) reads the S3 bucket name and IAM role ARN from GitHub secrets (so there is slightly less information exposed).

### Testing

- I have verified the prod deployment succeeds using a modified push-triggered workflow https://github.com/aws-observability/aws-rum-web/runs/4156725464?check_suite_focus=true
- Going forward, we can use the beta stage to verify workflow changes (e.g., by making changes and running the workflow on a forked repo with access to the beta stage AWS account)