### PR TITLE
Use declarative format for built-in plugin config.

### DIFF
--- a/app/dom_event.html
+++ b/app/dom_event.html
@@ -28,27 +28,6 @@
             }
 
             // Specific to DOM Event plugin
-            function recordDocumentClicks() {
-                cwr('configurePlugin', {
-                    pluginId: 'com.amazonaws.rum.dom-event',
-                    config: [{ event: 'click', element: document }]
-                });
-            }
-
-            function recordButton1Clicks() {
-                cwr('configurePlugin', {
-                    pluginId: 'com.amazonaws.rum.dom-event',
-                    config: [{ event: 'click', elementId: 'button1' }]
-                });
-            }
-
-            function doNotRecordClicks() {
-                cwr('configurePlugin', {
-                    pluginId: 'com.amazonaws.rum.dom-event',
-                    config: []
-                });
-            }
-
             function disable() {
                 cwr('disable');
             }
@@ -76,15 +55,6 @@
     <body>
         <p id="welcome">This application is used for RUM integ testing.</p>
         <hr />
-        <button id="recordDocumentClicks" onclick="recordDocumentClicks()">
-            Record document Clicks
-        </button>
-        <button id="recordButton1Clicks" onclick="recordButton1Clicks()">
-            Record #button1 Clicks
-        </button>
-        <button id="doNotRecordClicks" onclick="doNotRecordClicks()">
-            Do Not Record Clicks
-        </button>
         <button id="disable" onclick="disable()">Disable</button>
         <button id="enable" onclick="enable()">Enable</button>
         <hr />

--- a/app/index.html
+++ b/app/index.html
@@ -16,10 +16,8 @@
             }
 
             function onSubmitCommand() {
-                //e.g. configurePlugin
                 const command = document.getElementById('command').value;
                 if (document.getElementById('payload').value) {
-                    //e.g. {"pluginId": "com.amazonaws.rum.dom-event", "config": [{"event":"click", "elementId":"button2"}]}
                     const payload = JSON.parse(
                         document.getElementById('payload').value
                     );

--- a/app/ingestion.html
+++ b/app/ingestion.html
@@ -34,20 +34,6 @@
                 throw 'thrown string';
             }
 
-            function recordStackTrace() {
-                cwr('configurePlugin', {
-                    pluginId: 'com.amazonaws.rum.js-error',
-                    config: { stackTraceLength: 150 }
-                });
-            }
-
-            function doNotRecordStackTrace() {
-                cwr('configurePlugin', {
-                    pluginId: 'com.amazonaws.rum.js-error',
-                    config: { stackTraceLength: 0 }
-                });
-            }
-
             function recordCaughtError() {
                 cwr('recordError', new Error('My error message'));
             }
@@ -84,9 +70,6 @@
         </button>
         <button id="throwErrorString" onclick="throwErrorString()">
             Throw error string
-        </button>
-        <button id="recordStackTrace" onclick="recordStackTrace()">
-            Record stack trace
         </button>
         <button id="recordCaughtError" onclick="recordCaughtError()">
             Record caught error

--- a/app/js_error_event.html
+++ b/app/js_error_event.html
@@ -34,20 +34,6 @@
                 throw 'thrown string';
             }
 
-            function recordStackTrace() {
-                cwr('configurePlugin', {
-                    pluginId: 'com.amazonaws.rum.js-error',
-                    config: { stackTraceLength: 150 }
-                });
-            }
-
-            function doNotRecordStackTrace() {
-                cwr('configurePlugin', {
-                    pluginId: 'com.amazonaws.rum.js-error',
-                    config: { stackTraceLength: 0 }
-                });
-            }
-
             function recordCaughtError() {
                 cwr('recordError', new Error('My error message'));
             }
@@ -84,9 +70,6 @@
         </button>
         <button id="throwErrorString" onclick="throwErrorString()">
             Throw error string
-        </button>
-        <button id="recordStackTrace" onclick="recordStackTrace()">
-            Record stack trace
         </button>
         <button id="recordCaughtError" onclick="recordCaughtError()">
             Record caught error

--- a/src/CommandQueue.ts
+++ b/src/CommandQueue.ts
@@ -4,11 +4,6 @@ import { getRemoteConfig } from './remote-config/remote-config';
 
 /**
  * An AWS RUM Client command.
- *
- * A command is one of the following:
- * - <'setAwsCredentials', AWS.Credentials>
- * - <'addPlugin', TelemetryPlugin>
- * - <'configurePlugin', object>
  */
 export type Command = { c: string; p: any };
 
