### PR TITLE
feat: identify DOM events using CSS locator

### DIFF
--- a/app/dom_event.html
+++ b/app/dom_event.html
@@ -59,6 +59,9 @@
         <button id="button1">Button One</button>
         <a> Link One </a>
         <hr />
+        <button id="button2" label="label1">Button Two</button>
+        <button id="button3" label="label1">Button Three</button>
+        <hr />
         <button id="dispatch" onclick="dispatch()">Dispatch</button>
         <button id="clearRequestResponse" onclick="clearRequestResponse()">
             Clear

--- a/src/event-schemas/dom-event.json
+++ b/src/event-schemas/dom-event.json
@@ -16,8 +16,12 @@
         "elementId": {
             "type": "string",
             "description": "DOM element ID."
+        },
+        "cssLocator": {
+            "type": "string",
+            "description": "CSS Locator string."
         }
     },
     "additionalProperties": false,
-    "required": ["version", "event", "elementId"]
+    "required": ["version", "event", "elementId", "cssLocator"]
 }

--- a/src/event-schemas/dom-event.json
+++ b/src/event-schemas/dom-event.json
@@ -23,5 +23,5 @@
         }
     },
     "additionalProperties": false,
-    "required": ["version", "event", "elementId", "cssLocator"]
+    "required": ["version", "event", "elementId"]
 }

--- a/src/loader/loader-dom-event.js
+++ b/src/loader/loader-dom-event.js
@@ -9,7 +9,11 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
         new DomEventPlugin({
             events: [
                 { event: 'click', element: document },
-                { event: 'click', cssLocator: '[label="label1"]' }
+                {
+                    event: 'click',
+                    elementId: 'button2',
+                    cssLocator: '[label="label1"]'
+                }
             ]
         })
     ],

--- a/src/loader/loader-dom-event.js
+++ b/src/loader/loader-dom-event.js
@@ -11,8 +11,13 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
                 { event: 'click', element: document },
                 {
                     event: 'click',
-                    elementId: 'button2',
+                    elementId: 'button1',
                     cssLocator: '[label="label1"]'
+                },
+                {
+                    event: 'click',
+                    elementId: 'button1',
+                    element: document
                 }
             ]
         })

--- a/src/loader/loader-dom-event.js
+++ b/src/loader/loader-dom-event.js
@@ -6,7 +6,12 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
     dispatchInterval: 0,
     metaDataPluginsToLoad: [],
     eventPluginsToLoad: [
-        new DomEventPlugin({ events: [{ event: 'click', element: document }] })
+        new DomEventPlugin({
+            events: [
+                { event: 'click', element: document },
+                { event: 'click', cssLocator: '[label="label1"]' }
+            ]
+        })
     ],
     telemetries: [],
     clientBuilder: showRequestClientBuilder

--- a/src/plugins/event-plugins/DomEventPlugin.ts
+++ b/src/plugins/event-plugins/DomEventPlugin.ts
@@ -143,9 +143,9 @@ export class DomEventPlugin implements Plugin {
                 ?.addEventListener(eventType, eventListener);
         } else if (domEvent.cssLocator) {
             const elementList = document.querySelectorAll(domEvent.cssLocator);
-            for (let i = 0; i < elementList.length; i++) {
-                elementList[i].addEventListener(eventType, eventListener);
-            }
+            elementList.forEach((element: HTMLElement) => {
+                element.addEventListener(eventType, eventListener);
+            });
         } else if (domEvent.element) {
             domEvent.element.addEventListener(eventType, eventListener);
         }

