### PR TITLE
Add update version types to deployment workflow.

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+version=$1
+bucket=$2
+
+aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js
+aws s3api put-object --bucket $bucket --key "content/$version/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+
+if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+then
+    minorUpdate=$(echo $version | sed -En "s/^([0-9]+\.)[0-9]+\.[0-9]+/\1x/p")
+    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js
+    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+    patchUpdate=$(echo $version | sed -En "s/^([0-9]+\.[0-9]+\.)[0-9]+/\1x/p")
+    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/cwr.js" --body build/assets/cwr.js
+    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+fi

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-version=$1
-bucket=$2
+version=$(npm pkg get version | sed 's/"//g')
+bucket=$1
 
 aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js
 aws s3api put-object --bucket $bucket --key "content/$version/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,10 +2,6 @@ name: AWS RUM Web Client Release
 
 on:
     workflow_dispatch:
-        inputs:
-            version:
-                description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
-                required: true
 
 jobs:
     publish_to_cdn:
@@ -50,7 +46,7 @@ jobs:
             - name: Publish to CloudWatch RUM CDN
               run: |
                   chmod u+x .github/scripts/deploy.sh
-                  .github/scripts/deploy.sh ${{ github.event.inputs.version }} ${{ secrets.BUCKET }}
+                  .github/scripts/deploy.sh ${{ secrets.BUCKET }}
 
             - name: Create GitHub Release
               id: create_release

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -49,15 +49,8 @@ jobs:
 
             - name: Publish to CloudWatch RUM CDN
               run: |
-                  minorUpdate=$(echo ${{ github.event.inputs.version }} | sed -En "s/([0-9]+\.)[0-9]+\.[0-9]+/\1x/p")
-                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js
-                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$minorUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
-                  patchUpdate=$(echo ${{ github.event.inputs.version }} | sed -En "s/([0-9]+\.[0-9]+\.)[0-9]+/\1x/p")
-                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$patchUpdate/cwr.js" --body build/assets/cwr.js
-                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$patchUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
-                  exact=$(echo ${{ github.event.inputs.version }})
-                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$exact/cwr.js" --body build/assets/cwr.js
-                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$exact/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+                  chmod u+x .github/scripts/deploy.sh
+                  .github/scripts/deploy.sh ${{ github.event.inputs.version }} ${{ secrets.BUCKET }}
 
             - name: Create GitHub Release
               id: create_release

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -49,8 +49,15 @@ jobs:
 
             - name: Publish to CloudWatch RUM CDN
               run: |
-                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key 'content/${{ github.event.inputs.version }}/cwr.js' --body build/assets/cwr.js
-                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key 'content/${{ github.event.inputs.version }}/LICENSE-THIRD-PARTY' --body LICENSE-THIRD-PARTY
+                  minorUpdate=$(echo ${{ github.event.inputs.version }} | sed -En "s/([0-9]+\.)[0-9]+\.[0-9]+/\1x/p")
+                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js
+                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$minorUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+                  patchUpdate=$(echo ${{ github.event.inputs.version }} | sed -En "s/([0-9]+\.[0-9]+\.)[0-9]+/\1x/p")
+                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$patchUpdate/cwr.js" --body build/assets/cwr.js
+                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$patchUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+                  exact=$(echo ${{ github.event.inputs.version }})
+                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$exact/cwr.js" --body build/assets/cwr.js
+                  aws s3api put-object --bucket ${{ secrets.BUCKET }} --key "content/$exact/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
 
             - name: Create GitHub Release
               id: create_release


### PR DESCRIPTION
Some application owners may want to automatically consume new patch versions or minor versions.

This change modifies the deployment workflow to add two files to the CDN: one for applications to automatically consume new patch versions, and one for applications to automatically consume new minor versions.

The folder structure is modeled after [NPM semantic versioning notation](https://docs.npmjs.com/about-semantic-versioning#using-semantic-versioning-to-specify-update-types-your-package-can-accept). For example, if the current version is `1.0.3`, the following files will be published to CDN:
`/1.0.3/cwr.js`
`/1.0.x/cwr.js`
`/1.x/cwr.js`

However, if the version is tagged as a non-production release, only the exact version will be published. For example, if the current version is `1.0.3-beta.1`, the following files will be published to CDN:
`/1.0.3-beta.1/cwr.js`

This change also modifies the deployment workflow to read the version from `package.json` instead of as a workflow input. The workflow input was problematic because (1) it is susceptible to human error and (2) there is no way to verify its correctness during review.

### Testing
- I ran [successful releases](https://github.com/qhanam/aws-rum-web/actions/runs/1548164663) from my fork to the gamma stack ([1.0.2](https://client.rum-gamma.us-west-2.amazonaws.com/1.0.2/cwr.js), [1.0.x](https://client.rum-gamma.us-west-2.amazonaws.com/1.0.x/cwr.js), [1.x](https://client.rum-gamma.us-west-2.amazonaws.com/1.x/cwr.js), [1.0.3-test.1](https://client.rum-gamma.us-west-2.amazonaws.com/1.0.3-test.1/cwr.js))