### PR TITLE
Update webvitals tests to skip if browser is Safari or Firefox

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,10 @@ jobs:
             - name: Run Integ Tests
               run: npm run integ:local:${{ matrix.browser }}:headless
 
-            - name: Run IE Integ Tests
+            - name: Run IE,Edge,Firefox Integ Tests
               if: matrix.os == 'windows-latest'
-              run: npm run integ:local:ie
+              run: |
+               npm run integ:local:ie
+               npm run integ:local:edge
+               npm run integ:local:firefox
+               

--- a/src/plugins/event-plugins/__integ__/WebVitalsPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/WebVitalsPlugin.test.ts
@@ -39,33 +39,33 @@ test('WebVitalEvent records lcp and cls events', async (t: TestController) => {
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     let browser = t.browser.name;
     if (browser != 'Safari' && browser != 'Firefox') {
-    await t.wait(300);
+        await t.wait(300);
 
-    await t
-        // Interact with page to trigger lcp event
-        .click(testButton)
-        .click(makePageHidden)
-        .expect(RESPONSE_STATUS.textContent)
-        .eql(STATUS_202.toString())
-        .expect(REQUEST_BODY.textContent)
-        .contains('BatchId');
+        await t
+            // Interact with page to trigger lcp event
+            .click(testButton)
+            .click(makePageHidden)
+            .expect(RESPONSE_STATUS.textContent)
+            .eql(STATUS_202.toString())
+            .expect(REQUEST_BODY.textContent)
+            .contains('BatchId');
 
-    const json = removeUnwantedEvents(
-        JSON.parse(await REQUEST_BODY.textContent)
-    );
-    const eventType1 = json.RumEvents[0].type;
-    const eventDetails1 = JSON.parse(json.RumEvents[0].details);
-    const eventType2 = json.RumEvents[1].type;
-    const eventDetails2 = JSON.parse(json.RumEvents[1].details);
+        const json = removeUnwantedEvents(
+            JSON.parse(await REQUEST_BODY.textContent)
+        );
+        const eventType1 = json.RumEvents[0].type;
+        const eventDetails1 = JSON.parse(json.RumEvents[0].details);
+        const eventType2 = json.RumEvents[1].type;
+        const eventDetails2 = JSON.parse(json.RumEvents[1].details);
 
-    await t
-        .expect(eventType1)
-        .eql(LCP_EVENT_TYPE)
-        .expect(eventDetails1.value)
-        .typeOf('number')
-        .expect(eventType2)
-        .eql(CLS_EVENT_TYPE)
-        .expect(eventDetails2.value)
-        .typeOf('number');
+        await t
+            .expect(eventType1)
+            .eql(LCP_EVENT_TYPE)
+            .expect(eventDetails1.value)
+            .typeOf('number')
+            .expect(eventType2)
+            .eql(CLS_EVENT_TYPE)
+            .expect(eventDetails2.value)
+            .typeOf('number');
     }
 });

--- a/src/plugins/event-plugins/__integ__/WebVitalsPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/WebVitalsPlugin.test.ts
@@ -37,6 +37,8 @@ const removeUnwantedEvents = (json: any) => {
 test('WebVitalEvent records lcp and cls events', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
+    let browser = t.browser.name;
+    if (browser != 'Safari' && browser != 'Firefox') {
     await t.wait(300);
 
     await t
@@ -65,4 +67,5 @@ test('WebVitalEvent records lcp and cls events', async (t: TestController) => {
         .eql(CLS_EVENT_TYPE)
         .expect(eventDetails2.value)
         .typeOf('number');
+    }
 });


### PR DESCRIPTION
Firefox and Safari currently fail several web vitals browser integration tests. This is because Firefox and Safari do not natively support web vitals.To make CI workflow run without having this error we need to skip these tests if the browser is Safari or Firefox.

1.This change will make WebVitalsPlugin.test.ts to skip if browser is safari or firefox.

2.This change will make integ tests to run in all browsers.