### PR TITLE
Add transfer size and target URL to resource event.

### DIFF
--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -66,6 +66,7 @@ export type PartialConfig = {
     pageIdFormat?: PAGE_ID_FORMAT;
     pagesToExclude?: RegExp[];
     pagesToInclude?: RegExp[];
+    recordResourceUrl?: boolean;
     sessionEventLimit?: number;
     sessionLengthSeconds?: number;
     sessionSampleRate?: number;
@@ -109,6 +110,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         pageIdFormat: PAGE_ID_FORMAT.PATH,
         pagesToExclude: [],
         pagesToInclude: [],
+        recordResourceUrl: true,
         sessionEventLimit: 200,
         sessionLengthSeconds: 60 * 30,
         sessionSampleRate: 1,
@@ -150,6 +152,7 @@ export type Config = {
     pageIdFormat: PAGE_ID_FORMAT;
     pagesToExclude: RegExp[];
     pagesToInclude: RegExp[];
+    recordResourceUrl: boolean;
     sessionEventLimit: number;
     sessionLengthSeconds: number;
     sessionSampleRate: number;

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -148,6 +148,7 @@ describe('Orchestration tests', () => {
             pageIdFormat: 'PATH',
             pagesToExclude: [],
             pagesToInclude: [],
+            recordResourceUrl: true,
             sessionEventLimit: 200,
             sessionLengthSeconds: 1800,
             sessionSampleRate: 1,


### PR DESCRIPTION
Resource transfer size and target URL are required fields for CloudWatch RUM analytics.

This change adds these fields back to the resource event, but makes the resource URL optional in case the application fetches resources whose URLs contain PII.