### PR TITLE
Fix beacon endpoint -- use appmonitor url path

### DIFF
--- a/src/dispatch/DataPlaneClient.ts
+++ b/src/dispatch/DataPlaneClient.ts
@@ -107,7 +107,7 @@ export class DataPlaneClient {
             },
             protocol: getScheme(this.config.endpoint),
             hostname: host,
-            path: `/application/${putRumEventsRequest.AppMonitorDetails.id}/events`,
+            path: `/appmonitors/${putRumEventsRequest.AppMonitorDetails.id}`,
             body: serializedRequest
         });
 

--- a/src/dispatch/__tests__/BeaconHttpHandler.test.ts
+++ b/src/dispatch/__tests__/BeaconHttpHandler.test.ts
@@ -75,7 +75,7 @@ describe('BeaconHttpHandler tests', () => {
         // @ts-ignore
         const url: string = sendBeacon.mock.calls[0][0];
         expect(url).toContain(
-            'https://rumservicelambda.us-west-2.amazonaws.com/application/application123/events?X-Amz-Algorithm=AWS4-HMAC-SHA256'
+            'https://rumservicelambda.us-west-2.amazonaws.com/appmonitors/application123?X-Amz-Algorithm=AWS4-HMAC-SHA256'
         );
     });
 });

--- a/src/dispatch/__tests__/DataPlaneClient.test.ts
+++ b/src/dispatch/__tests__/DataPlaneClient.test.ts
@@ -129,7 +129,7 @@ describe('DataPlaneClient tests', () => {
             'content-type;host'
         );
         expect(signedRequest.query['X-Amz-Signature']).toEqual(
-            'c5e418bbf3d0a922d4f468b1dd7a209711423750d407b5c679c01014ec34240c'
+            'd37eb756444ebf6f785233714d6d942f2b20f69292fb09533f6b69556eb0ff2b'
         );
     });
 });


### PR DESCRIPTION
The RUM web client uses either `fetch` or `sendBeacon` to call the RUM data plane API. When the data plane endpoint was updated for the `fetch` request utility, we forgot to also update the `beacon` request utility.

This change fixes the beacon endpoint to use the correct path (i.e., update `/application/[id]/events` to `/appmonitors/[id]`).