--- a/src/plugins/event-plugins/DomEventPlugin.ts
+++ b/src/plugins/event-plugins/DomEventPlugin.ts
@@ -136,8 +136,8 @@ export class DomEventPlugin implements Plugin {
         const eventType = domEvent.event;
 
         this.eventListenerMap.set(domEvent, this.identifierToEventListenerMap);
-        let eventListenerCSS = this.getEventListener(domEvent);
-        let eventListenerID = this.getEventListener();
+        const eventListenerCSS = this.getEventListener(domEvent);
+        const eventListenerID = this.getEventListener();
         this.identifierToEventListenerMap.set('CSS', eventListenerCSS);
         this.identifierToEventListenerMap.set('ID', eventListenerID);
 
@@ -147,7 +147,7 @@ export class DomEventPlugin implements Plugin {
         if (domEvent.cssLocator) {
             const elementList = document.querySelectorAll(domEvent.cssLocator);
             elementList.forEach((element: HTMLElement) => {
-                if (document.getElementById(domEvent.elementId) == element) {
+                if (document.getElementById(domEvent.elementId) === element) {
                     isElementIdentifiedByLocator = true;
                 }
                 element.addEventListener(eventType, eventListenerCSS);
@@ -181,7 +181,7 @@ export class DomEventPlugin implements Plugin {
         if (domEvent.cssLocator) {
             const elementList = document.querySelectorAll(domEvent.cssLocator);
             elementList.forEach((element: HTMLElement) => {
-                if (document.getElementById(domEvent.elementId) == element) {
+                if (document.getElementById(domEvent.elementId) === element) {
                     isElementIdentifiedByLocator = true;
                 }
                 element.removeEventListener(domEvent.event, eventListenerCSS);

--- a/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
@@ -17,7 +17,7 @@ const button3: Selector = Selector(`#button3`);
 const dispatch: Selector = Selector(`#dispatch`);
 const clear: Selector = Selector(`#clearRequestResponse`);
 
-fixture('DomEventPlugin').page('http://localhost:9000/dom_event.html');
+fixture('DomEventPlugin').page('http://localhost:8080/dom_event.html');
 
 test('when document click events configured then button click is recorded', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.

--- a/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
@@ -17,7 +17,7 @@ const button3: Selector = Selector(`#button3`);
 const dispatch: Selector = Selector(`#dispatch`);
 const clear: Selector = Selector(`#clearRequestResponse`);
 
-fixture('DomEventPlugin').page('http://localhost:8080/dom_event.html');
+fixture('DomEventPlugin').page('http://localhost:9000/dom_event.html');
 
 test('when document click events configured then button click is recorded', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
@@ -193,6 +193,8 @@ test('when two elements identified by a CSS selector are clicked then CSS select
         let eventDetails = JSON.parse(events[i].details);
 
         await t
+            .expect(events.length)
+            .eql(2)
             .expect(eventType)
             .eql(DOM_EVENT_TYPE)
             .expect(eventDetails)
@@ -231,7 +233,7 @@ test('when element not identified by a CSS selector is clicked then CSS selector
         });
 });
 
-test('when element ID and CSS selector are specified and one element identified by ID and another by CSS selector are clicked, CSS selector is recorded for only element identified by CSS selector', async (t: TestController) => {
+test('when element ID and CSS selector are specified then only event for element identified by CSS selector is recorded', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t
@@ -244,79 +246,17 @@ test('when element ID and CSS selector are specified and one element identified 
 
     const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
         (e) =>
-            (e.type === DOM_EVENT_TYPE &&
-                JSON.parse(e.details).elementId === 'button1') ||
-            JSON.parse(e.details).cssLocator === '[label="label1"]'
-    );
-
-    const noCSSLocator = {
-        version: '1.0.0',
-        event: 'click',
-        elementId: 'button1'
-    };
-
-    const includeCSSLocator = {
-        version: '1.0.0',
-        event: 'click',
-        elementId: 'button3',
-        cssLocator: '[label="label1"]'
-    };
-
-    let expectedObject: {
-        version: string;
-        event: string;
-        elementId: string;
-        cssLocator?: string;
-    };
-
-    for (let i = 0; i < events.length; i++) {
-        if (i == 0) expectedObject = noCSSLocator;
-        else expectedObject = includeCSSLocator;
-        let eventType = events[i].type;
-        let eventDetails = JSON.parse(events[i].details);
-
-        await t
-            .expect(eventType)
-            .eql(DOM_EVENT_TYPE)
-            .expect(eventDetails)
-            .contains(expectedObject);
-    }
-});
-
-test('when element ID and CSS selector are specified and one element identified by only CSS selector and one element identified by both ID and CSS selector are clicked, CSS selector is recorded for both', async (t: TestController) => {
-    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
-    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
-    await t
-        .wait(300)
-        .click(button2)
-        .click(button3)
-        .click(dispatch)
-        .expect(REQUEST_BODY.textContent)
-        .contains('BatchId');
-
-    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
-        (e) =>
             e.type === DOM_EVENT_TYPE &&
-            JSON.parse(e.details).elementId === 'button2' &&
             JSON.parse(e.details).cssLocator === '[label="label1"]'
     );
+    const eventType = events[0].type;
+    const eventDetails = JSON.parse(events[0].details);
 
-    let button: string;
-    for (let i = 0; i < events.length; i++) {
-        if (i == 0) button = 'button2';
-        else button = 'button3';
-        let eventType = events[i].type;
-        let eventDetails = JSON.parse(events[i].details);
-
-        await t
-            .expect(eventType)
-            .eql(DOM_EVENT_TYPE)
-            .expect(eventDetails)
-            .contains({
-                version: '1.0.0',
-                event: 'click',
-                elementId: button,
-                cssLocator: '[label="label1"]'
-            });
-    }
+    await t
+        .expect(eventType)
+        .eql(DOM_EVENT_TYPE)
+        .expect(eventDetails)
+        .notContains({
+            elementId: 'button1'
+        });
 });

--- a/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
@@ -143,34 +143,6 @@ test('when client is disabled and enabled then button click is recorded', async 
     });
 });
 
-test('when element not identified by a CSS selector is clicked then node type is recorded', async (t: TestController) => {
-    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
-    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
-    await t
-        .wait(300)
-        .click(link1)
-        .click(dispatch)
-        .expect(REQUEST_BODY.textContent)
-        .contains('BatchId');
-
-    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
-        (e) =>
-            e.type === DOM_EVENT_TYPE && JSON.parse(e.details).elementId === 'A'
-    );
-
-    const eventType = events[0].type;
-    const eventDetails = JSON.parse(events[0].details);
-
-    await t
-        .expect(eventType)
-        .eql(DOM_EVENT_TYPE)
-        .expect(eventDetails)
-        .contains({
-            event: 'click',
-            cssLocator: 'A'
-        });
-});
-
 test('when element identified by a CSS selector is clicked then CSS selector is recorded', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
@@ -199,7 +171,6 @@ test('when element identified by a CSS selector is clicked then CSS selector is 
             cssLocator: '[label="label1"]'
         });
 });
-
 test('when two elements identified by a CSS selector are clicked then CSS selector is recorded', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
@@ -227,6 +198,124 @@ test('when two elements identified by a CSS selector are clicked then CSS select
             .expect(eventDetails)
             .contains({
                 event: 'click',
+                cssLocator: '[label="label1"]'
+            });
+    }
+});
+
+test('when element not identified by a CSS selector is clicked then CSS selector field is not recorded', async (t: TestController) => {
+    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
+    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
+    await t
+        .wait(300)
+        .click(button1)
+        .click(dispatch)
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) =>
+            e.type === DOM_EVENT_TYPE &&
+            JSON.parse(e.details).elementId === 'button1'
+    );
+
+    const eventType = events[0].type;
+    const eventDetails = JSON.parse(events[0].details);
+
+    await t
+        .expect(eventType)
+        .eql(DOM_EVENT_TYPE)
+        .expect(eventDetails)
+        .notContains({
+            cssLocator: '[label="label1"]'
+        });
+});
+
+test('when element ID and CSS selector are specified and one element identified by ID and another by CSS selector are clicked, CSS selector is recorded for only element identified by CSS selector', async (t: TestController) => {
+    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
+    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
+    await t
+        .wait(300)
+        .click(button1)
+        .click(button3)
+        .click(dispatch)
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) =>
+            (e.type === DOM_EVENT_TYPE &&
+                JSON.parse(e.details).elementId === 'button1') ||
+            JSON.parse(e.details).cssLocator === '[label="label1"]'
+    );
+
+    const noCSSLocator = {
+        version: '1.0.0',
+        event: 'click',
+        elementId: 'button1'
+    };
+
+    const includeCSSLocator = {
+        version: '1.0.0',
+        event: 'click',
+        elementId: 'button3',
+        cssLocator: '[label="label1"]'
+    };
+
+    let expectedObject: {
+        version: string;
+        event: string;
+        elementId: string;
+        cssLocator?: string;
+    };
+
+    for (let i = 0; i < events.length; i++) {
+        if (i == 0) expectedObject = noCSSLocator;
+        else expectedObject = includeCSSLocator;
+        let eventType = events[i].type;
+        let eventDetails = JSON.parse(events[i].details);
+
+        await t
+            .expect(eventType)
+            .eql(DOM_EVENT_TYPE)
+            .expect(eventDetails)
+            .contains(expectedObject);
+    }
+});
+
+test('when element ID and CSS selector are specified and one element identified by only CSS selector and one element identified by both ID and CSS selector are clicked, CSS selector is recorded for both', async (t: TestController) => {
+    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
+    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
+    await t
+        .wait(300)
+        .click(button2)
+        .click(button3)
+        .click(dispatch)
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) =>
+            e.type === DOM_EVENT_TYPE &&
+            JSON.parse(e.details).elementId === 'button2' &&
+            JSON.parse(e.details).cssLocator === '[label="label1"]'
+    );
+
+    let button: string;
+    for (let i = 0; i < events.length; i++) {
+        if (i == 0) button = 'button2';
+        else button = 'button3';
+        let eventType = events[i].type;
+        let eventDetails = JSON.parse(events[i].details);
+
+        await t
+            .expect(eventType)
+            .eql(DOM_EVENT_TYPE)
+            .expect(eventDetails)
+            .contains({
+                version: '1.0.0',
+                event: 'click',
+                elementId: button,
                 cssLocator: '[label="label1"]'
             });
     }

