### PR TITLE
Record landing with page view plugin.

### DIFF
--- a/app/cookies_disabled.html
+++ b/app/cookies_disabled.html
@@ -10,8 +10,6 @@
         />
 
         <script>
-            cwr('recordPageView', '/cookies_disabled.html');
-
             // Common to all test pages
             function dispatch() {
                 cwr('dispatch');

--- a/app/cookies_enabled.html
+++ b/app/cookies_enabled.html
@@ -10,8 +10,6 @@
         />
 
         <script>
-            cwr('recordPageView', '/cookies_enabled.html');
-
             // Common to all test pages
             function dispatch() {
                 cwr('dispatch');

--- a/app/dom_event.html
+++ b/app/dom_event.html
@@ -10,8 +10,6 @@
         />
 
         <script>
-            cwr('recordPageView', '/dom_event.html');
-
             // Common to all test pages
             function dispatch() {
                 cwr('dispatch');

--- a/app/http_fetch_event.html
+++ b/app/http_fetch_event.html
@@ -21,8 +21,6 @@
         />
 
         <script>
-            cwr('recordPageView', 'http_fetch_event.html');
-
             // Common to all test pages
             function dispatch() {
                 cwr('dispatch');

--- a/app/http_xhr_event.html
+++ b/app/http_xhr_event.html
@@ -11,8 +11,6 @@
         />
 
         <script>
-            cwr('recordPageView', '/http_xhr_event.html');
-
             // Common to all test pages
             function dispatch() {
                 cwr('dispatch');

--- a/app/page_event.html
+++ b/app/page_event.html
@@ -10,8 +10,6 @@
         />
 
         <script>
-            cwr('recordPageView', '/page_event.html');
-
             function pushStateOneToHistory() {
                 window.history.pushState(
                     { state: 'one' },

--- a/app/remote_config.html
+++ b/app/remote_config.html
@@ -10,8 +10,6 @@
         />
 
         <script>
-            cwr('recordPageView', '/remote_config.html');
-
             // Specific to JavaScript error plugin
             function triggerTypeError() {
                 undefined.foo();

--- a/src/plugins/event-plugins/PageViewPlugin.ts
+++ b/src/plugins/event-plugins/PageViewPlugin.ts
@@ -26,6 +26,7 @@ export class PageViewPlugin extends MonkeyPatched implements Plugin {
     public load(context: PluginContext): void {
         this.context = context;
         this.addListener();
+        this.recordPageView();
     }
 
     public getPluginId(): string {

--- a/src/plugins/event-plugins/__tests__/PageViewPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/PageViewPlugin.test.ts
@@ -5,8 +5,11 @@ import { PageViewPlugin } from '../PageViewPlugin';
 const PAGE_VIEW_ONE_PATH = '/page_view_one?region=us-west-1#lang';
 const PAGE_VIEW_TWO_PATH = '/page_view_two?region=us-west-1#lang';
 
+const PAGE_VIEW_LANDING_EXPECTED_PAGE_ID = '/console/home';
 const PAGE_VIEW_ONE_EXPECTED_PAGE_ID = '/page_view_one';
 const PAGE_VIEW_TWO_EXPECTED_PAGE_ID = '/page_view_two';
+
+declare const jsdom: any;
 
 describe('PageViewPlugin tests', () => {
     let url;
@@ -16,9 +19,7 @@ describe('PageViewPlugin tests', () => {
     });
 
     beforeEach(() => {
-        // @ts-ignore
-        context.recordPageView.mockClear();
-        // @ts-ignore
+        (context.recordPageView as any).mockClear();
         jsdom.reconfigure({
             url: url
         });
@@ -42,12 +43,10 @@ describe('PageViewPlugin tests', () => {
         );
 
         // Assert
-        // @ts-ignore
-        expect(context.recordPageView.mock.calls[0][0]).toEqual(
+        expect((context.recordPageView as any).mock.calls[1][0]).toEqual(
             PAGE_VIEW_ONE_EXPECTED_PAGE_ID
         );
-        // @ts-ignore
-        expect(context.recordPageView.mock.calls[1][0]).toEqual(
+        expect((context.recordPageView as any).mock.calls[2][0]).toEqual(
             PAGE_VIEW_TWO_EXPECTED_PAGE_ID
         );
 
@@ -68,13 +67,14 @@ describe('PageViewPlugin tests', () => {
         );
 
         // Assert
-        // @ts-ignore
-        expect(context.recordPageView.mock.calls[0][0]).toEqual(
+        expect((context.recordPageView as any).mock.calls[1][0]).toEqual(
             PAGE_VIEW_ONE_EXPECTED_PAGE_ID
         );
 
-        // @ts-ignore
-        window.removeEventListener('popstate', plugin.popstateListener);
+        window.removeEventListener(
+            'popstate',
+            (plugin as any).popstateListener
+        );
     });
 
     test('when a popstate event occurs then a page view event is recorded', async () => {
@@ -87,13 +87,14 @@ describe('PageViewPlugin tests', () => {
         dispatchEvent(new PopStateEvent('popstate'));
 
         // Assert
-        // @ts-ignore
-        expect(context.recordPageView.mock.calls[0][0]).toEqual(
+        expect((context.recordPageView as any).mock.calls[1][0]).toEqual(
             PAGE_VIEW_ONE_EXPECTED_PAGE_ID
         );
 
-        // @ts-ignore
-        window.removeEventListener('popstate', plugin.popstateListener);
+        window.removeEventListener(
+            'popstate',
+            (plugin as any).popstateListener
+        );
     });
 
     test('when PATH_AND_HASH is used then a the path and hash is recorded.', async () => {
@@ -110,14 +111,15 @@ describe('PageViewPlugin tests', () => {
         );
 
         // Assert
-        // @ts-ignore
-        expect(context.recordPageView.mock.calls[0][0]).toEqual(
+        expect((context.recordPageView as any).mock.calls[1][0]).toEqual(
             '/page_view_one#lang'
         );
 
         context.config.pageIdFormat = PAGE_ID_FORMAT.PATH;
-        // @ts-ignore
-        window.removeEventListener('popstate', plugin.popstateListener);
+        window.removeEventListener(
+            'popstate',
+            (plugin as any).popstateListener
+        );
     });
 
     test('when HASH is used then a the hash is recorded.', async () => {
@@ -134,12 +136,15 @@ describe('PageViewPlugin tests', () => {
         );
 
         // Assert
-        // @ts-ignore
-        expect(context.recordPageView.mock.calls[0][0]).toEqual('#lang');
+        expect((context.recordPageView as any).mock.calls[1][0]).toEqual(
+            '#lang'
+        );
 
         context.config.pageIdFormat = PAGE_ID_FORMAT.PATH;
-        // @ts-ignore
-        window.removeEventListener('popstate', plugin.popstateListener);
+        window.removeEventListener(
+            'popstate',
+            (plugin as any).popstateListener
+        );
     });
 
     test('when there is no hash in the URL then only the path is recorded.', async () => {
@@ -157,12 +162,32 @@ describe('PageViewPlugin tests', () => {
 
         // Assert
         // @ts-ignore
-        expect(context.recordPageView.mock.calls[0][0]).toEqual(
+        expect(context.recordPageView.mock.calls[1][0]).toEqual(
             PAGE_VIEW_ONE_EXPECTED_PAGE_ID
         );
 
         context.config.pageIdFormat = PAGE_ID_FORMAT.PATH;
-        // @ts-ignore
-        window.removeEventListener('popstate', plugin.popstateListener);
+        window.removeEventListener(
+            'popstate',
+            (plugin as any).popstateListener
+        );
+    });
+
+    test('when the plugin is loaded then a page view event is recorded.', async () => {
+        // Init
+        const plugin = new PageViewPlugin();
+
+        // Run
+        plugin.load(context);
+
+        // Assert
+        expect((context.recordPageView as any).mock.calls[0][0]).toEqual(
+            PAGE_VIEW_LANDING_EXPECTED_PAGE_ID
+        );
+
+        window.removeEventListener(
+            'popstate',
+            (plugin as any).popstateListener
+        );
     });
 });


### PR DESCRIPTION
The page view plugin does not record page views on load. This is problematic because the landing page is not recorded.

This change modifies the page view plugin such that it records a page view when the page is loaded.

The functional change is in `src/plugins/event-plugins/PageViewPlugin.ts` -- all other changes update integ and unit tests.