### PR TITLE
fix: documentation typos

### DIFF
--- a/docs/cdn_angular.md
+++ b/docs/cdn_angular.md
@@ -54,7 +54,7 @@ export class MyComponent implements OnInit {
 
 ## Instrument Error Handling to Record Errors
 
-Angular intercepts uncaught JavaScript errors that origininate within the
+Angular intercepts uncaught JavaScript errors that originate within the
 Angular application. Because Angular intercepts these errors, they will not be
 recorded by the web client. This can be fixed by creating an error handler that
 records uncaught errors using the web client's `recordError` command:

--- a/docs/cdn_installation.md
+++ b/docs/cdn_installation.md
@@ -16,7 +16,7 @@ the following:
 
 ## Arguments
 
-The code snippet accepts six arguments. The snippet below shows these arguments with the body of the snippet's function ommitted for readability:
+The code snippet accepts six arguments. The snippet below shows these arguments with the body of the snippet's function omitted for readability:
 ```html
 <script>
     (function(n,i,v,r,s,c,u,x,z){...})(
@@ -41,9 +41,9 @@ The code snippet accepts six arguments. The snippet below shows these arguments 
 
 ## Configuration
 
-The application-specific web client configuration is a JavaScript object whose fields are all optional. While these feilds are optional, depending on your application the web client may not function properly if certain fields are omitted. For example, `identityPoolId` and `guestRoleArn` are both required unless your application performs its own AWS authentication and passes the credentials to the web client using the command `cwr('setAwsCredentials', {...});`.
+The application-specific web client configuration is a JavaScript object whose fields are all optional. While these fields are optional, depending on your application the web client may not function properly if certain fields are omitted. For example, `identityPoolId` and `guestRoleArn` are both required unless your application performs its own AWS authentication and passes the credentials to the web client using the command `cwr('setAwsCredentials', {...});`.
 
-The snippet below shows several configuration opions with the body of the snippet's function ommitted for readability:
+The snippet below shows several configuration options with the body of the snippet's function omitted for readability:
 ```html
 <script>
     (function(n,i,v,r,s,c,u,x,z){...})(

--- a/docs/cdn_react.md
+++ b/docs/cdn_react.md
@@ -57,10 +57,10 @@ export default Container;
 
 ## Instrument Error Handling to Record Errors
 
-React intercepts uncaught JavaScript errors that origininate within the React
+React intercepts uncaught JavaScript errors that originate within the React
 application. Because React intercepts these errors, they will not be recorded by
 the web client. This can be fixed by adding [error
-boundries](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html)
+boundaries](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html)
 that record uncaught errors using the web client's `recordError` command:
 
 ```typescript


### PR DESCRIPTION
Noticed a few typos in the documentation as I was reading them. Just fixing those.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
