### PR TITLE
Add enableXRay config option.

### DIFF
--- a/src/loader/loader-http-fetch-event.js
+++ b/src/loader/loader-http-fetch-event.js
@@ -7,7 +7,6 @@ const config = {
     ...defaultConfig,
     ...{
         logicalServiceName: 'sample.rum.aws.amazon.com',
-        trace: true,
         recordAllRequests: true
     }
 };
@@ -17,6 +16,7 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
     dispatchInterval: 0,
     metaDataPluginsToLoad: [],
     eventPluginsToLoad: [new FetchPlugin(config)],
+    enableXRay: true,
     telemetries: [],
     clientBuilder: showRequestClientBuilder
 });

--- a/src/loader/loader-http-xhr-event.js
+++ b/src/loader/loader-http-xhr-event.js
@@ -8,7 +8,6 @@ const config = {
     ...{
         logicalServiceName: 'sample.rum.aws.amazon.com',
         urlsToInclude: [/response\.json/],
-        trace: true,
         recordAllRequests: true
     }
 };
@@ -17,6 +16,7 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
     allowCookies: true,
     dispatchInterval: 0,
     metaDataPluginsToLoad: [],
+    enableXRay: true,
     eventPluginsToLoad: [new XhrPlugin(config)],
     telemetries: [],
     clientBuilder: showRequestClientBuilder

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -57,6 +57,7 @@ export type PartialConfig = {
     disableAutoPageView?: boolean;
     dispatchInterval?: number;
     enableRumClient?: boolean;
+    enableXRay?: boolean;
     endpoint?: string;
     eventCacheSize?: number;
     eventPluginsToLoad?: Plugin[];
@@ -101,6 +102,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         disableAutoPageView: false,
         dispatchInterval: 5 * 1000,
         enableRumClient: true,
+        enableXRay: false,
         endpoint: 'https://dataplane.rum.us-west-2.amazonaws.com',
         eventCacheSize: 200,
         eventPluginsToLoad: [],
@@ -134,6 +136,7 @@ export type Config = {
     disableAutoPageView: boolean;
     dispatchInterval: number;
     enableRumClient: boolean;
+    enableXRay: boolean;
     endpoint: string;
     eventCacheSize: number;
     eventPluginsToLoad: Plugin[];
@@ -154,7 +157,7 @@ export type Config = {
     sessionEventLimit: number;
     sessionLengthSeconds: number;
     sessionSampleRate: number;
-    telemetries: string[];
+    telemetries: Telemetry[];
     userIdRetentionDays: number;
 };
 
@@ -367,10 +370,15 @@ export class Orchestration {
         this.config.telemetries.forEach((type) => {
             if (typeof type === 'string' && functor[type.toLowerCase()]) {
                 plugins = [...plugins, ...functor[type.toLowerCase()]({})];
-            } else if (Array.isArray(type) && functor[type[0].toLowerCase()]) {
+            } else if (
+                Array.isArray(type) &&
+                functor[(type[0] as string).toLowerCase()]
+            ) {
                 plugins = [
                     ...plugins,
-                    ...functor[type[0].toLowerCase()](type[1])
+                    ...functor[(type[0] as string).toLowerCase()](
+                        type[1] as object
+                    )
                 ];
             }
         });

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -1,4 +1,4 @@
-import { TELEMETRY_TYPES, Orchestration } from '../Orchestration';
+import { Config, Orchestration } from '../Orchestration';
 import { Dispatch } from '../../dispatch/Dispatch';
 import { EventCache } from '../../event-cache/EventCache';
 import { DomEventPlugin } from '../../plugins/event-plugins/DomEventPlugin';
@@ -141,6 +141,7 @@ describe('Orchestration tests', () => {
             telemetries: ['errors', 'performance', 'interaction'],
             disableAutoPageView: false,
             dispatchInterval: 5000,
+            enableXRay: false,
             endpoint: 'https://dataplane.rum.us-west-2.amazonaws.com',
             eventCacheSize: 200,
             eventPluginsToLoad: [],

--- a/src/plugins/event-plugins/FetchPlugin.ts
+++ b/src/plugins/event-plugins/FetchPlugin.ts
@@ -68,7 +68,7 @@ export class FetchPlugin extends MonkeyPatched implements Plugin {
     }
 
     private isTracingEnabled = () => {
-        return this.config.trace;
+        return this.context.config.enableXRay;
     };
 
     private isSessionRecorded = () => {

--- a/src/plugins/event-plugins/XhrPlugin.ts
+++ b/src/plugins/event-plugins/XhrPlugin.ts
@@ -129,7 +129,7 @@ export class XhrPlugin extends MonkeyPatched implements Plugin {
     }
 
     private isTracingEnabled = () => {
-        return this.config.trace;
+        return this.context.config.enableXRay;
     };
 
     private isSessionRecorded = () => {

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -2,7 +2,8 @@ import { PartialHttpPluginConfig } from '../../utils/http-utils';
 import { advanceTo } from 'jest-date-mock';
 import { XhrPlugin } from '../XhrPlugin';
 import {
-    context,
+    xRayOffContext,
+    xRayOnContext,
     record,
     recordPageView
 } from '../../../test-utils/test-utils';
@@ -33,7 +34,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -47,9 +48,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(HTTP_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             request: {
                 method: 'GET'
@@ -65,8 +64,7 @@ describe('XhrPlugin tests', () => {
         // Init
         const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
-            urlsToInclude: [/response\.json/],
-            trace: true
+            urlsToInclude: [/response\.json/]
         };
 
         mock.get(/.*/, {
@@ -74,7 +72,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOnContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -88,9 +86,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             in_progress: false,
             name: 'sample.rum.aws.amazon.com',
@@ -112,7 +108,6 @@ describe('XhrPlugin tests', () => {
         // Init
         const config: PartialHttpPluginConfig = {
             urlsToInclude: [/response\.json/],
-            trace: true,
             recordAllRequests: true
         };
 
@@ -121,7 +116,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOnContext);
         plugin.disable();
 
         // Run
@@ -139,8 +134,7 @@ describe('XhrPlugin tests', () => {
     test('when plugin is re-enabled then the plugin records a trace', async () => {
         // Init
         const config: PartialHttpPluginConfig = {
-            urlsToInclude: [/response\.json/],
-            trace: true
+            urlsToInclude: [/response\.json/]
         };
 
         mock.get(/.*/, {
@@ -148,7 +142,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOnContext);
         plugin.disable();
         plugin.enable();
 
@@ -163,7 +157,6 @@ describe('XhrPlugin tests', () => {
         plugin.disable();
 
         // Assert
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
     });
 
@@ -173,15 +166,14 @@ describe('XhrPlugin tests', () => {
             ...DEFAULT_CONFIG,
             ...{
                 logicalServiceName: 'sample.rum.aws.amazon.com',
-                urlsToInclude: [/response\.json/],
-                trace: true
+                urlsToInclude: [/response\.json/]
             }
         };
 
         mock.get(/.*/, () => Promise.reject(new Error()));
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOnContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -195,9 +187,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(2);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             in_progress: false,
             name: 'sample.rum.aws.amazon.com',
@@ -225,14 +215,13 @@ describe('XhrPlugin tests', () => {
         // Init
         const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
-            urlsToInclude: [/response\.json/],
-            trace: false
+            urlsToInclude: [/response\.json/]
         };
 
         mock.get(/.*/, () => Promise.reject(new Error('Network failure')));
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -246,9 +235,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(HTTP_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             request: {
                 method: 'GET'
@@ -264,14 +251,13 @@ describe('XhrPlugin tests', () => {
         // Init
         const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
-            urlsToInclude: [/response\.json/],
-            trace: true
+            urlsToInclude: [/response\.json/]
         };
 
         mock.get(/.*/, () => new Promise(() => {}));
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOnContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -286,9 +272,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(2);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             in_progress: false,
             name: 'sample.rum.aws.amazon.com',
@@ -310,14 +294,13 @@ describe('XhrPlugin tests', () => {
         // Init
         const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
-            urlsToInclude: [/response\.json/],
-            trace: false
+            urlsToInclude: [/response\.json/]
         };
 
         mock.get(/.*/, () => new Promise(() => {}));
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -332,9 +315,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(HTTP_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             request: {
                 method: 'GET'
@@ -349,8 +330,7 @@ describe('XhrPlugin tests', () => {
         // Init
         const config: PartialHttpPluginConfig = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
-            urlsToInclude: [/response\.json/],
-            trace: true
+            urlsToInclude: [/response\.json/]
         };
 
         mock.get(/.*/, {
@@ -358,7 +338,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOnContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -373,9 +353,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(2);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             in_progress: false,
             name: 'sample.rum.aws.amazon.com',
@@ -396,8 +374,7 @@ describe('XhrPlugin tests', () => {
     test('when XHR aborts then the plugin adds the error to the http event', async () => {
         // Init
         const config: PartialHttpPluginConfig = {
-            urlsToInclude: [/response\.json/],
-            trace: false
+            urlsToInclude: [/response\.json/]
         };
 
         mock.get(/.*/, {
@@ -405,7 +382,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -420,9 +397,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(HTTP_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             request: {
                 method: 'GET'
@@ -437,11 +412,9 @@ describe('XhrPlugin tests', () => {
         // Init
         let header: string;
         const config: PartialHttpPluginConfig = {
-            urlsToInclude: [/response\.json/],
-            trace: true
+            urlsToInclude: [/response\.json/]
         };
 
-        // @ts-ignore
         mock.get(/.*/, (req, res) => {
             header = req.header('X-Amzn-Trace-Id');
             return res
@@ -450,7 +423,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOnContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -472,8 +445,7 @@ describe('XhrPlugin tests', () => {
     test('when trace is disabled then the plugin does not record a trace', async () => {
         // Init
         const config: PartialHttpPluginConfig = {
-            urlsToInclude: [/response\.json/],
-            trace: false
+            urlsToInclude: [/response\.json/]
         };
 
         mock.get(/.*/, {
@@ -481,7 +453,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -550,7 +522,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -578,7 +550,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -607,7 +579,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -635,7 +607,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -662,7 +634,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr = new XMLHttpRequest();
@@ -689,7 +661,7 @@ describe('XhrPlugin tests', () => {
         });
 
         const plugin: XhrPlugin = new XhrPlugin(config);
-        plugin.load(context);
+        plugin.load(xRayOffContext);
 
         // Run
         const xhr_cognito = new XMLHttpRequest();

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -17,7 +17,6 @@ export type PartialHttpPluginConfig = {
     logicalServiceName?: string;
     urlsToInclude?: RegExp[];
     urlsToExclude?: RegExp[];
-    trace?: boolean;
     stackTraceLength?: number;
     recordAllRequests?: boolean;
 };
@@ -26,7 +25,6 @@ export type HttpPluginConfig = {
     logicalServiceName: string;
     urlsToInclude: RegExp[];
     urlsToExclude: RegExp[];
-    trace: boolean;
     stackTraceLength: number;
     recordAllRequests: boolean;
 };
@@ -40,7 +38,6 @@ export const defaultConfig: HttpPluginConfig = {
         // STS endpoints https://docs.aws.amazon.com/general/latest/gr/sts.html
         /sts\.([^\.]*\.)?amazonaws\.com/
     ],
-    trace: false,
     stackTraceLength: 200,
     recordAllRequests: false
 };

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -113,6 +113,24 @@ export const context: PluginContext = {
     getSession
 };
 
+export const xRayOffContext: PluginContext = {
+    applicationId: 'b',
+    applicationVersion: '1.0',
+    config: { ...DEFAULT_CONFIG, ...{ enableXRay: false } },
+    record,
+    recordPageView,
+    getSession
+};
+
+export const xRayOnContext: PluginContext = {
+    applicationId: 'b',
+    applicationVersion: '1.0',
+    config: { ...DEFAULT_CONFIG, ...{ enableXRay: true } },
+    record,
+    recordPageView,
+    getSession
+};
+
 export const stringToUtf16 = (inputString: string) => {
     const utf16array = [];
     for (let index = 0; index < inputString.length; index++) {


### PR DESCRIPTION
The RUM control plane does not support telemetry configurations (e.g., `{ telemetries: [['http', {trace: true}] }`). As a workaround, we are retaining the existing config option `enableXRay` in the control plane model, and modifying the web client to use this option instead of the plugin configuration `['http', { trace: true }]`.

This change adds the `enableXRay` and interprets it the same as `['http', { trace: true }]` was being interpreted. This change also removes the old `trace` plugin config option to avoid potential ambiguity.
