### PR TITLE
Fix missing X-Amzn-Trace-Id header

### DIFF
--- a/app/http_fetch_event.html
+++ b/app/http_fetch_event.html
@@ -5,6 +5,8 @@
 
         <script>
             window.fetch = function (request, init) {
+                document.getElementById('fetchRequestHeaders').innerText =
+                    init.headers['X-Amzn-Trace-Id'];
                 return Promise.resolve({
                     status: 200,
                     headers: {},
@@ -116,6 +118,12 @@
             <tr>
                 <td>Response Body</td>
                 <td id="response_body"></td>
+            </tr>
+        </table>
+        <table>
+            <tr>
+                <td>Mock Request Headers</td>
+                <td id="fetchRequestHeaders"></td>
             </tr>
         </table>
     </body>

--- a/app/ingestion.html
+++ b/app/ingestion.html
@@ -45,6 +45,212 @@
             function enable() {
                 cwr('enable');
             }
+
+            function httpStat500() {
+                fetch('https://httpstat.us/500');
+            }
+
+            function httpStat200() {
+                fetch('https://httpstat.us/200');
+            }
+
+            function playGame() {
+                run();
+            }
+
+            function randomUserName() {
+                return `user${Math.floor(Math.random() * 1000)}`;
+            }
+            function randomSessionName() {
+                return `session${Math.floor(Math.random() * 1000)}`;
+            }
+            function randomGameName() {
+                return `game${Math.floor(Math.random() * 1000)}`;
+            }
+            function randomGameRules() {
+                return 'TicTacToe';
+            }
+
+            async function run() {
+                let session;
+                let game;
+                const username = randomUserName();
+                const sessionname = randomSessionName();
+                const gamename = randomGameName();
+                const rules = randomGameRules();
+                const user = await createUser(username);
+                session = await createSession();
+                session = await updateSession(
+                    session.id,
+                    sessionname,
+                    username
+                );
+                game = await createGame(session.id);
+                game = await updateGame(
+                    game.id,
+                    game.session,
+                    gamename,
+                    rules,
+                    [user.id]
+                );
+                await setRules(game.id, game.session);
+                await startGame(game.id, game.session);
+                game = await getInitialState(game.id, game.session);
+                await play(session.id, game.id, user.id, 'X1');
+                await play(session.id, game.id, user.id, 'O2');
+                await play(session.id, game.id, user.id, 'X3');
+                await play(session.id, game.id, user.id, 'O4');
+                await play(session.id, game.id, user.id, 'X5');
+                await play(session.id, game.id, user.id, 'O6');
+                await play(session.id, game.id, user.id, 'X7');
+            }
+
+            async function createUser(username) {
+                const response = await fetch(
+                    'http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/user',
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        },
+                        body: JSON.stringify({ name: username })
+                    }
+                );
+                // Example response: {"id":"JVTUDFG6","name":"myuser"}
+                return response.json();
+            }
+
+            async function createSession() {
+                const response = await fetch(
+                    'http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/session',
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        },
+                        body: JSON.stringify({})
+                    }
+                );
+                // Example response: {"id":"2HM515LD","owner":null,"name":null,"users":null,"games":null}
+                return response.json();
+            }
+
+            async function updateSession(sessionId, sessionName, ownerId) {
+                const response = await fetch(
+                    `http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/session/${sessionId}`,
+                    {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        },
+                        body: JSON.stringify({
+                            id: sessionId,
+                            owner: ownerId,
+                            name: sessionName,
+                            users: null,
+                            games: null
+                        })
+                    }
+                );
+                // Example response: {"id":"2HM515LD","owner":"JVTUDFG6","name":"games","users":null,"games":null}
+                return response.json();
+            }
+
+            async function createGame(sessionId) {
+                const response = await fetch(
+                    `http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/game/${sessionId}`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        },
+                        body: JSON.stringify({})
+                    }
+                );
+                // Example response: {"id":"QJ57AQDR","session":"2HM515LD","name":null,"users":null,"rules":null,"startTime":null,"endTime":null,"states":null,"moves":null}
+                return response.json();
+            }
+
+            async function updateGame(
+                gameId,
+                sessionId,
+                gameName,
+                rules,
+                users
+            ) {
+                const response = await fetch(
+                    `http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/game/${sessionId}/${gameId}`,
+                    {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        },
+                        body: JSON.stringify({
+                            id: gameId,
+                            session: sessionId,
+                            name: gameName,
+                            users: users,
+                            rules: rules,
+                            startTime: Date.now()
+                        })
+                    }
+                );
+                // Example response: {"id":"2HM515LD","owner":"JVTUDFG6","name":"games","users":null,"games":null}
+                return response.json();
+            }
+
+            async function setRules(gameId, sessionId) {
+                const response = await fetch(
+                    `http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/game/${sessionId}/${gameId}/rules/TicTacToe`,
+                    {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        }
+                    }
+                );
+            }
+
+            async function startGame(gameId, sessionId) {
+                const response = await fetch(
+                    `http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/game/${sessionId}/${gameId}/starttime/${Date.now()}`,
+                    {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        }
+                    }
+                );
+            }
+
+            async function getInitialState(gameId, sessionId) {
+                const response = await fetch(
+                    `http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/game/${sessionId}/${gameId}`,
+                    {
+                        method: 'GET',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        }
+                    }
+                );
+                // Example response: {"id":"GC07VRGC","session":"6ROKMJ04","name":"game340","users":["2DTM9BEB"],"rules":"TicTacToe","startTime":1621296353039,"endTime":null,"states":["H6VPUAUU"],"moves":null}
+                return response.json();
+            }
+
+            async function play(sessionId, gameId, userId, move) {
+                const response = await fetch(
+                    `http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/move/${sessionId}/${gameId}/${userId}`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        },
+                        body: move
+                    }
+                );
+                // Example response: {"id":"HI2TEC22","game":"MHU803QE","session":"2IA03FM","user":"TECIPULQ","move":"X7"}
+                return response.json();
+            }
         </script>
 
         <style>
