### PR TITLE
Remove source map from prod webpack bundle.

### DIFF
--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -7,7 +7,6 @@ const TerserPlugin = require('terser-webpack-plugin');
 module.exports = merge(common, {
     plugins: [new LicensePlugin()],
     mode: 'production',
-    devtool: 'nosources-source-map',
     optimization: {
         minimizer: [
             new TerserPlugin({


### PR DESCRIPTION
The prod webpack bundle currently builds a source map file `cwr.map.js` and references this file from `cwr.js`. Since the source map file is not uploaded to the CDN, it causes an error to appear the browser console when the browser cannot fetch the referenced source map.

This change removes the source map reference from the webpack bundle. Best practice is to omit the source map in production.