### PR TITLE
fix: change RUM origin from AWS::RUM::Application to AWS::RUM::AppMonitor

### DIFF
--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -89,7 +89,7 @@ export const createXRayTraceEvent = (
     const traceEvent: XRayTraceEvent = {
         version: '1.0.0',
         name,
-        origin: 'AWS::RUM::Application',
+        origin: 'AWS::RUM::AppMonitor',
         id: generateSegmentId(),
         start_time: startTime,
         trace_id: generateTraceId(),


### PR DESCRIPTION
When RUM integrate with X-Ray, RUM was using the terminology `Application`, but then change to `Appmonior`. Raise this PR to keep consistency.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