@@ -74,6 +280,11 @@
         <button id="recordCaughtError" onclick="recordCaughtError()">
             Record caught error
         </button>
+        <hr />
+        <button id="httpStat200" onclick="httpStat200()">httpstat 200</button>
+        <button id="httpStat500" onclick="httpStat500()">httpstat 500</button>
+        <button id="playGame" onclick="playGame()">Send fetch requests</button>
+        <hr />
         <button id="disable" onclick="disable()">Disable</button>
         <button id="enable" onclick="enable()">Enable</button>
         <hr />

--- a/src/loader/loader-ingestion.js
+++ b/src/loader/loader-ingestion.js
@@ -1,6 +1,5 @@
 import { loader } from './loader';
 import { showIntegRequestClientBuilder } from '../test-utils/integ-http-handler';
-import { JsErrorPlugin } from '../plugins/event-plugins/JsErrorPlugin';
 loader(
     'cwr',
     '[applicationId]',
@@ -14,9 +13,8 @@ loader(
         endpoint: '[endpoint]',
         guestRoleArn: '[guestRoleArn]',
         identityPoolId: '[identityPoolId]',
-        metaDataPluginsToLoad: [],
-        eventPluginsToLoad: [new JsErrorPlugin()],
         sessionSampleRate: 1,
-        telemetries: []
+        telemetries: ['performance', 'errors', 'http'],
+        enableXRay: true
     }
 );

--- a/src/plugins/event-plugins/FetchPlugin.ts
+++ b/src/plugins/event-plugins/FetchPlugin.ts
@@ -154,7 +154,7 @@ export class FetchPlugin extends MonkeyPatched implements Plugin {
         return {
             version: '1.0.0',
             request: {
-                method: init.method ? init.method : 'GET'
+                method: init?.method ? init.method : 'GET'
             }
         };
     };
