### PR TITLE
Prepare 1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog for AWS RUM Web Client
 
-<!--LATEST=1.0.3-->
+<!--LATEST=1.0.4-->
 <!--ENTRYINSERT-->
+
+## 1.0.4
+
+-   fix: Added npm prepublish script
 
 ## 1.0.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-rum-web",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",
     "author": "Amazon CloudWatch RUM Staff <nobody@amazon.com>",


### PR DESCRIPTION
Bump version to 1.0.4 and update changelog.

`1.0.3` has been [deprecated in NPM](https://www.npmjs.com/package/aws-rum-web?activeTab=versions) because the published version is inconsistent with GitHub.

`1.0.4` will replace `1.0.3` so that the GitHub, CDN and NPM versions will be consistent.