--- a/src/plugins/event-plugins/__tests__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/DomEventPlugin.test.ts
@@ -185,7 +185,7 @@ describe('DomEventPlugin tests', () => {
         expect('cssLocator' in record.mock.calls[0][1]).toEqual(false);
     });
 
-    test('when listening to document click and both element ID and CSS selector is specified, element CSS selector is used as CSS selector for only element identified by CSS selector', async () => {
+    test('when listening to document click and both element ID and CSS selector is specified, only event for element identified by CSS selector is recorded', async () => {
         // Init
         document.body.innerHTML =
             '<button id="button1"></button> <button id = "button2" label="label1"></button>';
@@ -209,78 +209,50 @@ describe('DomEventPlugin tests', () => {
         plugin.disable();
 
         // Assert
-        expect(record).toHaveBeenCalledTimes(2);
-
-        const noCSSLocator = {
-            version: '1.0.0',
-            event: 'click',
-            elementId: 'button1'
-        };
-
-        const includeCSSLocator = {
-            version: '1.0.0',
-            event: 'click',
-            elementId: 'button2',
-            cssLocator: '[label="label1"]'
-        };
-
-        let expectedObject: {
-            version: string;
-            event: string;
-            elementId: string;
-            cssLocator?: string;
-        };
-
-        for (let i = 0; i < record.mock.calls.length; i++) {
-            if (i == 0) expectedObject = noCSSLocator;
-            else expectedObject = includeCSSLocator;
-            expect(record.mock.calls[i][0]).toEqual(DOM_EVENT_TYPE);
-            expect(record.mock.calls[i][1]).toMatchObject(
-                expect.objectContaining(expectedObject)
-            );
-        }
+        expect(record).toHaveBeenCalledTimes(1);
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(DOM_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                event: 'click',
+                cssLocator: '[label="label1"]'
+            })
+        );
     });
 
-    test('when listening to document click and both element ID and CSS selector is specified and element identified by ID is also identified by CSS selector, CSS selector is used as CSS selector for all elements', async () => {
+    test('when listening to document click and both element ID and element is specified, only event for element identified by ID is recorded', async () => {
         // Init
         document.body.innerHTML =
-            '<button id="button1" label="label1"></button> <button id = "button2" label="label1"></button>';
+            '<button id="button1"></button> <button id = "button2"></button>';
         const plugin: DomEventPlugin = new DomEventPlugin({
             events: [
                 {
                     event: 'click',
                     elementId: 'button1',
-                    cssLocator: '[label="label1"]'
+                    element: document as any
                 }
             ]
         });
 
         // Run
         plugin.load(context);
-        let elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
-            '[label="label1"]'
-        ) as NodeListOf<HTMLElement>;
-        for (let i = 0; i < elementList.length; i++) {
-            elementList[i].click();
-        }
+        document.getElementById('button1').click();
+        document.getElementById('button2').click();
         plugin.disable();
 
         // Assert
-        expect(record).toHaveBeenCalledTimes(2);
-
-        let button: string;
-        for (let i = 0; i < record.mock.calls.length; i++) {
-            if (i == 0) button = 'button1';
-            else button = 'button2';
-            expect(record.mock.calls[i][0]).toEqual(DOM_EVENT_TYPE);
-            expect(record.mock.calls[i][1]).toMatchObject(
-                expect.objectContaining({
-                    version: '1.0.0',
-                    event: 'click',
-                    elementId: button,
-                    cssLocator: '[label="label1"]'
-                })
-            );
-        }
+        expect(record).toHaveBeenCalledTimes(1);
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(DOM_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                event: 'click',
+                elementId: 'button1'
+            })
+        );
     });
 });