@@ -193,7 +193,6 @@ export class FetchPlugin extends MonkeyPatched implements Plugin {
         input: RequestInfo,
         init?: RequestInit
     ): Promise<Response> => {
-        init = init ? init : {};
         const httpEvent: HttpEvent = this.createHttpEvent(input, init);
         let trace: XRayTraceEvent | undefined;
 
@@ -202,6 +201,10 @@ export class FetchPlugin extends MonkeyPatched implements Plugin {
         }
 
         if (this.isTracingEnabled() && this.isSessionRecorded()) {
+            if (!init) {
+                init = {};
+                [].push.call(argsArray, init);
+            }
             trace = this.beginTrace(input, init);
         }
 

--- a/src/plugins/event-plugins/__integ__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/FetchPlugin.test.ts
@@ -6,6 +6,7 @@ const sendFetchRequest: Selector = Selector(`#sendFetchRequest`);
 const sendDataPlaneRequest: Selector = Selector(`#sendDataPlaneRequest`);
 const dispatch: Selector = Selector(`#dispatch`);
 const clearRequestResponse: Selector = Selector(`#clearRequestResponse`);
+const fetchRequestHeaders: Selector = Selector(`#fetchRequestHeaders`);
 
 fixture('X-Ray Fetch Plugin').page(
     'http://localhost:8080/http_fetch_event.html'
@@ -21,6 +22,8 @@ test('when fetch is called then a trace is recorded', async (t: TestController) 
         .contains('BatchId')
         .click(clearRequestResponse)
         .click(sendFetchRequest)
+        .expect(fetchRequestHeaders.textContent)
+        .match(/Root=1-[0-9a-f]{8}-[0-9a-f]{24};Parent=[0-9a-f]{16};Sampled=1/)
         .click(dispatch)
         .expect(REQUEST_BODY.textContent)
         .contains('BatchId');

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -300,6 +300,30 @@ describe('FetchPlugin tests', () => {
             (init.headers['X-Amzn-Trace-Id'] =
                 'Root=1-0-000000000000000000000000;Parent=0000000000000000;Sampled=1')
         );
+        expect(init.headers instanceof Array).toBeFalsy();
+    });
+
+    test('RequestInit is added to the HTTP request', async () => {
+        // Init
+        const config: PartialHttpPluginConfig = {
+            logicalServiceName: 'sample.rum.aws.amazon.com',
+            urlsToInclude: [/aws\.amazon\.com/]
+        };
+
+        const plugin: FetchPlugin = new FetchPlugin(config);
+        plugin.load(xRayOnContext);
+
+        // Run
+        await fetch('https://aws.amazon.com');
+        plugin.disable();
+
+        // Assert
+        expect(mockFetch.mock.calls[0][1]).toMatchObject({
+            headers: {
+                'X-Amzn-Trace-Id':
+                    'Root=1-0-000000000000000000000000;Parent=0000000000000000;Sampled=1'
+            }
+        });
     });
 
     test('when trace is disabled then the plugin does not record a trace', async () => {

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -107,7 +107,7 @@ export const addAmznTraceIdHeader = (
     segmentId: string
 ) => {
     if (!init.headers) {
-        init.headers = [];
+        init.headers = {};
     }
     init.headers[X_AMZN_TRACE_ID] = getAmznTraceIdHeaderValue(
         traceId,


### PR DESCRIPTION
 X-Amzn-Trace-Id missing from some fetch requests

Example of requests where the X-Amzn-Trace-Id header is not added:
```
fetch("https://httpstat.us/200");
fetch("https://httpstat.us/500");
```

Example of requests where the X-Amzn-Trace-Id header is added:
```
fetch(
  'http://scorekeep-env.eba-mi3pgqai.us-west-2.elasticbeanstalk.com/api/user',
  {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json;charset=utf-8'
    },
    body: JSON.stringify({ name: username })
  }
);
```

This change fixes two issues: (1) the init object was not being added to the args array, and (2) the header object was being created as an array instead of an object.
