### PR TITLE
Use location.hostname as subsegment name when path is relative

### DIFF
--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -650,4 +650,26 @@ describe('FetchPlugin tests', () => {
         // Assert
         expect(mockFetch).toHaveBeenCalledTimes(2);
     });
+
+    test('when a url is relative then the subsegment name is location.hostname', async () => {
+        // Init
+        const config: PartialHttpPluginConfig = {};
+        const plugin: FetchPlugin = new FetchPlugin(config);
+        plugin.load(xRayOnContext);
+
+        // Run
+        await fetch('/resource');
+        plugin.disable();
+
+        // Assert
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject({
+            subsegments: [
+                {
+                    name: 'us-east-1.console.aws.amazon.com'
+                }
+            ]
+        });
+    });
 });

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -123,13 +123,15 @@ export const createXRaySubsegment = (
 };
 
 export const requestInfoToHostname = (request: Request | URL | string) => {
+    let hostname = '';
     if ((request as URL).hostname) {
-        return (request as URL).hostname;
+        hostname = (request as URL).hostname;
     } else if ((request as Request).url) {
-        return getHost((request as Request).url);
+        hostname = getHost((request as Request).url);
     } else {
-        return getHost(request.toString());
+        hostname = getHost(request.toString());
     }
+    return hostname ? hostname : window.location.hostname;
 };
 
 export const addAmznTraceIdHeader = (


### PR DESCRIPTION
Resolve https://github.com/aws-observability/aws-rum-web/issues/50

This change modifies the behavior of Fetch and XHR X-Ray tracing such that the name of the subsegment defaults to `window.location.hostname` when a hostname cannot be parsed from the request URL.