### PR TITLE
Remove URL from meta data.

### DIFF
--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -13,8 +13,6 @@ export type Page = {
 
 export type Attributes = {
     title: string;
-    url: string;
-    pageUrl: string;
     pageId: string;
     parentPageId?: string;
     interaction?: number;
@@ -123,8 +121,6 @@ export class PageManager {
     private collectAttributes() {
         this.attributes = {
             title: document.title,
-            url: document.location.toString(),
-            pageUrl: document.location.toString(),
             pageId: this.page.pageId
         };
 

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -44,7 +44,6 @@ test('PageViewEventPlugin records landing page view event', async (t: TestContro
         })
         .expect(metaData)
         .contains({
-            url: 'http://localhost:8080/page_event.html',
             pageId: '/page_event.html',
             title: 'RUM Integ Test'
         });
@@ -84,7 +83,6 @@ test('PageViewEventPlugin records page view event', async (t: TestController) =>
         })
         .expect(metaData)
         .contains({
-            url: 'http://localhost:8080/page_event.html',
             pageId: '/page_view_two',
             title: 'RUM Integ Test'
         });


### PR DESCRIPTION
The RUM web client records the page URL in event meta data. This is problematic because the URL could contain PII (i.e., as URL parameters).

This change removes the page URL from event meta data. 