### PR TITLE
Add troubleshooting guide to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ which will install the web client in your application.
 2. [Executing Commands](docs/cdn_commands.md)
 3. [Using the Web Client with Angular](docs/cdn_angular.md)
 4. [Using the Web Client with React](docs/cdn_react.md)
+5. [Using the Web Client with React](docs/cdn_react.md)
+6. [Troubleshooting CDN Installations](docs/cdn_troubleshooting.md)
 
 ## Getting Help
 

--- a/docs/cdn_angular.md
+++ b/docs/cdn_angular.md
@@ -54,7 +54,7 @@ export class MyComponent implements OnInit {
 
 ## Instrument Error Handling to Record Errors
 
-Angular intercepts uncaught JavaScript errors that origininate within the
+Angular intercepts uncaught JavaScript errors that originate within the
 Angular application. Because Angular intercepts these errors, they will not be
 recorded by the web client. This can be fixed by creating an error handler that
 records uncaught errors using the web client's `recordError` command:

--- a/docs/cdn_installation.md
+++ b/docs/cdn_installation.md
@@ -16,7 +16,7 @@ the following:
 
 ## Arguments
 
-The code snippet accepts six arguments. The snippet below shows these arguments with the body of the snippet's function ommitted for readability:
+The code snippet accepts six arguments. The snippet below shows these arguments with the body of the snippet's function omitted for readability:
 ```html
 <script>
     (function(n,i,v,r,s,c,u,x,z){...})(
@@ -41,9 +41,9 @@ The code snippet accepts six arguments. The snippet below shows these arguments 
 
 ## Configuration
 
-The application-specific web client configuration is a JavaScript object whose fields are all optional. While these feilds are optional, depending on your application the web client may not function properly if certain fields are omitted. For example, `identityPoolId` and `guestRoleArn` are both required unless your application performs its own AWS authentication and passes the credentials to the web client using the command `cwr('setAwsCredentials', {...});`.
+The application-specific web client configuration is a JavaScript object whose fields are all optional. While these fields are optional, depending on your application the web client may not function properly if certain fields are omitted. For example, `identityPoolId` and `guestRoleArn` are both required unless your application performs its own AWS authentication and passes the credentials to the web client using the command `cwr('setAwsCredentials', {...});`.
 
-The snippet below shows several configuration opions with the body of the snippet's function ommitted for readability:
+The snippet below shows several configuration options with the body of the snippet's function omitted for readability:
 ```html
 <script>
     (function(n,i,v,r,s,c,u,x,z){...})(
@@ -77,7 +77,7 @@ The snippet below shows several configuration opions with the body of the snippe
 | pageIdFormat | String | `'PATH'` | The portion of the `window.location` that will be used as the page ID. Options include `PATH`, `HASH` and `PATH_AND_HASH`.<br/><br/>For example, consider the URL `https://amazonaws.com/home?param=true#content`<br/><br/>`PATH`: `/home`<br/>`HASH`: `#content`<br/>`PATH_AND_HASH`: `/home#content` |
 | pagesToInclude | RegExp[] | `[]` | A list of regular expressions which specify the `window.location` values for which the web client will record data. Pages are matched using the `RegExp.test()` function.<br/><br/>For example, when `pagesToInclude: [ /\/home/ ]`, then data from `https://amazonaws.com/home` will be included,  and `https://amazonaws.com/` will not be included. |
 | pagesToExclude | RegExp[] | `[]` | A list of regular expressions which specify the `window.location` values for which the web client will record data. Pages are matched using the `RegExp.test()` function.<br/><br/>For example, when `pagesToExclude: [ /\/home/ ]`, then data from `https://amazonaws.com/home` will be excluded,  and `https://amazonaws.com/` will not be excluded. |
-| recordResourceUrl | Boolean | `true` | When this field is `false`, the web client will not record the URLs of resources downloaded by your appliation.<br/><br/> Some types of resources (e.g., profile images) may be referenced by URLs which contain PII. If this applies to your application, you must set this field to `false` to comply with CloudWatch RUM's shared responsibility model. |
+| recordResourceUrl | Boolean | `true` | When this field is `false`, the web client will not record the URLs of resources downloaded by your application.<br/><br/> Some types of resources (e.g., profile images) may be referenced by URLs which contain PII. If this applies to your application, you must set this field to `false` to comply with CloudWatch RUM's shared responsibility model. |
 | sessionEventLimit | Number | `200` | The maximum number of events to record during a single session. |
 | sessionSampleRate | Number | `1` | The proportion of sessions that will be recorded by the web client, specified as a unit interval (a number greater than or equal to 0 and less than or equal to 1). When this field is `0`, no sessions will be recorded. When this field is `1`, all sessions will be recorded. |
 | telemetries | [Telemetry Config Array](#telemetry-config-array) | `[]` | See [Telemetry Config Array](#telemetry-config-array) |

--- a/docs/cdn_react.md
+++ b/docs/cdn_react.md
@@ -57,10 +57,10 @@ export default Container;
 
 ## Instrument Error Handling to Record Errors
 
-React intercepts uncaught JavaScript errors that origininate within the React
+React intercepts uncaught JavaScript errors that originate within the React
 application. Because React intercepts these errors, they will not be recorded by
 the web client. This can be fixed by adding [error
-boundries](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html)
+boundaries](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html)
 that record uncaught errors using the web client's `recordError` command:
 
 ```typescript

--- a/docs/cdn_troubleshooting.md
+++ b/docs/cdn_troubleshooting.md
@@ -1,0 +1,158 @@
+# Troubleshooting CDN Installations
+
+## Events are not being sent by the web client to CloudWatch RUM
+
+### Session sample rate is less than one
+
+If `sessionSampleRate` is less than `1`, events may or may not be emitted for a
+given session. Try setting `sessionSampleRate: 1` in the web client
+configuration.
+
+### No AWS Credentials
+
+The web client requires AWS credentials to sign RUM payloads. When the RUM web
+client does not have AWS credentials, it will not attempt to send events to
+CloudWatch RUM. Your application must either (1) provide the web client with an
+anonymous Cognito identity using `identityPoolId` and `guestRoleArn`, or (2)
+provide the web client with AWS credentials using the `cwr('setAwsCredentials',
+credentials);` command.
+
+---
+## CloudWatch RUM returns 403
+
+CloudWatch RUM's `PutRumEvents` API returns 403 when authentication or
+authorization has failed. Since the web client has made the request, we know
+that either (a) the Cognito and STS calls have succeeded, (b) the `cwr_c`
+localStorage key contains AWS credentials, or (3) the application has forwarded
+credentials to the web client using the `cwr('setAwsCredentials', credentials);`
+command.
+
+### Incorrect AWS region
+
+Data must be sent to the same region as the CloudWatch RUM AppMonitor was
+created. For example, if the AppMonitor was created in `us-east-1`, but the web
+client is configured to send data to the endpoint
+`'https://dataplane.rum.us-west-2.amazonaws.com'`, authentication will fail.
+Verify that (1) the region argument is correct and (2) the `endpoint`
+configuration option, if set, is correct.
+
+### Credentials stored in localStorage are for a different AppMonitor
+
+When anonymous authorization is used, the web client stores credentials in
+localStorage. If multiple AppMonitors are used within the same domain,
+authorization will fail when navigating between pages with different
+AppMonitors.
+
+### IAM role is not authorized to call PutRumEvents on AppMonitor
+
+If a new AppMonitor is created and re-uses an existing Cognito Identity Pool and
+IAM Role, the IAM Role will not automatically have permissions to call
+PutRumEvents on the new AppMonitor. 
+
+Verify the IAM role has the following permission:
+ 
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "rum:PutRumEvents",
+            "Resource": "arn:aws:rum:[region]:[account]:appmonitor/[AppMonitor name]"
+        }
+    ]
+}
+```
+
+Verify the IAM role has the following trust relationship:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "cognito-identity.amazonaws.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "cognito-identity.amazonaws.com:aud": "[cognito identity pool id]"
+        },
+        "ForAnyValue:StringLike": {
+          "cognito-identity.amazonaws.com:amr": "unauthenticated"
+        }
+      }
+    }
+  ]
+}
+```
+---
+
+## Content security policy blocks the web client
+
+If your web application uses a content security policy, it likely needs to be
+amended to support the RUM web client. By default, a content security policy
+blocks unsafe inline scripts such as the code snippet used to install the RUM
+web client. You can use a hash or an nonce to allow the snippet. See [MDN Web
+Docs: CSP:
+script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#sources)
+for more information.
+
+The hash method is the recommended method for adding the RUM web client
+installation snippet to the `script-src` directive. A complete CSP for the rum
+web client will contain the following directives and values:
+
+| Directive | Value |
+| --- | --- |
+| script-src | `'sha256-[snippet hash]'`<br/>`https://client.rum.us-east-1.amazonaws.com` |
+| connect-src | `https://dataplane.rum.[region].amazonaws.com`<br/>`https://cognito-identity.[region].amazonaws.com`<br/>`https://sts.[region].amazonaws.com` |
+
+A hash of the snippet can be generated from the command line using openssl:
+
+```bash
+SNIPPET='(function(n,i,v,r,s,c,u,x,z){x=window.AwsRumClient={q:[],n:n,i:i,v:v,r:r,c:c,u:u};window[n]=function(c,p){x.q.push({c:c,p:p});};z=document.createElement('script');z.async=true;z.src=s;document.head.insertBefore(z,document.getElementsByTagName('script')[0]);})('cwr','00000000-0000-0000-0000-000000000000','1.0.0','us-west-2','https://client.rum.us-east-1.amazonaws.com/1.0.2/cwr.js',{sessionSampleRate:1,guestRoleArn:'arn:aws:iam::000000000000:role/RUM-Monitor-us-west-2-000000000000-00xx-Unauth',identityPoolId:'us-west-2:00000000-0000-0000-0000-000000000000',endpoint:'https://dataplane.rum.us-west-2.amazonaws.com',telemetries:['errors','http','performance'],allowCookies:true});'
+echo $SNIPPET | openssl sha256 -binary | openssl base64
+```
+
+In this case, the output of this command is the following, however the output for your snippet will differ:
+```
+dhFqvDHwFpO34BJSlFlEdnhKI/jmMD2Yl50PvxjyLN0=
+```
+Place the hash in the `'sha256-[snippet hash]'` directive value above. In this
+case, the directive will be `script-src
+sha256-dhFqvDHwFpO34BJSlFlEdnhKI/jmMD2Yl50PvxjyLN0=`.
+
+---
+## X-Ray tracing does not connect client-side trace with server-side trace
+
+To connect client-side and server-side traces, you must set the
+`addXRayTraceIdHeader` to `true` in the `http` telemetry configuration. The web
+client will then add the `X-Amzn-Trace-Id` header in each HTTP request. The
+example below shows what this configuration looks like, with all other
+configurations removed for readability.
+
+> :warning: Enabling `addXRayTraceIdHeader` will cause a new header to be added
+to all HTTP requests. Adding headers can modify CORS behavior, including causing
+the request to fail. Adding headers after SigV4 signing will invalidate the
+request signature, causing the request to fail. Test your application with this
+header enabled before enabling this option in a production environment.
+
+```html
+<script>
+    (function(n,i,v,r,s,c,u,x,z){...})(
+        'cwr',
+        '00000000-0000-0000-0000-000000000000',
+        '1.0.0',
+        'us-west-2',
+        'https://client.rum.us-east-1.amazonaws.com/1.0.2/cwr.js',
+        {
+            enableXRay: true,
+            telemetries: [ 
+                [ 'http', { addXRayTraceIdHeader: true } ]
+            ]
+        }
+    );
+</script>
+```


### PR DESCRIPTION
We have observed several common issues experienced by application owners setting up the RUM web client.

This change adds a troubleshooting guide, which includes these common issues.

This change also fixes several spelling errors in documentation.