### PR TITLE
fix: add Cache-Control max-age to CDN files

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -3,15 +3,15 @@
 version=$(npm pkg get version | sed 's/"//g')
 bucket=$1
 
-aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js
-aws s3api put-object --bucket $bucket --key "content/$version/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js --cache-control max-age=604800
+aws s3api put-object --bucket $bucket --key "content/$version/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=604800
 
 if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 then
     minorUpdate=$(echo $version | sed -En "s/^([0-9]+\.)[0-9]+\.[0-9]+/\1x/p")
-    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js
-    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200
+    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=7200
     patchUpdate=$(echo $version | sed -En "s/^([0-9]+\.[0-9]+\.)[0-9]+/\1x/p")
-    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/cwr.js" --body build/assets/cwr.js
-    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY
+    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200
+    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=7200
 fi


### PR DESCRIPTION
Partially resolves #73 .

This change adds a Cache-Control header to new web client versions deployed to CDN. Specific versions (e.g., `1.0.4`) have a max age of **one week**. Auto-update versions (e.g., `1.0.x` and `1.x`) have a max age of **two hours**, so that impact is limited in case a change needs be be rolled back.

Note that browsers typically cache files by default (using a heuristic to estimate TTL), so this change is non-critical. 

We still need to add Cache-Control headers to the existing CDN files to fully resolve #73. This will be done by directly modifying the header info of the existing files.

### Testing

I ran the deployment workflow in the gamma environment and verified the header `cache-control: max-age=604800` is present in `1.0.4/cwr.js`, and `cache-control: max-age=7200` is present in `1.0.x/cwr.js` and `1.x/cwr.js`. The Lighthouse recommendation no longer appeared for `1.0.4/cwr.js`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