--- a/src/plugins/event-plugins/__tests__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/DomEventPlugin.test.ts
@@ -102,4 +102,87 @@ describe('DomEventPlugin tests', () => {
             })
         );
     });
+    test('when listening to document click and event target has CSS selector, element CSS selector is used as CSS selector', async () => {
+        // Init
+        document.body.innerHTML = '<button label="label1"/>';
+        const plugin: DomEventPlugin = new DomEventPlugin({
+            events: [{ event: 'click', cssLocator: '[label="label1"]' }]
+        });
+
+        // Run
+        plugin.load(context);
+        let element: HTMLElement = document.querySelector(
+            '[label="label1"]'
+        ) as HTMLElement;
+        element.click();
+        // document.getElementsByTagName('button')[0].click();
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(DOM_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                event: 'click',
+                cssLocator: '[label="label1"]'
+            })
+        );
+    });
+
+    test('when listening to document click and two event targets have the same CSS selector, element CSS selector is used as CSS selector for both', async () => {
+        // Init
+        document.body.innerHTML =
+            '<button label="label1"/> <button label="label1"/>';
+        const plugin: DomEventPlugin = new DomEventPlugin({
+            events: [{ event: 'click', cssLocator: '[label="label1"]' }]
+        });
+
+        // Run
+        plugin.load(context);
+        let elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
+            '[label="label1"]'
+        ) as NodeListOf<HTMLElement>;
+        for (let i = 0; i < elementList.length; i++) {
+            elementList[i].click();
+        }
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(2);
+        for (let i = 0; i < record.mock.calls.length; i++) {
+            expect(record.mock.calls[i][0]).toEqual(DOM_EVENT_TYPE);
+            expect(record.mock.calls[i][1]).toMatchObject(
+                expect.objectContaining({
+                    version: '1.0.0',
+                    event: 'click',
+                    cssLocator: '[label="label1"]'
+                })
+            );
+        }
+    });
+
+    test('when listening to document click and event target has no CSS selector, element tag is used as CSS selector', async () => {
+        // Init
+        document.body.innerHTML = '<button/>';
+        const plugin: DomEventPlugin = new DomEventPlugin({
+            events: [{ event: 'click', element: document as any }]
+        });
+
+        // Run
+        plugin.load(context);
+        document.getElementsByTagName('button')[0].click();
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(DOM_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                event: 'click',
+                cssLocator: 'BUTTON'
+            })
+        );
+    });
 });


### PR DESCRIPTION
Users currently configure the DOM event plugin to listen to events either with (1) the ID of the DOM element or (2) the actual JavaScript object. However, a customer may want to add a tag to certain elements which should be recorded. There is currently no way to listen for a certain tag.

This feature allows customers to specify listeners for DOM elements using CSS locators.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.