### PR TITLE
Fix unit test promise assertions.

### DIFF
--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -193,15 +193,14 @@ describe('CommandQueue tests', () => {
 
     test('push() recordEvent throws UnsupportedOperationException', async () => {
         const commandQueue: CommandQueue = getCommandQueue();
-        commandQueue
-            .push({
+        return expect(
+            commandQueue.push({
                 c: 'recordEvent',
                 p: { event: 'my_event' }
             })
-            .then(() => fail())
-            .catch((e) =>
-                expect(e).toMatch('UnsupportedOperationException: recordEvent')
-            );
+        ).rejects.toEqual(
+            new Error('CWR: UnsupportedOperationException: recordEvent')
+        );
     });
 
     test('enable calls Orchestration.enable', async () => {

--- a/src/dispatch/__tests__/Authentication.test.ts
+++ b/src/dispatch/__tests__/Authentication.test.ts
@@ -210,8 +210,9 @@ describe('Authentication tests', () => {
     });
 
     test('when assumeRole fails then throw error', async () => {
+        const e: Error = new Error('assumeRole error');
         assumeRole.mockImplementation(() => {
-            throw new Error('assumeRole error');
+            throw e;
         });
         // Init
         const auth = new Authentication({
@@ -223,12 +224,15 @@ describe('Authentication tests', () => {
         });
 
         // Assert
-        expect(auth.ChainAnonymousCredentialsProvider()).toThrowError;
+        return expect(auth.ChainAnonymousCredentialsProvider()).rejects.toEqual(
+            e
+        );
     });
 
     test('when mockGetId fails then throw error', async () => {
+        const e: Error = new Error('mockGetId error');
         mockGetId.mockImplementation(() => {
-            throw new Error('mockGetId error');
+            throw e;
         });
         // Init
         const auth = new Authentication({
@@ -240,12 +244,15 @@ describe('Authentication tests', () => {
         });
 
         // Assert
-        expect(auth.ChainAnonymousCredentialsProvider()).toThrowError;
+        return expect(auth.ChainAnonymousCredentialsProvider()).rejects.toEqual(
+            e
+        );
     });
 
     test('when mockGetIdToken fails then throw error', async () => {
+        const e: Error = new Error('mockGetId error');
         mockGetIdToken.mockImplementation(() => {
-            throw new Error('mockGetId error');
+            throw e;
         });
         // Init
         const auth = new Authentication({
@@ -257,7 +264,7 @@ describe('Authentication tests', () => {
         });
 
         // Assert
-        expect(auth.ChainAnonymousCredentialsProvider()).toThrowError;
+        expect(auth.ChainAnonymousCredentialsProvider()).rejects.toEqual(e);
     });
 
     // tslint:disable-next-line:max-line-length

--- a/src/dispatch/__tests__/BeaconHttpHandler.test.ts
+++ b/src/dispatch/__tests__/BeaconHttpHandler.test.ts
@@ -5,12 +5,12 @@ import { HttpResponse } from '@aws-sdk/protocol-http';
 import { advanceTo } from 'jest-date-mock';
 
 const sendBeacon = jest.fn(() => true);
-global.navigator.sendBeacon = sendBeacon;
 
 describe('BeaconHttpHandler tests', () => {
     beforeEach(() => {
         advanceTo(0);
         sendBeacon.mockClear();
+        global.navigator.sendBeacon = sendBeacon;
     });
 
     test('when sendBeacon succeeds then HttpResponse status is 200', async () => {
@@ -25,7 +25,6 @@ describe('BeaconHttpHandler tests', () => {
         });
 
         // Run
-        // @ts-ignore
         const response: HttpResponse = (
             await client.sendBeacon(Utils.PUT_RUM_EVENTS_REQUEST)
         ).response;
@@ -36,6 +35,7 @@ describe('BeaconHttpHandler tests', () => {
 
     test('when sendBeacon fails then promise is rejected', async () => {
         // Init
+        global.navigator.sendBeacon = jest.fn(() => false);
         const beaconHandler = new BeaconHttpHandler();
         const client: DataPlaneClient = new DataPlaneClient({
             fetchRequestHandler: undefined,
@@ -46,12 +46,11 @@ describe('BeaconHttpHandler tests', () => {
         });
 
         // Run
-        // @ts-ignore
         const response: Promise<{ response: HttpResponse }> = client.sendBeacon(
             Utils.PUT_RUM_EVENTS_REQUEST
         );
         // Assert
-        expect(response).rejects.toEqual(undefined);
+        return expect(response).rejects.toEqual(undefined);
     });
 
     test('sendBeacon builds correct url', async () => {
@@ -66,14 +65,12 @@ describe('BeaconHttpHandler tests', () => {
         });
 
         // Run
-        // @ts-ignore
         const response: HttpResponse = (
             await client.sendBeacon(Utils.PUT_RUM_EVENTS_REQUEST)
         ).response;
 
         // Assert
-        // @ts-ignore
-        const url: string = sendBeacon.mock.calls[0][0];
+        const url: string = (sendBeacon.mock.calls[0] as any)[0];
         expect(url).toContain(
             'https://rumservicelambda.us-west-2.amazonaws.com/appmonitors/application123?X-Amz-Algorithm=AWS4-HMAC-SHA256'
         );

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -59,7 +59,7 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when getCredentialsForIdentity error, then an error is thrown', async () => {
-        // @ts-ignore
+        const e: Error = new Error('There are no credentials');
         fetchHandler.mockImplementation(() => {
             throw new Error('There are no credentials');
         });
@@ -71,9 +71,9 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Assert
-        expect(client.getCredentialsForIdentity('my-fake-identity-id'))
-            .toThrowError;
-        expect(fetchHandler).toHaveBeenCalledTimes(1);
+        return expect(
+            client.getCredentialsForIdentity('my-fake-identity-id')
+        ).rejects.toEqual(e);
     });
 
     test('when getOpenIdToken is called, then token command is returned', async () => {
@@ -103,7 +103,7 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when getOpenIdToken error, then an error is thrown', async () => {
-        // @ts-ignore
+        const e: Error = new Error('There are no credentials');
         fetchHandler.mockImplementation(() => {
             throw new Error('There are no credentials');
         });
@@ -119,8 +119,7 @@ describe('CognitoIdentityClient tests', () => {
             client.getOpenIdToken({
                 IdentityId: 'my-fake-identity-id'
             })
-        ).toThrowError;
-        expect(fetchHandler).toHaveBeenCalledTimes(1);
+        ).rejects.toEqual(e);
     });
 
     test('when getId is called, then token command is returned', async () => {
@@ -149,7 +148,7 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when getId error, then an error is thrown', async () => {
-        // @ts-ignore
+        const e: Error = new Error('There are no credentials');
         fetchHandler.mockImplementation(() => {
             throw new Error('There are no credentials');
         });
@@ -161,11 +160,10 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Assert
-        expect(
+        return expect(
             client.getId({
                 IdentityPoolId: 'my-fake-identity-pool-id'
             })
-        ).toThrowError;
-        expect(fetchHandler).toHaveBeenCalledTimes(1);
+        ).rejects.toEqual(e);
     });
 });

--- a/src/dispatch/__tests__/StsClient.test.ts
+++ b/src/dispatch/__tests__/StsClient.test.ts
@@ -60,9 +60,9 @@ describe('StsClient tests', () => {
     });
 
     test('when STS fails, error is thrown', async () => {
-        // @ts-ignore
+        const e: Error = new Error('There are no STS credentials');
         fetchHandler.mockImplementation(() => {
-            throw new Error('There are no STS credentials');
+            throw e;
         });
 
         // Init
@@ -72,13 +72,12 @@ describe('StsClient tests', () => {
         });
 
         // Assert
-        expect(
+        return expect(
             client.assumeRoleWithWebIdentity({
                 RoleArn: 'mock-role-arn',
                 RoleSessionName: 'mock-session-name',
                 WebIdentityToken: 'mock-web-identity-token'
             })
-        ).toThrowError;
-        expect(fetchHandler).toHaveBeenCalledTimes(1);
+        ).rejects.toEqual(e);
     });
 });

--- a/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
@@ -42,20 +42,17 @@ describe('JsErrorPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject(
             expect.objectContaining({
                 version: '1.0.0',
                 type: 'TypeError',
-                message: "Cannot read property 'foo' of null",
+                message: expect.stringContaining('Cannot read'),
                 stack: expect.stringContaining('at HTMLButtonElement.onclick')
             })
         );
@@ -69,15 +66,12 @@ describe('JsErrorPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject(
             expect.objectContaining({
                 version: '1.0.0',
@@ -102,16 +96,13 @@ describe('JsErrorPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
-        expect(record.mock.calls[0][1].stack).toEqual(undefined);
+        expect((record.mock.calls[0][1] as any).stack).toEqual(undefined);
     });
 
     test('when an object without a name, message and stack is thrown then type, message and stack default values', async () => {
@@ -124,15 +115,12 @@ describe('JsErrorPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             version: '1.0.0',
             type: 'error',
@@ -154,14 +142,11 @@ describe('JsErrorPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
         // Assert
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             version: '1.0.0',
             type: 'mystringerror',
@@ -181,14 +166,11 @@ describe('JsErrorPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
         // Assert
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             version: '1.0.0',
             type: '5',
@@ -208,14 +190,11 @@ describe('JsErrorPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
         // Assert
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject({
             version: '1.0.0',
             type: 'false',
@@ -240,7 +219,6 @@ describe('JsErrorPlugin tests', () => {
         // So that the error doesn't cause the test to fail.
         window.addEventListener('error', () => {});
 
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
@@ -258,7 +236,6 @@ describe('JsErrorPlugin tests', () => {
         plugin.load(context);
         plugin.disable();
         plugin.enable();
-        // @ts-ignore
         document.getElementById('createJSError').click();
         plugin.disable();
 
@@ -277,9 +254,7 @@ describe('JsErrorPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject(
             expect.objectContaining({
                 version: '1.0.0',
@@ -300,9 +275,7 @@ describe('JsErrorPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject(
             expect.objectContaining({
                 version: '1.0.0',
@@ -331,9 +304,7 @@ describe('JsErrorPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject(
             expect.objectContaining({
                 version: '1.0.0',
@@ -357,9 +328,7 @@ describe('JsErrorPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject(
             expect.objectContaining({
                 version: '1.0.0',
@@ -386,9 +355,7 @@ describe('JsErrorPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        // @ts-ignore
         expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
-        // @ts-ignore
         expect(record.mock.calls[0][1]).toMatchObject(
             expect.objectContaining({
                 version: '1.0.0',


### PR DESCRIPTION
### Description

Resolve https://github.com/aws-observability/aws-rum-web/issues/58

This change fixes handling of rejected promises in Jest tests.  Now (1) these tests no longer fail, and (2) when they do fail, the test that failed is visible (instead of the process crashing).

### Notes

- Remove `// ts-ignore` in modified files
- Fix test broken by new Node.js error TypeError message format