### PR TITLE
fix: capture PerformanceNavigationTiming events even when window.load fires before plugin loads

### DIFF
--- a/app/delayed_page.html
+++ b/app/delayed_page.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>RUM Integ Test</title>
+        <link
+            rel="icon"
+            type="image/png"
+            href="https://awsmedia.s3.amazonaws.com/favicon.ico"
+        />
+        <script>
+            function createJSError() {
+                // TypeError: null has no properties
+                null.foo;
+            }
+
+            function onSubmitCommand() {
+                const command = document.getElementById('command').value;
+                if (document.getElementById('payload').value) {
+                    const payload = JSON.parse(
+                        document.getElementById('payload').value
+                    );
+                    cwr(command, payload);
+                } else {
+                    cwr(command);
+                }
+            }
+        </script>
+
+        <style>
+            table {
+                border-collapse: collapse;
+                margin-top: 10px;
+                margin-bottom: 10px;
+            }
+
+            td,
+            th {
+                border: 1px solid black;
+                text-align: left;
+                padding: 8px;
+            }
+        </style>
+    </head>
+
+    <body>
+        <p id="welcome">This application is used for RUM integ testing.</p>
+        <form>
+            <label for="command">Command : </label>
+            <input type="text" id="command" /><br /><br />
+            <label for="payload">Payload : </label>
+            <textarea id="payload"></textarea><br /><br />
+            <input
+                type="button"
+                id="submit"
+                value="Submit"
+                onclick="onSubmitCommand()"
+            />
+        </form>
+        <br />
+        <button id="button1">Test ClickEvent1</button>
+        <button id="button2">Test ClickEvent2</button>
+        <button id="createJSError" onclick="createJSError()">
+            Create JS Error
+        </button>
+        <script>
+            function createJSError() {
+                // TypeError: null has no properties
+                null.foo;
+            }
+        </script>
+        <script>
+            function createHTTPError() {
+                var xhr = new XMLHttpRequest();
+                xhr.open(
+                    'POST',
+                    'https://www.google-analytics.com/collect',
+                    true
+                );
+                xhr.setRequestHeader('Content-type', 'application/json');
+                xhr.send();
+            }
+        </script>
+        <script>
+            function disallowCookies() {
+                cwr('allowCookies', false);
+            }
+        </script>
+        <button id="createHTTPError" onclick="createHTTPError()">
+            Create HTTP Error
+        </button>
+        <button id="randomSessionClick">Random Session click</button>
+        <button id="disallowCookies" onclick="disallowCookies()">
+            Disallow Cookies
+        </button>
+        <span id="request"></span>
+        <span id="response"></span>
+        <table>
+            <tr>
+                <td>Request URL</td>
+                <td id="request_url"></td>
+            </tr>
+            <tr>
+                <td>Request Header</td>
+                <td id="request_header"></td>
+            </tr>
+            <tr>
+                <td>Request Body</td>
+                <td id="request_body"></td>
+            </tr>
+        </table>
+        <table>
+            <tr>
+                <td>Response Status Code</td>
+                <td id="response_status"></td>
+            </tr>
+            <tr>
+                <td>Response Header</td>
+                <td id="response_header"></td>
+            </tr>
+            <tr>
+                <td>Response Body</td>
+                <td id="response_body"></td>
+            </tr>
+        </table>
+        <script>
+            window.onload = function () {
+                var scriptElement = document.createElement('script');
+                scriptElement.type = 'text/javascript';
+                scriptElement.src = './loader_standard.js';
+                document.head.appendChild(scriptElement);
+            };
+        </script>
+    </body>
+</html>

