### PR TITLE
fix: set aws api call xray subsegment namespace to aws

### DIFF
--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -114,7 +114,7 @@ export const createXRaySubsegment = (
         start_time: startTime,
         end_time: undefined,
         in_progress: false,
-        namespace: 'remote'
+        namespace: name.endsWith('amazonaws.com') ? 'aws' : 'remote'
     };
     if (http) {
         subsegment.http = http;


### PR DESCRIPTION
According from https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-aws:

> namespace – aws for AWS SDK calls; remote for other downstream calls.

By setting this, xray console service map will treat this node as a AWS service node. 