### PR TITLE
fix: Point to correct license files in bundle banner.

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -5,13 +5,16 @@ bucket=$1
 
 aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js --cache-control max-age=604800
 aws s3api put-object --bucket $bucket --key "content/$version/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=604800
+aws s3api put-object --bucket $bucket --key "content/$version/LICENSE" --body LICENSE --cache-control max-age=604800
 
 if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 then
     minorUpdate=$(echo $version | sed -En "s/^([0-9]+\.)[0-9]+\.[0-9]+/\1x/p")
     aws s3api put-object --bucket $bucket --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200
     aws s3api put-object --bucket $bucket --key "content/$minorUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=7200
+    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/LICENSE" --body LICENSE --cache-control max-age=7200
     patchUpdate=$(echo $version | sed -En "s/^([0-9]+\.[0-9]+\.)[0-9]+/\1x/p")
     aws s3api put-object --bucket $bucket --key "content/$patchUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200
     aws s3api put-object --bucket $bucket --key "content/$patchUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=7200
+    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/LICENSE" --body LICENSE --cache-control max-age=7200
 fi

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
         "webpack-cli": "^4.9.0",
         "webpack-dev-middleware": "^5.2.1",
         "webpack-dev-server": "^4.3.1",
-        "webpack-license-plugin": "^4.2.1",
         "webpack-merge": "^5.8.0",
         "xhr-mock": "^2.5.1"
     },

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -1,17 +1,19 @@
 const path = require('path');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common');
-const LicensePlugin = require('webpack-license-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = merge(common, {
-    plugins: [new LicensePlugin()],
     mode: 'production',
     optimization: {
         minimizer: [
             new TerserPlugin({
                 parallel: true,
-                extractComments: true
+                extractComments: {
+                    banner: (licenseFile) => {
+                        return `License information can be found in LICENSE and LICENSE-THIRD-PARTY`;
+                    }
+                }
             })
         ]
     },


### PR DESCRIPTION
The license banner currently points to a file which is incomplete and which we don't upload to CDN.

This change (1) adds the LICENSE file to CDN and (2) fixes the banner to point to LICENSE and LICENSE-THIRD-PARTY.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