--- a/src/plugins/event-plugins/__integ__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/NavigationPlugin.test.ts
@@ -1,0 +1,150 @@
+import {
+    STATUS_202,
+    DISPATCH_COMMAND,
+    COMMAND,
+    PAYLOAD,
+    SUBMIT,
+    REQUEST_BODY,
+    RESPONSE_STATUS,
+    ID,
+    TIMESTAMP
+} from '../../../test-utils/integ-test-utils';
+import { PERFORMANCE_NAVIGATION_EVENT_TYPE } from '../../utils/constant';
+
+const INITIATOR_TYPE = 'initiatorType';
+const NAVIGATION_TYPE = 'navigationType';
+const START_TIME = 'startTime';
+const UNLOAD_EVENT_START = 'unloadEventStart';
+const PROMPT_FOR_UNLOAD = 'promptForUnload';
+const REDIRECT_COUNT = 'redirectCount';
+const REDIRECT_START = 'redirectStart';
+const REDIRECT_TIME = 'redirectTime';
+const WORKER_START = 'workerStart';
+const WORKER_TIME = 'workerTime';
+const FETCH_START = 'fetchStart';
+const DOMAIN_LOOKUP_START = 'domainLookupStart';
+const DNS = 'dns';
+const NEXT_HOP_PROTOCOL = 'nextHopProtocol';
+const CONNECT_START = 'connectStart';
+const CONNECT = 'connect';
+const SECURE_CONNECTION_START = 'secureConnectionStart';
+const TLS_TIME = 'tlsTime';
+const REQUEST_START = 'requestStart';
+const TIME_TO_FIRST_BYTE = 'timeToFirstByte';
+const RESPONSE_START = 'responseStart';
+const RESPONSE_TIME = 'responseTime';
+const DOM_INTERACTIVE = 'domInteractive';
+const DOM_CONTENT_LOADED_EVENT_START = 'domContentLoadedEventStart';
+const DOM_CONTENT_LOADED = 'domContentLoaded';
+const DOM_COMPLETE = 'domComplete';
+const DOM_PROCESSING_TIME = 'domProcessingTime';
+const LOAD_EVENT_START = 'loadEventStart';
+const LOAD_EVENT_TIME = 'loadEventTime';
+const DURATION = 'duration';
+const HEADER_SIZE = 'headerSize';
+const TRANSFER_SIZE = 'transferSize';
+const COMPRESSION_RATIO = 'compressionRatio';
+const SAFARI = 'Safari';
+
+fixture('NagivationEvent Plugin').page(
+    'http://localhost:8080/delayed_page.html'
+);
+
+test('when plugin loads after window.load then navigation timing events are recorded', async (t: TestController) => {
+    await t
+        .typeText(COMMAND, DISPATCH_COMMAND, { replace: true })
+        .click(PAYLOAD)
+        .pressKey('ctrl+a delete')
+        .click(SUBMIT);
+
+    const isBrowserSafari =
+        (await REQUEST_BODY.textContent).indexOf(SAFARI) > -1;
+
+    await t
+        .expect(REQUEST_BODY.textContent)
+        .contains(PERFORMANCE_NAVIGATION_EVENT_TYPE)
+        .expect(REQUEST_BODY.textContent)
+        .contains(ID)
+        .expect(REQUEST_BODY.textContent)
+        .contains(TIMESTAMP)
+
+        .expect(REQUEST_BODY.textContent)
+        .contains(INITIATOR_TYPE)
+        .expect(REQUEST_BODY.textContent)
+        .contains(START_TIME)
+        .expect(REQUEST_BODY.textContent)
+        .contains(UNLOAD_EVENT_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(PROMPT_FOR_UNLOAD)
+        .expect(REQUEST_BODY.textContent)
+        .contains(REDIRECT_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(REDIRECT_TIME)
+
+        .expect(REQUEST_BODY.textContent)
+        .contains(FETCH_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(DOMAIN_LOOKUP_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(DNS)
+
+        .expect(REQUEST_BODY.textContent)
+        .contains(CONNECT_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(CONNECT)
+        .expect(REQUEST_BODY.textContent)
+        .contains(SECURE_CONNECTION_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(TLS_TIME)
+        .expect(REQUEST_BODY.textContent)
+        .contains(REQUEST_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(TIME_TO_FIRST_BYTE)
+        .expect(REQUEST_BODY.textContent)
+        .contains(RESPONSE_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(RESPONSE_TIME)
+        .expect(REQUEST_BODY.textContent)
+        .contains(DOM_INTERACTIVE)
+        .expect(REQUEST_BODY.textContent)
+        .contains(DOM_CONTENT_LOADED_EVENT_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(DOM_CONTENT_LOADED)
+        .expect(REQUEST_BODY.textContent)
+        .contains(DOM_COMPLETE)
+        .expect(REQUEST_BODY.textContent)
+        .contains(DOM_PROCESSING_TIME)
+        .expect(REQUEST_BODY.textContent)
+        .contains(LOAD_EVENT_START)
+        .expect(REQUEST_BODY.textContent)
+        .contains(LOAD_EVENT_TIME)
+        .expect(REQUEST_BODY.textContent)
+        .contains(DURATION)
+
+        .expect(RESPONSE_STATUS.textContent)
+        .eql(STATUS_202.toString());
+
+    /**
+     * Deprecated Timing Level1 used for Safari browser do not contain following attributes
+     * https://nicj.net/navigationtiming-in-practice/
+     */
+    if (!isBrowserSafari) {
+        await t
+            .expect(REQUEST_BODY.textContent)
+            .contains(REDIRECT_COUNT)
+            .expect(REQUEST_BODY.textContent)
+            .contains(NAVIGATION_TYPE)
+            .expect(REQUEST_BODY.textContent)
+            .contains(WORKER_START)
+            .expect(REQUEST_BODY.textContent)
+            .contains(WORKER_TIME)
+            .expect(REQUEST_BODY.textContent)
+            .contains(NEXT_HOP_PROTOCOL)
+            .expect(REQUEST_BODY.textContent)
+            .contains(HEADER_SIZE)
+            .expect(REQUEST_BODY.textContent)
+            .contains(TRANSFER_SIZE)
+            .expect(REQUEST_BODY.textContent)
+            .contains(COMPRESSION_RATIO);
+    }
+});

--- a/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
@@ -1,6 +1,7 @@
 import {
     navigationEvent,
     performanceEvent,
+    performanceEventNotLoaded,
     mockPerformanceObserver,
     mockPerformanceObject,
     MockPerformanceTiming
@@ -92,13 +93,41 @@ describe('NavigationPlugin tests', () => {
         // enables plugin by default
         const plugin: NavigationPlugin = buildNavigationPlugin();
 
-        // adds eventListener on load event
-        plugin.load(context);
+        // window has already loaded, so it will fire when we load.
+        // thus disabling the plugin before we load
         plugin.disable();
+        plugin.load(context);
+
         window.dispatchEvent(new Event('load'));
         plugin.disable();
 
         // Assert
         expect(record).toHaveBeenCalledTimes(0);
+    });
+
+    test('when window.load fires after plugin loads then navigation timing is recorded', async () => {
+        // Setting up new mocked window that has not loaded
+        (window as any).performance = performanceEventNotLoaded.performance();
+
+        // enables plugin by default and loads
+        const plugin: NavigationPlugin = buildNavigationPlugin();
+        plugin.load(context);
+        // assert that the plugin did not fire
+        expect(record).toHaveBeenCalledTimes(0);
+
+        // now that the page has loaded, we should fire
+        window.dispatchEvent(new Event('load'));
+        expect(record).toHaveBeenCalledTimes(1);
+    });
+
+    test('when window.load fires before plugin loads then navigation timing is recorded', async () => {
+        // enables plugin by default
+        const plugin: NavigationPlugin = buildNavigationPlugin();
+
+        // window by default has aleady loaded before the plugin
+        // so when we load the plugin now, it should still record event
+        plugin.load(context);
+        // Assert
+        expect(record).toHaveBeenCalled();
     });
 });

--- a/src/test-utils/mock-data.ts
+++ b/src/test-utils/mock-data.ts
@@ -51,6 +51,43 @@ export const navigationEvent = {
     navigationTimingLevel: 2
 };
 
+export const navigationEventNotLoaded = {
+    connectEnd: 6.495000001450535,
+    connectStart: 6.495000001450535,
+    decodedBodySize: 149690,
+    domComplete: 904.4250000006286,
+    domContentLoadedEventEnd: 405.5950000001758,
+    domContentLoadedEventStart: 380.26000000172644,
+    domInteractive: 380.2250000007916,
+    domainLookupEnd: 6.495000001450535,
+    domainLookupStart: 6.495000001450535,
+    duration: 905.125000001135,
+    encodedBodySize: 35941,
+    entryType: 'navigation',
+    fetchStart: 6.495000001450535,
+    initiatorType: 'navigation',
+    loadEventEnd: 0,
+    loadEventStart: 0,
+    name:
+        'https://stackoverflow.com/questions/53224116/nodejs-performance-hooks-crash-when-calling-performance-getentriesbytype',
+    nextHopProtocol: 'h2',
+    redirectCount: 0,
+    redirectEnd: 0,
+    redirectStart: 0,
+    requestStart: 30.170000001817243,
+    responseEnd: 356.44999999931315,
+    responseStart: 174.32499999995343,
+    secureConnectionStart: 6.495000001450535,
+    serverTiming: [],
+    startTime: 0,
+    transferSize: 36525,
+    type: 'navigate',
+    unloadEventEnd: 0,
+    unloadEventStart: 0,
+    workerStart: 0,
+    navigationTimingLevel: 2
+};
+
 export const resourceEvent = {
     connectEnd: 0,
     connectStart: 0,
@@ -271,6 +308,40 @@ export const performanceEvent = {
             getEntriesByType: (entryType: string) => {
                 if (entryType === 'navigation') {
                     return [navigationEvent];
+                }
+
+                if (entryType === 'resource') {
+                    return [resourceEvent2];
+                }
+
+                if (entryType === 'paint') {
+                    return [firstPaintEvent, firstContentfulPaintEvent];
+                }
+                return [];
+            },
+            now: () => {
+                return Date.now();
+            },
+            timing: MockPerformanceTiming
+        };
+        Object.defineProperty(window, 'performance', {
+            configurable: true,
+            enumerable: true,
+            value: performance,
+            writable: true
+        });
+        return window.performance;
+    },
+    PerformanceObserver: MockPerformanceObserver
+};
+
+export const performanceEventNotLoaded = {
+    performance: () => {
+        delete (window as any).performance;
+        const performance = {
+            getEntriesByType: (entryType: string) => {
+                if (entryType === 'navigation') {
+                    return [navigationEventNotLoaded];
                 }
 
                 if (entryType === 'resource') {


### PR DESCRIPTION
Modified NavigationPlugin to capture PerformanceNavigationEvents when the plugin loads after the page does.
- Removed PerformanceObserver from eventListener.
- Added two new unit test cases and modified existing one case with respect to the new implementation change.
- Created a new app called delayed_page.html that loads the script after the page finishes loading.
- Created a new integ test case using the delayed_page app to verify that PerformanceNavigationEvents are captured.

To test the change, do the following:
- Create a temporary app (delayed_page.html) in your local repository without any other implementation changes
- Run server and either use Chrome debugger or open up local host, compare the output between index.html and delayed_page.html.
- index.html should have the navigation events, while the delayed_page.html does not.
- This indicates that with the original implementation, delayed_page properly simulates a web page loading prior to plugin
- Once this is verified, pull in the NavigationPlugin changes, and rerun the server/debugger to see that now PerformanceNavigationEvents are captured in the delayed_page app.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
