### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 build
+CHANGELOG.md
 dist
 coverage
 src/events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
-# Changelog for AWS RUM Web Client
+# Changelog
 
-<!--LATEST=1.0.5-->
-<!--ENTRYINSERT-->
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 1.1.0 (2022-02-10)
+
+### Features
+
+* Support cookie names unique to appmonitor. ([#82](https://github.com/aws-observability/aws-rum-web/issues/82)) ([143f6f0](https://github.com/aws-observability/aws-rum-web/commit/143f6f0a011500585e81896e9b4755c189a51053))
+
+### Bug Fixes
+
+* capture PerformanceNavigationTiming events even when window.load fires before plugin loads ([#81](https://github.com/aws-observability/aws-rum-web/issues/81)) ([ece1306](https://github.com/aws-observability/aws-rum-web/commit/ece1306d82f51453d4009701eed4051d91708810))
+* change RUM origin from AWS::RUM::Application to AWS::RUM::AppMonitor ([#85](https://github.com/aws-observability/aws-rum-web/issues/85)) ([ead3b41](https://github.com/aws-observability/aws-rum-web/commit/ead3b410bc7421c83bcd963d370ade7cbfb39a4e))
+* documentation typos ([#80](https://github.com/aws-observability/aws-rum-web/issues/80)) ([5492091](https://github.com/aws-observability/aws-rum-web/commit/549209115ac27d999820d5b6ff0c25586eb98ef3))
 
 ## 1.0.5
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aws-rum-web",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-rum-web",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^1.1.0",
@@ -15,7 +15,6 @@
                 "@aws-sdk/signature-v4": "^3.36.0",
                 "@aws-sdk/util-hex-encoding": "^3.36.0",
                 "@babel/runtime": "^7.16.0",
-                "chromedriver": "^97.0.4",
                 "shimmer": "^1.2.1",
                 "ua-parser-js": "^0.7.23",
                 "uuid": "^8.3.2",
@@ -3095,6 +3094,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -3107,6 +3107,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -3115,6 +3116,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -3200,7 +3202,10 @@
         "node_modules/@testim/chrome-version": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.2.tgz",
-            "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw=="
+            "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
@@ -3441,7 +3446,7 @@
             "version": "16.10.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
             "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -3547,7 +3552,9 @@
             "version": "2.9.2",
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
             "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+            "dev": true,
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -3820,6 +3827,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -3831,6 +3839,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
             "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
             "dependencies": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
@@ -4028,6 +4037,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4129,6 +4139,9 @@
             "version": "0.24.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
             "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.14.4"
             }
@@ -4396,7 +4409,8 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -4710,6 +4724,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4719,6 +4734,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -4819,6 +4835,9 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -5142,7 +5161,10 @@
             "version": "97.0.4",
             "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-97.0.4.tgz",
             "integrity": "sha512-mAOH1QSCaeYgniNOqceAzC8BVORQtWxsmgSOBuy8TV/CyyDTllLmKtNNORsxdqrDtefVlxRVQkEzYrlKiJsfFw==",
+            "dev": true,
             "hasInstallScript": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@testim/chrome-version": "^1.1.2",
                 "axios": "^0.24.0",
@@ -5163,6 +5185,9 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
             "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "globby": "^11.0.1",
                 "graceful-fs": "^4.2.4",
@@ -5184,6 +5209,9 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
             "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5192,6 +5220,9 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5218,6 +5249,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5477,7 +5509,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "node_modules/concat-stream": {
             "version": "1.6.2",
@@ -6252,6 +6285,7 @@
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
             "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -6348,7 +6382,8 @@
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true
         },
         "node_modules/deepmerge": {
             "version": "4.2.2",
@@ -6567,6 +6602,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
             "dependencies": {
                 "path-type": "^4.0.0"
             },
@@ -6730,6 +6766,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -7147,6 +7184,9 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
             "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "debug": "^4.1.1",
                 "get-stream": "^5.1.0",
@@ -7166,6 +7206,9 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
             "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "pump": "^3.0.0"
             },
@@ -7186,6 +7229,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
             "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+            "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -7201,6 +7245,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
             "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "dev": true,
             "dependencies": {
                 "braces": "^3.0.1",
                 "picomatch": "^2.2.3"
@@ -7231,6 +7276,7 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
             "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -7260,6 +7306,9 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "pend": "~1.2.0"
             }
@@ -7292,6 +7341,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -7393,6 +7443,7 @@
             "version": "1.14.7",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
             "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -7465,7 +7516,8 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -7693,6 +7745,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -7712,6 +7765,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -7763,6 +7817,7 @@
             "version": "11.0.4",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
             "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+            "dev": true,
             "dependencies": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -7781,7 +7836,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+            "dev": true
         },
         "node_modules/graphlib": {
             "version": "2.1.8",
@@ -8092,6 +8148,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "dev": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -8151,6 +8208,7 @@
             "version": "5.1.8",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
             "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -8278,6 +8336,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8292,6 +8351,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -8300,7 +8360,8 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "node_modules/ini": {
             "version": "1.3.8",
@@ -8357,6 +8418,9 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
             "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8468,6 +8532,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8506,6 +8571,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.2.tgz",
             "integrity": "sha512-ZZTOjRcDjuAAAv2cTBQP/lL59ZTArx77+7UzHdWW/XB1mrfp7DEaVpKmZ0XIzx+M7AxfhKcqV+nMetUQmFifwg==",
+            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -8532,6 +8598,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -8675,7 +8742,10 @@
         "node_modules/is-url": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/is-utf8": {
             "version": "0.2.1",
@@ -8699,6 +8769,9 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.7.tgz",
             "integrity": "sha512-4vBQoURAXC6hnLFxD4VW7uc04XiwTTl/8ydYJxKvPwkWQrSjInkuM5VZVg6BGr1/natq69zDuvO9lGpLClJqvA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "ip-regex": "^4.1.0",
@@ -12556,6 +12629,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -12639,6 +12713,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -12981,7 +13056,8 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/multicast-dns": {
             "version": "6.2.3",
@@ -13451,6 +13527,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -13670,6 +13747,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
             "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "dev": true,
             "dependencies": {
                 "aggregate-error": "^3.0.0"
             },
@@ -13749,6 +13827,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13784,6 +13863,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13800,12 +13880,16 @@
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/picomatch": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
             "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -14108,7 +14192,10 @@
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/pseudomap": {
             "version": "1.0.2",
@@ -14126,6 +14213,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -14188,6 +14276,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -14610,6 +14699,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true,
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -14619,6 +14709,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -14633,6 +14724,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -15005,6 +15097,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -15574,6 +15667,9 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
             "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "debug": "4.3.1",
                 "is2": "^2.0.6"
@@ -15583,6 +15679,9 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -16872,6 +16971,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -18416,7 +18516,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",
@@ -18576,6 +18677,9 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
@@ -20821,6 +20925,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -20829,12 +20934,14 @@
         "@nodelib/fs.stat": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true
         },
         "@nodelib/fs.walk": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -20906,7 +21013,10 @@
         "@testim/chrome-version": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.2.tgz",
-            "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw=="
+            "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "@tootallnate/once": {
             "version": "1.1.2",
@@ -21144,7 +21254,7 @@
             "version": "16.10.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
             "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w==",
-            "devOptional": true
+            "dev": true
         },
         "@types/normalize-package-data": {
             "version": "2.4.1",
@@ -21250,7 +21360,9 @@
             "version": "2.9.2",
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
             "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+            "dev": true,
             "optional": true,
+            "peer": true,
             "requires": {
                 "@types/node": "*"
             }
@@ -21496,6 +21608,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "requires": {
                 "debug": "4"
             }
@@ -21504,6 +21617,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
             "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
             "requires": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
@@ -21654,7 +21768,8 @@
         "array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -21729,6 +21844,9 @@
             "version": "0.24.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
             "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "follow-redirects": "^1.14.4"
             }
@@ -21936,7 +22054,8 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "base64-js": {
             "version": "1.5.1",
@@ -22179,6 +22298,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -22188,6 +22308,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -22257,7 +22378,10 @@
         "buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "buffer-equal-constant-time": {
             "version": "1.0.1",
@@ -22506,6 +22630,9 @@
             "version": "97.0.4",
             "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-97.0.4.tgz",
             "integrity": "sha512-mAOH1QSCaeYgniNOqceAzC8BVORQtWxsmgSOBuy8TV/CyyDTllLmKtNNORsxdqrDtefVlxRVQkEzYrlKiJsfFw==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "@testim/chrome-version": "^1.1.2",
                 "axios": "^0.24.0",
@@ -22520,6 +22647,9 @@
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
                     "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+                    "dev": true,
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "globby": "^11.0.1",
                         "graceful-fs": "^4.2.4",
@@ -22534,12 +22664,18 @@
                 "is-path-cwd": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-                    "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
+                    "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+                    "dev": true,
+                    "optional": true,
+                    "peer": true
                 },
                 "is-path-inside": {
                     "version": "3.0.3",
                     "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-                    "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
+                    "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+                    "dev": true,
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -22564,7 +22700,8 @@
         "clean-stack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true
         },
         "cli-boxes": {
             "version": "2.2.1",
@@ -22769,7 +22906,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -23372,6 +23510,7 @@
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
             "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -23444,7 +23583,8 @@
         "deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true
         },
         "deepmerge": {
             "version": "4.2.2",
@@ -23616,6 +23756,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
             "requires": {
                 "path-type": "^4.0.0"
             }
@@ -23746,6 +23887,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -24100,6 +24242,9 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
             "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "@types/yauzl": "^2.9.1",
                 "debug": "^4.1.1",
@@ -24111,6 +24256,9 @@
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
                     "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "pump": "^3.0.0"
                     }
@@ -24127,6 +24275,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
             "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -24139,6 +24288,7 @@
                     "version": "4.0.4",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
                     "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+                    "dev": true,
                     "requires": {
                         "braces": "^3.0.1",
                         "picomatch": "^2.2.3"
@@ -24168,6 +24318,7 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
             "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
             }
@@ -24194,6 +24345,9 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "pend": "~1.2.0"
             }
@@ -24220,6 +24374,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -24303,7 +24458,8 @@
         "follow-redirects": {
             "version": "1.14.7",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+            "dev": true
         },
         "forwarded": {
             "version": "0.2.0",
@@ -24350,7 +24506,8 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fsevents": {
             "version": "2.3.2",
@@ -24517,6 +24674,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -24530,6 +24688,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"
             }
@@ -24569,6 +24728,7 @@
             "version": "11.0.4",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
             "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+            "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -24581,7 +24741,8 @@
         "graceful-fs": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+            "dev": true
         },
         "graphlib": {
             "version": "2.1.8",
@@ -24830,6 +24991,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "dev": true,
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
@@ -24865,7 +25027,8 @@
         "ignore": {
             "version": "5.1.8",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "dev": true
         },
         "immediate": {
             "version": "3.0.6",
@@ -24958,7 +25121,8 @@
         "indent-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true
         },
         "infer-owner": {
             "version": "1.0.4",
@@ -24970,6 +25134,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -24978,7 +25143,8 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "ini": {
             "version": "1.3.8",
@@ -25024,7 +25190,10 @@
         "ip-regex": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "ipaddr.js": {
             "version": "2.0.1",
@@ -25099,7 +25268,8 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
         },
         "is-finite": {
             "version": "1.1.0",
@@ -25123,6 +25293,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.2.tgz",
             "integrity": "sha512-ZZTOjRcDjuAAAv2cTBQP/lL59ZTArx77+7UzHdWW/XB1mrfp7DEaVpKmZ0XIzx+M7AxfhKcqV+nMetUQmFifwg==",
+            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -25142,7 +25313,8 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
         },
         "is-obj": {
             "version": "2.0.0",
@@ -25241,7 +25413,10 @@
         "is-url": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "is-utf8": {
             "version": "0.2.1",
@@ -25262,6 +25437,9 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.7.tgz",
             "integrity": "sha512-4vBQoURAXC6hnLFxD4VW7uc04XiwTTl/8ydYJxKvPwkWQrSjInkuM5VZVg6BGr1/natq69zDuvO9lGpLClJqvA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "deep-is": "^0.1.3",
                 "ip-regex": "^4.1.0",
@@ -28258,7 +28436,8 @@
         "merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
         },
         "methods": {
             "version": "1.1.2",
@@ -28318,6 +28497,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -28570,7 +28750,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "multicast-dns": {
             "version": "6.2.3",
@@ -28930,6 +29111,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -29088,6 +29270,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
             "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "dev": true,
             "requires": {
                 "aggregate-error": "^3.0.0"
             }
@@ -29145,7 +29328,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -29174,7 +29358,8 @@
         "path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true
         },
         "pathval": {
             "version": "1.1.1",
@@ -29185,12 +29370,16 @@
         "pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "picomatch": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "dev": true
         },
         "pify": {
             "version": "4.0.1",
@@ -29428,7 +29617,10 @@
         "proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "pseudomap": {
             "version": "1.0.2",
@@ -29446,6 +29638,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -29487,7 +29680,8 @@
         "queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true
         },
         "quick-lru": {
             "version": "4.0.1",
@@ -29819,12 +30013,14 @@
         "reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
         },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -29833,6 +30029,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
             "requires": {
                 "queue-microtask": "^1.2.2"
             }
@@ -30142,7 +30339,8 @@
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true
         },
         "sockjs": {
             "version": "0.3.21",
@@ -30601,6 +30799,9 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
             "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "debug": "4.3.1",
                 "is2": "^2.0.6"
@@ -30610,6 +30811,9 @@
                     "version": "4.3.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
                     "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "ms": "2.1.2"
                     }
@@ -31649,6 +31853,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -32777,7 +32982,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "3.0.3",
@@ -32895,6 +33101,9 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "dev": true,
+            "optional": true,
+            "peer": true,
             "requires": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-rum-web",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",
     "author": "Amazon CloudWatch RUM Staff <nobody@amazon.com>",
@@ -25,6 +25,7 @@
         "build:webpack:prod": "npm run build:schemas && webpack --config webpack/webpack.prod.js",
         "build:es": "npm run build:schemas && tsc --project ./tsconfig.es.json",
         "build:cjs": "npm run build:schemas && tsc --project ./tsconfig.cjs.json",
+        "version": "standard-version",
         "lint": "npx tslint --config ./tslint.json --project ./tsconfig.webpack.json --format verbose",
         "lint:fix": "npx tslint -c ./tslint.json -p ./tsconfig.webpack.json --format verbose --fix",
         "prettier": "npx prettier --check .",
@@ -73,6 +74,7 @@
         "node-fetch": "^2.6.1",
         "pre-commit": "^1.2.2",
         "prettier": "2.2.1",
+        "standard-version": "^9.3.2",
         "testcafe": "^1.16.1",
         "testcafe-reporter-html": "^1.4.6",
         "testcafe-reporter-json": "^1.0.0",


### PR DESCRIPTION
Release v1.1.0. Added a build target to execute the [standard-version](https://github.com/conventional-changelog/standard-version) utility. This bumps the version and updates the changelog.
```
npm run version
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
