### PR TITLE
Fix global var backwards compatibility with old snippets.

### DIFF
--- a/src/index-browser.ts
+++ b/src/index-browser.ts
@@ -5,7 +5,7 @@ declare global {
         AwsRumClient: AwsRumClientInit;
     }
 }
-if (window.AwsNexusTelemetry) {
+if (!window.AwsRumClient && window.AwsNexusTelemetry) {
     window.AwsRumClient = window.AwsNexusTelemetry;
 }
 if (typeof fetch === 'function' && typeof navigator.sendBeacon === 'function') {


### PR DESCRIPTION
Old code snippets (which asynchronously load the RUM web client) used a global variable named `AwsNexusTelemetry` to pass arguments (e.g., application ID, service endpoint, config options) from the code snippet to the RUM web client. This global variable was renamed to `AwsRumClientInit`. This breaks the RUM web client when it is loaded from old code snippets.

This change adds a check to see if the old global variable name is set, and if so, uses that value. This provides backwards compatibility until existing users have migrated.