### PR TITLE
Set userIdRetentionDays default to 30.

### DIFF
--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -115,7 +115,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
             TELEMETRY_TYPES.PERFORMANCE,
             TELEMETRY_TYPES.INTERACTION
         ],
-        userIdRetentionDays: 0
+        userIdRetentionDays: 30
     };
 };
 

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -150,7 +150,7 @@ describe('Orchestration tests', () => {
             sessionEventLimit: 200,
             sessionLengthSeconds: 1800,
             sessionSampleRate: 1,
-            userIdRetentionDays: 0,
+            userIdRetentionDays: 30,
             enableRumClient: true,
             fetchFunction: fetch
         });


### PR DESCRIPTION
The default value for `userIdRetentionDays` is currently zero, which causes confusion during the onboarding process (i.e., "Why is the user ID always nil?).

This change sets the default to 30 days.