@@ -42,16 +37,6 @@ export class CommandQueue {
             payload: Credentials | CredentialProvider
         ): void => {
             this.orchestration.setAwsCredentials(payload);
-        },
-        configurePlugin: (payload: any): void => {
-            if (payload.pluginId && payload.config) {
-                this.orchestration.configurePlugin(
-                    payload.pluginId,
-                    payload.config
-                );
-            } else {
-                throw new Error('IncorrectParametersException');
-            }
         },
         recordPageView: (payload: string): void => {
             this.orchestration.recordPageView(payload);

--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -42,7 +42,6 @@ const enable = jest.fn();
 const dispatch = jest.fn();
 const dispatchBeacon = jest.fn();
 const setAwsCredentials = jest.fn();
-const configurePlugin = jest.fn();
 const allowCookies = jest.fn();
 const recordPageView = jest.fn();
 const recordError = jest.fn();
@@ -53,7 +52,6 @@ jest.mock('../orchestration/Orchestration', () => ({
         dispatch,
         dispatchBeacon,
         setAwsCredentials,
-        configurePlugin,
         allowCookies,
         recordPageView,
         recordError
@@ -244,16 +242,6 @@ describe('CommandQueue tests', () => {
         });
         expect(Orchestration).toHaveBeenCalled();
         expect(setAwsCredentials).toHaveBeenCalled();
-    });
-
-    test('configurePlugin calls Orchestration.configurePlugin', async () => {
-        const cq: CommandQueue = getCommandQueue();
-        const result = await cq.push({
-            c: 'configurePlugin',
-            p: { pluginId: 'myplugin', config: {} }
-        });
-        expect(Orchestration).toHaveBeenCalled();
-        expect(configurePlugin).toHaveBeenCalled();
     });
 
     test('allowCookies calls Orchestration.allowCookies', async () => {

--- a/src/loader/loader-dom-event.js
+++ b/src/loader/loader-dom-event.js
@@ -5,7 +5,9 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
     allowCookies: true,
     dispatchInterval: 0,
     metaDataPluginsToLoad: [],
-    eventPluginsToLoad: [new DomEventPlugin()],
+    eventPluginsToLoad: [
+        new DomEventPlugin({ events: [{ event: 'click', element: document }] })
+    ],
     telemetries: [],
     clientBuilder: showRequestClientBuilder
 });

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -29,17 +29,12 @@ jest.mock('../../event-cache/EventCache', () => ({
 
 const addPlugin = jest.fn();
 
-const configurePluginSpy = jest.fn((p, q) => {
-    /*do nothing*/
-});
-
 const enablePlugins = jest.fn();
 const disablePlugins = jest.fn();
 
 jest.mock('../../plugins/PluginManager', () => ({
     PluginManager: jest.fn().mockImplementation(() => ({
         addPlugin: addPlugin,
-        configurePlugin: configurePluginSpy,
         enable: enablePlugins,
         disable: disablePlugins
     }))
@@ -219,6 +214,21 @@ describe('Orchestration tests', () => {
         });
 
         expect(actual.sort()).toEqual(expected.sort());
+    });
+
+    test('when a config is passed to the http data collection then the config is added as a constructor arg', async () => {
+        // Init
+        new Orchestration('a', 'c', 'us-east-1', {
+            telemetries: [['http', { trace: true }]]
+        });
+
+        // Assert
+        addPlugin.mock.calls.forEach((call) => {
+            const plugin: any = call[0];
+            if (plugin.getPluginId() === 'com.amazonaws.rum.fetch') {
+                expect(plugin.config.trace).toEqual(true);
+            }
+        });
     });
 
     test('when performance data collection is set then the performance plugins are instantiated', async () => {

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -39,13 +39,6 @@ export interface Plugin {
     getPluginId(): string;
 
     /**
-     * Configure the plugin. The plugin should start or stop recording events for
-     * which it is configured.
-     * @param config The configuration for the plugin (e.g., enable/disable events).
-     */
-    configure(config: object): void;
-
-    /**
      * Manually record an event.
      * @param data Data that the plugin will use to create an event.
      */

--- a/src/plugins/PluginManager.ts
+++ b/src/plugins/PluginManager.ts
@@ -14,14 +14,10 @@ export class PluginManager {
     }
 
     /**
-     * Add an event plugin to PluginManager.
-     * It also:
-     * 1. config the plugin with in intial configuration
-     * 2. initialize the plugin
+     * Add an event plugin to PluginManager and initialize the plugin.
      * @param plugin The plugin which adheres to the RUM web client's plugin interface.
-     * @param config The initial configuration for the plugin.
      */
-    public addPlugin(plugin: Plugin, config?: any): void {
+    public addPlugin(plugin: Plugin): void {
         const pluginId: string = plugin.getPluginId();
 
         // add to plugin map
@@ -33,11 +29,6 @@ export class PluginManager {
 
         // initialize plugin
         plugin.load(this.context);
-
-        // config plugin
-        if (config) {
-            plugin.configure(config);
-        }
     }
 
     /**
@@ -60,22 +51,6 @@ export class PluginManager {
      */
     public hasPlugin(pluginId: string): boolean {
         return this.plugins.has(pluginId);
-    }
-
-    /**
-     * Configure a plugin.
-     * @param pluginId The unique identifier for the plugin being configured.
-     * @param config The configuration for the plugin (e.g., enable/disable events).
-     */
-    public configurePlugin(pluginId: string, config: object): void {
-        const plugin = this.plugins.get(pluginId);
-        if (plugin) {
-            plugin.configure(config);
-        } else {
-            throw new Error(
-                'AWS RUM Client configurePlugin: Invalid plugin ID'
-            );
-        }
     }
 
     /**

--- a/src/plugins/__tests__/plugins.test.ts
+++ b/src/plugins/__tests__/plugins.test.ts
@@ -13,40 +13,10 @@ describe('Plugins tests', () => {
         const demoPlugin: DemoPlugin = new DemoPlugin();
 
         // Run
-        pluginManager.addPlugin(demoPlugin, {});
+        pluginManager.addPlugin(demoPlugin);
 
         // Assert
         expect(pluginManager.hasPlugin(demoPlugin.getPluginId())).toBeTruthy();
-    });
-
-    test('update a plugin', async () => {
-        // Init
-        const pluginManager: PluginManager = new PluginManager(context);
-        const demoPlugin: DemoPlugin = new DemoPlugin();
-
-        // Run
-        pluginManager.addPlugin(demoPlugin, { enable: true });
-
-        // Assert
-        expect(demoPlugin.configuration.enable).toEqual(true);
-
-        // update plugin config
-        pluginManager.configurePlugin(DEMO_PLUGIN_ID, { enable: false });
-
-        // Assert
-        expect(demoPlugin.configuration.enable).toEqual(false);
-    });
-
-    test('when an invalid plugin is configured then the plugin manager throws an error', async () => {
-        // Init
-        const pluginManager: PluginManager = new PluginManager(context);
-
-        // Run and Assert
-        expect(() =>
-            pluginManager.configurePlugin('does_not_exist', {})
-        ).toThrowError(
-            new Error('AWS RUM Client configurePlugin: Invalid plugin ID')
-        );
     });
 
     test('when data is recorded to an invalid plugin then the plugin manager throws an error', async () => {
@@ -63,7 +33,7 @@ describe('Plugins tests', () => {
         // Init
         const pluginManager: PluginManager = new PluginManager(context);
         const demoPlugin: DemoPlugin = new DemoPlugin();
-        pluginManager.addPlugin(demoPlugin, { enable: true });
+        pluginManager.addPlugin(demoPlugin);
 
         // Run
         pluginManager.record(DEMO_PLUGIN_ID, 'data to record');

--- a/src/plugins/event-plugins/DemoPlugin.ts
+++ b/src/plugins/event-plugins/DemoPlugin.ts
@@ -46,13 +46,6 @@ export class DemoPlugin implements Plugin {
         return DEMO_PLUGIN_ID;
     }
 
-    configure(config: object): void {
-        this.configuration = {
-            ...this.configuration,
-            ...config
-        };
-    }
-
     record(data: any): void {
         const demoEvent = {
             eventData: data

--- a/src/plugins/event-plugins/FetchPlugin.ts
+++ b/src/plugins/event-plugins/FetchPlugin.ts
@@ -2,12 +2,12 @@ import { Plugin, PluginContext } from '../Plugin';
 import { Http, XRayTraceEvent } from '../../events/xray-trace-event';
 import { MonkeyPatch, MonkeyPatched } from '../MonkeyPatched';
 import {
-    HttpPluginConfig,
+    PartialHttpPluginConfig,
     defaultConfig,
     epochTime,
     createXRayTraceEvent,
     addAmznTraceIdHeader,
-    HttpPluginConfigWithDefaults,
+    HttpPluginConfig,
     createXRayTraceEventHttp,
     isUrlAllowed
 } from '../utils/http-utils';
@@ -39,10 +39,10 @@ export const FETCH_PLUGIN_ID = 'com.amazonaws.rum.fetch';
  */
 export class FetchPlugin extends MonkeyPatched implements Plugin {
     private pluginId: string;
-    private config: HttpPluginConfigWithDefaults;
+    private config: HttpPluginConfig;
     private context: PluginContext;
 
-    constructor(config?: HttpPluginConfig) {
+    constructor(config?: PartialHttpPluginConfig) {
         super();
         this.pluginId = FETCH_PLUGIN_ID;
         this.config = { ...defaultConfig, ...config };
@@ -55,10 +55,6 @@ export class FetchPlugin extends MonkeyPatched implements Plugin {
 
     public getPluginId(): string {
         return this.pluginId;
-    }
-
-    public configure(config: HttpPluginConfig): void {
-        this.config = { ...this.config, ...config };
     }
 
     protected patches(): MonkeyPatch[] {

--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -4,6 +4,10 @@ import { errorEventToJsErrorEvent } from '../utils/js-error-utils';
 
 export const JS_ERROR_EVENT_PLUGIN_ID = 'com.amazonaws.rum.js-error';
 
+export type PartialJsErrorPluginConfig = {
+    stackTraceLength?: number;
+};
+
 export type JsErrorPluginConfig = {
     stackTraceLength: number;
 };
@@ -18,10 +22,10 @@ export class JsErrorPlugin implements Plugin {
     private config: JsErrorPluginConfig;
     private recordEvent: RecordEvent;
 
-    constructor(config?: JsErrorPluginConfig) {
+    constructor(config?: PartialJsErrorPluginConfig) {
         this.pluginId = JS_ERROR_EVENT_PLUGIN_ID;
         this.enabled = true;
-        this.config = config ? config : defaultConfig;
+        this.config = { ...defaultConfig, ...config };
     }
 
     load(context: PluginContext): void {
@@ -47,10 +51,6 @@ export class JsErrorPlugin implements Plugin {
 
     getPluginId(): string {
         return this.pluginId;
-    }
-
-    configure(config: JsErrorPluginConfig): void {
-        this.config = config;
     }
 
     record(error: any): void {

--- a/src/plugins/event-plugins/NavigationPlugin.ts
+++ b/src/plugins/event-plugins/NavigationPlugin.ts
@@ -51,9 +51,6 @@ export class NavigationPlugin implements Plugin {
         return this.pluginId;
     }
 
-    // tslint:disable:no-empty
-    configure(config: string[]): void {}
-
     /**
      * Use Navigation timing Level 1 for all browsers by default -
      * https://developer.mozilla.org/en-US/docs/Web/API/Performance/timing

--- a/src/plugins/event-plugins/PageViewPlugin.ts
+++ b/src/plugins/event-plugins/PageViewPlugin.ts
@@ -32,9 +32,6 @@ export class PageViewPlugin extends MonkeyPatched implements Plugin {
         return this.pluginId;
     }
 
-    // tslint:disable-next-line:no-empty
-    public configure(config: any): void {}
-
     protected patches(): MonkeyPatch[] {
         return [
             {

--- a/src/plugins/event-plugins/ResourcePlugin.ts
+++ b/src/plugins/event-plugins/ResourcePlugin.ts
@@ -13,13 +13,19 @@ export const RESOURCE_EVENT_PLUGIN_ID = 'com.amazonaws.rum.resource';
 const RESOURCE = 'resource';
 const LOAD = 'load';
 
+export type PartialResourcePluginConfig = {
+    eventLimit?: number;
+    recordAllTypes?: ResourceType[];
+    sampleTypes?: ResourceType[];
+};
+
 export type ResourcePluginConfig = {
     eventLimit: number;
     recordAllTypes: ResourceType[];
     sampleTypes: ResourceType[];
 };
 
-export const defaultRepConfig = {
+export const defaultConfig = {
     eventLimit: 10,
     recordAllTypes: [ResourceType.DOCUMENT, ResourceType.SCRIPT],
     sampleTypes: [
@@ -46,14 +52,14 @@ export class ResourcePlugin implements Plugin {
      */
     private dataPlaneEndpoint: string;
 
-    constructor(dataPlaneEndpoint) {
+    constructor(config?: PartialResourcePluginConfig) {
         this.pluginId = RESOURCE_EVENT_PLUGIN_ID;
         this.enabled = true;
-        this.dataPlaneEndpoint = dataPlaneEndpoint;
-        this.config = defaultRepConfig;
+        this.config = { ...defaultConfig, ...config };
     }
 
     load(context: PluginContext): void {
+        this.dataPlaneEndpoint = context.config.endpoint;
         this.recordEvent = context.record;
         window.addEventListener(LOAD, this.resourceEventListener);
     }
@@ -78,10 +84,6 @@ export class ResourcePlugin implements Plugin {
 
     getPluginId(): string {
         return this.pluginId;
-    }
-
-    configure(config: ResourcePluginConfig): void {
-        this.config = config;
     }
 
     resourceEventListener = (event: Event): void => {

--- a/src/plugins/event-plugins/XhrPlugin.ts
+++ b/src/plugins/event-plugins/XhrPlugin.ts
@@ -3,14 +3,14 @@ import { XRayTraceEvent } from '../../events/xray-trace-event';
 import { HttpEvent } from '../../events/http-event';
 import { MonkeyPatch, MonkeyPatched } from '../MonkeyPatched';
 import {
-    HttpPluginConfig,
+    PartialHttpPluginConfig,
     defaultConfig,
     epochTime,
     createXRayTraceEvent,
     getAmznTraceIdHeaderValue,
     X_AMZN_TRACE_ID,
     isUrlAllowed,
-    HttpPluginConfigWithDefaults
+    HttpPluginConfig
 } from '../utils/http-utils';
 import { XhrError } from '../../errors/XhrError';
 import { HTTP_EVENT_TYPE, XRAY_TRACE_EVENT_TYPE } from '../utils/constant';
@@ -93,11 +93,11 @@ export const XHR_PLUGIN_ID = 'com.amazonaws.rum.xhr';
  */
 export class XhrPlugin extends MonkeyPatched implements Plugin {
     private pluginId: string;
-    private config: HttpPluginConfigWithDefaults;
+    private config: HttpPluginConfig;
     private xhrMap: Map<XMLHttpRequest, XhrDetails>;
     private context: PluginContext;
 
-    constructor(config?: HttpPluginConfig) {
+    constructor(config?: PartialHttpPluginConfig) {
         super();
         this.pluginId = XHR_PLUGIN_ID;
         this.config = { ...defaultConfig, ...config };
@@ -111,10 +111,6 @@ export class XhrPlugin extends MonkeyPatched implements Plugin {
 
     public getPluginId(): string {
         return this.pluginId;
-    }
-
-    public configure(config: HttpPluginConfig): void {
-        this.config = { ...this.config, ...config };
     }
 
     protected patches(): MonkeyPatch[] {

--- a/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
@@ -21,7 +21,6 @@ test('when document click events configured then button click is recorded', asyn
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t
         .wait(300)
-        .click(recordDocumentClicks)
         .click(button1)
         .click(dispatch)
         .expect(REQUEST_BODY.textContent)
@@ -51,7 +50,6 @@ test('when element without an id is clicked then node type is recorded', async (
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t
         .wait(300)
-        .click(recordDocumentClicks)
         .click(link1)
         .click(dispatch)
         .expect(REQUEST_BODY.textContent)
@@ -80,7 +78,6 @@ test('when element id click event configured then button click is recorded', asy
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t
         .wait(300)
-        .click(recordButton1Clicks)
         .click(button1)
         .click(dispatch)
         .expect(REQUEST_BODY.textContent)
@@ -98,32 +95,11 @@ test('when element id click event configured then button click is recorded', asy
     });
 });
 
-test('when client is disabled prior to config then button click is not recorded', async (t: TestController) => {
+test('when client is disabled then button click is not recorded', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t
         .wait(300)
-        .click(disable)
-        .click(recordButton1Clicks)
-        .click(button1)
-        .click(enable)
-        .click(dispatch)
-        .expect(REQUEST_BODY.textContent)
-        .contains('BatchId');
-
-    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
-        (e) => e.type === DOM_EVENT_TYPE
-    );
-
-    await t.expect(events.length).eql(0);
-});
-
-test('when client is disabled after config then button click is not recorded', async (t: TestController) => {
-    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
-    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
-    await t
-        .wait(300)
-        .click(recordButton1Clicks)
         .click(disable)
         .click(button1)
         .click(enable)
@@ -132,7 +108,9 @@ test('when client is disabled after config then button click is not recorded', a
         .contains('BatchId');
 
     const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
-        (e) => e.type === DOM_EVENT_TYPE
+        (e) =>
+            e.type === DOM_EVENT_TYPE &&
+            JSON.parse(e.details).elementId === 'button1'
     );
 
     await t.expect(events.length).eql(0);
@@ -143,7 +121,6 @@ test('when client is disabled and enabled then button click is recorded', async 
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t
         .wait(300)
-        .click(recordButton1Clicks)
         .click(disable)
         .click(enable)
         .click(button1)

--- a/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
@@ -62,12 +62,11 @@ test('when a TypeError is thrown then name and message are recorded', async (t: 
         .match(/\d+/);
 });
 
-test('when stack trace is > 0 then stack trace is recorded', async (t: TestController) => {
+test('stack trace is recorded by default', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t
         .wait(300)
-        .click(recordStackTrace)
         .click(triggerTypeError)
         .click(dispatch)
         .expect(REQUEST_BODY.textContent)

--- a/src/plugins/event-plugins/__tests__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/DomEventPlugin.test.ts
@@ -10,12 +10,12 @@ describe('DomEventPlugin tests', () => {
     test('DomEventPlugin records events by default', async () => {
         // Init
         document.body.innerHTML = '<button id="button1"/>';
-        const plugin: DomEventPlugin = new DomEventPlugin();
+        const plugin: DomEventPlugin = new DomEventPlugin({
+            events: [{ event: 'click', elementId: 'button1' }]
+        });
 
         // Run
         plugin.load(context);
-        plugin.configure([{ event: 'click', elementId: 'button1' }]);
-        // @ts-ignore
         document.getElementById('button1').click();
         plugin.disable();
 
@@ -26,13 +26,13 @@ describe('DomEventPlugin tests', () => {
     test('DomEventPlugin does not record events when disabled', async () => {
         // Init
         document.body.innerHTML = '<button id="button1"/>';
-        const plugin: DomEventPlugin = new DomEventPlugin();
+        const plugin: DomEventPlugin = new DomEventPlugin({
+            events: [{ event: 'click', elementId: 'button1' }]
+        });
 
         // Run
         plugin.load(context);
-        plugin.configure([{ event: 'click', elementId: 'button1' }]);
         plugin.disable();
-        // @ts-ignore
         document.getElementById('button1').click();
 
         // Assert
@@ -42,14 +42,14 @@ describe('DomEventPlugin tests', () => {
     test('DomEventPlugin records events when disabled, then enabled', async () => {
         // Init
         document.body.innerHTML = '<button id="button1"/>';
-        const plugin: DomEventPlugin = new DomEventPlugin();
+        const plugin: DomEventPlugin = new DomEventPlugin({
+            events: [{ event: 'click', elementId: 'button1' }]
+        });
 
         // Run
         plugin.load(context);
-        plugin.configure([{ event: 'click', elementId: 'button1' }]);
         plugin.disable();
         plugin.enable();
-        // @ts-ignore
         document.getElementById('button1').click();
         plugin.disable();
 
@@ -60,12 +60,12 @@ describe('DomEventPlugin tests', () => {
     test('when listening to document click and event target has an ID, element ID is used as ID', async () => {
         // Init
         document.body.innerHTML = '<button id="button1"/>';
-        const plugin: DomEventPlugin = new DomEventPlugin();
+        const plugin: DomEventPlugin = new DomEventPlugin({
+            events: [{ event: 'click', element: document as any }]
+        });
 
         // Run
         plugin.load(context);
-        plugin.configure([{ event: 'click', element: document }]);
-        // @ts-ignore
         document.getElementById('button1').click();
         plugin.disable();
 
@@ -83,12 +83,12 @@ describe('DomEventPlugin tests', () => {
     test('when listening to document click and event target has no ID, element tag is used as ID', async () => {
         // Init
         document.body.innerHTML = '<button/>';
-        const plugin: DomEventPlugin = new DomEventPlugin();
+        const plugin: DomEventPlugin = new DomEventPlugin({
+            events: [{ event: 'click', element: document as any }]
+        });
 
         // Run
         plugin.load(context);
-        plugin.configure([{ event: 'click', element: document }]);
-        // @ts-ignore
         document.getElementsByTagName('button')[0].click();
         plugin.disable();
 

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.integ.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.integ.test.ts
@@ -1,19 +1,19 @@
 import { Orchestration } from '../../../orchestration/Orchestration';
 import { createAwsCredentials } from '../../../test-utils/test-utils';
-import { HttpPluginConfig } from '../../utils/http-utils';
+import { PartialHttpPluginConfig } from '../../utils/http-utils';
 import { FetchPlugin } from '../FetchPlugin';
 
-const mockFetch = jest.fn((input: RequestInfo, init?: RequestInit) =>
-    Promise.resolve({
-        status: 200,
-        statusText: 'OK',
-        headers: [],
-        body: '{}',
-        ok: true
-    })
+const mockFetch = jest.fn(
+    (input: RequestInfo, init?: RequestInit) =>
+        Promise.resolve({
+            status: 200,
+            statusText: 'OK',
+            headers: [],
+            body: '{}',
+            ok: true
+        }) as any
 );
 
-// @ts-ignore
 global.fetch = mockFetch;
 global.Request = jest.fn().mockImplementation((url, requestOptions) => ({
     url,
@@ -27,7 +27,7 @@ describe('FetchPlugin integ tests', () => {
 
     test('dispatch requests are not recorded by the http plugin', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             recordAllRequests: true
         };
 

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -1,5 +1,5 @@
 import { FetchPlugin } from '../FetchPlugin';
-import { HttpPluginConfig } from '../../utils/http-utils';
+import { PartialHttpPluginConfig } from '../../utils/http-utils';
 import { advanceTo } from 'jest-date-mock';
 import {
     context,
@@ -70,7 +70,7 @@ describe('FetchPlugin tests', () => {
 
     test('when fetch is called then the plugin records the http request/response', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/aws\.amazon\.com/],
             trace: false,
             recordAllRequests: true
@@ -101,7 +101,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch throws an error then the plugin adds the error to the http event', async () => {
         // Init
         global.fetch = mockFetchWithError;
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: false
@@ -134,7 +134,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch throws an error object then the plugin adds the error object to the http event', async () => {
         // Init
         global.fetch = mockFetchWithErrorObject;
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: false
@@ -167,7 +167,7 @@ describe('FetchPlugin tests', () => {
 
     test('when fetch is called then the plugin records a trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: true
@@ -202,7 +202,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch throws an error then the plugin adds the error to the trace', async () => {
         // Init
         global.fetch = mockFetchWithError;
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: true
@@ -246,7 +246,7 @@ describe('FetchPlugin tests', () => {
 
     test('when plugin is disabled then the plugin does not record a trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: true
@@ -266,7 +266,7 @@ describe('FetchPlugin tests', () => {
 
     test('when plugin is re-enabled then the plugin records a trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: true
@@ -288,7 +288,7 @@ describe('FetchPlugin tests', () => {
 
     test('X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: true
@@ -311,7 +311,7 @@ describe('FetchPlugin tests', () => {
     });
 
     test('when trace is disabled then the plugin does not record a trace', async () => {
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: false
@@ -343,7 +343,7 @@ describe('FetchPlugin tests', () => {
             recordPageView,
             getSession
         };
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             trace: true
@@ -364,7 +364,7 @@ describe('FetchPlugin tests', () => {
     test('the plugin records a stack trace by default', async () => {
         // Init
         global.fetch = mockFetchWithErrorObjectAndStack;
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -397,7 +397,7 @@ describe('FetchPlugin tests', () => {
     test('when stack trace length is zero then the plugin does not record a stack trace', async () => {
         // Init
         global.fetch = mockFetchWithErrorObjectAndStack;
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             stackTraceLength: 0
@@ -432,7 +432,7 @@ describe('FetchPlugin tests', () => {
 
     test('when recordAllRequests is true then the plugin records a request with status OK', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: true
         };
@@ -451,7 +451,7 @@ describe('FetchPlugin tests', () => {
 
     test('when recordAllRequests is false then the plugin does not record a request with status OK', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: false
         };
@@ -471,7 +471,7 @@ describe('FetchPlugin tests', () => {
     test('when recordAllRequests is false then the plugin records a request with status 500', async () => {
         // Init
         global.fetch = mockFetchWith500;
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: false
         };
@@ -491,7 +491,7 @@ describe('FetchPlugin tests', () => {
 
     test('when a url is excluded then the plugin does not record a request to that url', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/aws\.amazon\.com/],
             urlsToExclude: [/aws\.amazon\.com/],
             recordAllRequests: true
@@ -511,7 +511,7 @@ describe('FetchPlugin tests', () => {
 
     test('all urls are included by default', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             recordAllRequests: true
         };
 
@@ -529,7 +529,7 @@ describe('FetchPlugin tests', () => {
 
     test('when a request is made to cognito or sts using default exclude list then the requests are not recorded', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             recordAllRequests: true
         };
 
@@ -548,7 +548,7 @@ describe('FetchPlugin tests', () => {
 
     test('when a request is made to cognito or sts using an empty exclude list then the requests are recorded', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             recordAllRequests: true,
             urlsToExclude: []
         };

--- a/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
@@ -8,15 +8,15 @@ import {
     mockPerformanceObjectWithResources,
     resourceEvent
 } from '../../../test-utils/mock-data';
-import { defaultRepConfig, ResourcePlugin } from '../ResourcePlugin';
+import { PartialResourcePluginConfig, ResourcePlugin } from '../ResourcePlugin';
 import { mockRandom } from 'jest-mock-random';
 import { context, record } from '../../../test-utils/test-utils';
 import { PERFORMANCE_RESOURCE_EVENT_TYPE } from '../../utils/constant';
 
 const DATA_PLANE_URL = 'https://dataplane.rum.us-west-2.amazonaws.com';
 
-const buildResourcePlugin = () => {
-    return new ResourcePlugin(DATA_PLANE_URL);
+const buildResourcePlugin = (config?: PartialResourcePluginConfig) => {
+    return new ResourcePlugin(config);
 };
 
 describe('ResourcePlugin tests', () => {
@@ -104,8 +104,7 @@ describe('ResourcePlugin tests', () => {
         mockPerformanceObjectWithResources();
         mockPerformanceObserver();
 
-        const plugin: ResourcePlugin = buildResourcePlugin();
-        plugin.configure({ ...defaultRepConfig, ...{ eventLimit: 1 } });
+        const plugin: ResourcePlugin = buildResourcePlugin({ eventLimit: 1 });
 
         // Run
         plugin.load(context);
@@ -123,8 +122,7 @@ describe('ResourcePlugin tests', () => {
         mockPerformanceObserver();
 
         // Run
-        const plugin: ResourcePlugin = buildResourcePlugin();
-        plugin.configure({ ...defaultRepConfig, ...{ eventLimit: 1 } });
+        const plugin: ResourcePlugin = buildResourcePlugin({ eventLimit: 1 });
 
         plugin.load(context);
         window.dispatchEvent(new Event('load'));
@@ -147,8 +145,7 @@ describe('ResourcePlugin tests', () => {
         mockPerformanceObjectWithResources();
         mockPerformanceObserver();
 
-        const plugin: ResourcePlugin = buildResourcePlugin();
-        plugin.configure({ ...defaultRepConfig, ...{ eventLimit: 3 } });
+        const plugin: ResourcePlugin = buildResourcePlugin({ eventLimit: 3 });
 
         // Run
         plugin.load(context);

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -1,4 +1,4 @@
-import { HttpPluginConfig } from '../../utils/http-utils';
+import { PartialHttpPluginConfig } from '../../utils/http-utils';
 import { advanceTo } from 'jest-date-mock';
 import { XhrPlugin } from '../XhrPlugin';
 import {
@@ -23,7 +23,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR is called then the plugin records the http request/response', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
         };
@@ -63,7 +63,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR is called then the plugin records a trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/],
             trace: true
@@ -110,7 +110,7 @@ describe('XhrPlugin tests', () => {
 
     test('when plugin is disabled then the plugin does not record any events', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             trace: true,
             recordAllRequests: true
@@ -138,7 +138,7 @@ describe('XhrPlugin tests', () => {
 
     test('when plugin is re-enabled then the plugin records a trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             trace: true
         };
@@ -169,7 +169,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR returns an error code then the plugin adds the error to the trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             ...DEFAULT_CONFIG,
             ...{
                 logicalServiceName: 'sample.rum.aws.amazon.com',
@@ -223,7 +223,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR returns an error code then the plugin adds the error to the http event', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/],
             trace: false
@@ -262,7 +262,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR times out then the plugin adds the error to the trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/],
             trace: true
@@ -308,7 +308,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR times out then the plugin adds the error to the http event', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/],
             trace: false
@@ -347,7 +347,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR aborts then the plugin adds the error to the trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/],
             trace: true
@@ -395,7 +395,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR aborts then the plugin adds the error to the http event', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             trace: false
         };
@@ -436,7 +436,7 @@ describe('XhrPlugin tests', () => {
     test('X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
         let header: string;
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             trace: true
         };
@@ -471,7 +471,7 @@ describe('XhrPlugin tests', () => {
 
     test('when trace is disabled then the plugin does not record a trace', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             trace: false
         };
@@ -512,7 +512,7 @@ describe('XhrPlugin tests', () => {
             recordPageView,
             getSession
         };
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/]
         };
@@ -540,7 +540,7 @@ describe('XhrPlugin tests', () => {
 
     test('when recordAllRequests is false then the plugin does record a request with status OK', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
         };
@@ -568,7 +568,7 @@ describe('XhrPlugin tests', () => {
 
     test('when recordAllRequests is false then the plugin does not record a request with status OK', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: false
         };
@@ -596,7 +596,7 @@ describe('XhrPlugin tests', () => {
 
     test('when recordAllRequests is false then the plugin records a request with status 500', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: false
         };
@@ -625,7 +625,7 @@ describe('XhrPlugin tests', () => {
 
     test('when a url is excluded then the plugin does not record a request to that url', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
             urlsToExclude: [/response\.json/]
         };
@@ -653,7 +653,7 @@ describe('XhrPlugin tests', () => {
 
     test('all urls are included by default', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             recordAllRequests: true
         };
 
@@ -680,7 +680,7 @@ describe('XhrPlugin tests', () => {
 
     test('when a request is made to cognito or sts using default exclude list then the requests are not recorded', async () => {
         // Init
-        const config: HttpPluginConfig = {
+        const config: PartialHttpPluginConfig = {
             recordAllRequests: true
         };
 

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -13,7 +13,7 @@ for (let i = 0; i < 256; i++) {
 
 export const X_AMZN_TRACE_ID = 'X-Amzn-Trace-Id';
 
-export type HttpPluginConfig = {
+export type PartialHttpPluginConfig = {
     logicalServiceName?: string;
     urlsToInclude?: RegExp[];
     urlsToExclude?: RegExp[];
@@ -22,7 +22,7 @@ export type HttpPluginConfig = {
     recordAllRequests?: boolean;
 };
 
-export type HttpPluginConfigWithDefaults = {
+export type HttpPluginConfig = {
     logicalServiceName: string;
     urlsToInclude: RegExp[];
     urlsToExclude: RegExp[];
@@ -31,7 +31,7 @@ export type HttpPluginConfigWithDefaults = {
     recordAllRequests: boolean;
 };
 
-export const defaultConfig: HttpPluginConfigWithDefaults = {
+export const defaultConfig: HttpPluginConfig = {
     logicalServiceName: 'rum.aws.amazon.com',
     urlsToInclude: [/.*/],
     urlsToExclude: [
@@ -45,10 +45,7 @@ export const defaultConfig: HttpPluginConfigWithDefaults = {
     recordAllRequests: false
 };
 
-export const isUrlAllowed = (
-    url: string,
-    config: HttpPluginConfigWithDefaults
-) => {
+export const isUrlAllowed = (url: string, config: HttpPluginConfig) => {
     const include = config.urlsToInclude.some((urlPattern) =>
         urlPattern.test(url)
     );

--- a/src/sessions/__integ__/SessionManager.test.ts
+++ b/src/sessions/__integ__/SessionManager.test.ts
@@ -9,7 +9,6 @@ import {
     REQUEST_BODY,
     RESPONSE_STATUS
 } from '../../test-utils/integ-test-utils';
-import { DOM_EVENT_PLUGIN_ID } from '../../plugins/event-plugins/DomEventPlugin';
 
 import { SESSION_START_EVENT_TYPE } from '../SessionManager';
 
@@ -23,9 +22,6 @@ const OS_NAME = 'osName';
 const OS_VERSION = 'osVersion';
 const DEVICE_TYPE = 'deviceType';
 const PLATFORM_TYPE = 'platformType';
-
-const CONFIGURE_DOM_EVENT_PLUGIN_COMMAND = 'configurePlugin';
-const CONFIGURE_DOM_EVENT_PLUGIN_PAYLOAD = `{"pluginId": "${DOM_EVENT_PLUGIN_ID}", "config": [{"event":"click", "elementId":"button1"}]}`;
 
 const button1: Selector = Selector(`#${BUTTON_ID_1}`);
 
@@ -79,16 +75,6 @@ test('UserAgentMetaDataPlugin records user agent metadata', async (t: TestContro
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t.wait(300);
-
-    // update configure, register click event for button1
-    await t
-        .typeText(COMMAND, CONFIGURE_DOM_EVENT_PLUGIN_COMMAND, {
-            replace: true
-        })
-        .typeText(PAYLOAD, CONFIGURE_DOM_EVENT_PLUGIN_PAYLOAD, {
-            replace: true
-        })
-        .click(SUBMIT);
 
     // click button
     await t.click(button1);


### PR DESCRIPTION
RUM web client plugins (e.g., the instrumentation which records RUM events) are currently configured by calling the API function `configurePlugin`. For example, to enable tracing on the HTTP plugin, one would first enable `http` telemetry in the `telemetries` configuration of the code snippet, and then execute a command to enable tracing on the `http` telemetry. The example below demonstrates this.
```
(function (n, i, v, r, s, c, u, x, z) { ... })(
  'cwr',
  '00000000-0000-0000-0000-000000000000',
  '1.0.0',
  'us-west-2',
  'https://client.rum.amazonaws.com/1.0.0/cwr.js',
  {
    telemetries: ['errors', 'http', 'performance']
  }
);
cwr('configurePlugin', {pluginId: 'com.amazonaws.rum.http_fetch', config: { trace: true });
```

This is a confusing process for application owners because the configuration of the plugin is disassociated from the instantiation of the plugin. It also prevents a single configuration file (e.g., one hosted on CDN) from configuring plugins because the configuration is not declarative.

This change (1) removes the `configurePlugin` API and (2) adds the ability to specify a plugin configuration alongside the plugin being enabled in the RUM web client configuration. The example below demonstrates how the `http` telemetry can be configured to enable tracing after this change is applied.
```
  {
    telemetries: ['errors', ['http', { trace: true }], 'performance']
  }
```
Each telemetry can now be either (A) a string containing the name of the plugin (e.g., `'errors'` and `'performance'`) -- the default plugin configuration is used in this case, or (B) an array containing a tuple, where the name of the plugin is in position 0 and the configuration for the plugin is in position 1 (e.g., `['http', { trace: true }]`) -- the union of the default plugin configuration and the provided plugin configuration is used in this case.
