### PR TITLE
fix: Set x-amzn-trace-id header directly in request headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
                 "webpack-cli": "^4.9.0",
                 "webpack-dev-middleware": "^5.2.1",
                 "webpack-dev-server": "^4.3.1",
-                "webpack-license-plugin": "^4.2.1",
                 "webpack-merge": "^5.8.0",
                 "xhr-mock": "^2.5.1"
             }
@@ -7580,18 +7579,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/get-npm-tarball-url": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/get-npm-tarball-url/-/get-npm-tarball-url-2.0.2.tgz",
-            "integrity": "sha512-2dPhgT0K4pVyciTqdS0gr9nEwyCQwt9ql1/t5MCUMvcjWjAysjGJgT7Sx4n6oq3tFBjBN238mxX4RfTjT3838Q==",
-            "dev": true,
-            "dependencies": {
-                "normalize-registry-url": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -13125,32 +13112,6 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
-        "node_modules/needle": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-            "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^3.2.6",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-            },
-            "bin": {
-                "needle": "bin/needle"
-            },
-            "engines": {
-                "node": ">= 4.4.x"
-            }
-        },
-        "node_modules/needle/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
         "node_modules/negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -13392,12 +13353,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/normalize-registry-url": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-registry-url/-/normalize-registry-url-1.0.0.tgz",
-            "integrity": "sha512-0v6T4851b72ykk5zEtFoN4QX/Fqyk7pouIj9xZyAvAe9jlDhAwT4z6FlwsoQCHjeuK2EGUoAwy/F4y4B1uZq9A==",
-            "dev": true
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
@@ -14764,12 +14719,6 @@
                 "truncate-utf8-bytes": "^1.0.0"
             }
         },
-        "node_modules/sax": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-            "dev": true
-        },
         "node_modules/saxes": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -15213,15 +15162,6 @@
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-expression-validate": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-2.0.0.tgz",
-            "integrity": "sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==",
-            "dev": true,
-            "dependencies": {
-                "spdx-expression-parse": "^3.0.0"
             }
         },
         "node_modules/spdx-license-ids": {
@@ -18164,105 +18104,6 @@
                 "utf-8-validate": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/webpack-license-plugin": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-license-plugin/-/webpack-license-plugin-4.2.1.tgz",
-            "integrity": "sha512-T5Q6P1rI4RwkLpo0lryYyTBNyJ/R7aimQfC5uGpOV8q2bCb5/Q5YJUQp/7H9CPR7k7M46XzFOo9J4wwfX0ropQ==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.1.0",
-                "get-npm-tarball-url": "^2.0.1",
-                "lodash": "^4.17.20",
-                "needle": "^2.2.4",
-                "spdx-expression-validate": "^2.0.0",
-                "webpack-sources": "^3.2.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "webpack": ">=4.0.0 < 6.0.0"
-            }
-        },
-        "node_modules/webpack-license-plugin/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/webpack-license-plugin/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/webpack-license-plugin/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/webpack-license-plugin/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/webpack-license-plugin/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/webpack-license-plugin/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/webpack-license-plugin/node_modules/webpack-sources": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-            "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.13.0"
             }
         },
         "node_modules/webpack-merge": {
@@ -24551,15 +24392,6 @@
                 "has-symbols": "^1.0.1"
             }
         },
-        "get-npm-tarball-url": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/get-npm-tarball-url/-/get-npm-tarball-url-2.0.2.tgz",
-            "integrity": "sha512-2dPhgT0K4pVyciTqdS0gr9nEwyCQwt9ql1/t5MCUMvcjWjAysjGJgT7Sx4n6oq3tFBjBN238mxX4RfTjT3838Q==",
-            "dev": true,
-            "requires": {
-                "normalize-registry-url": "^1.0.0"
-            }
-        },
         "get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -28804,28 +28636,6 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
-        "needle": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-            "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-            "dev": true,
-            "requires": {
-                "debug": "^3.2.6",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                }
-            }
-        },
         "negotiator": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -29011,12 +28821,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
-        },
-        "normalize-registry-url": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-registry-url/-/normalize-registry-url-1.0.0.tgz",
-            "integrity": "sha512-0v6T4851b72ykk5zEtFoN4QX/Fqyk7pouIj9xZyAvAe9jlDhAwT4z6FlwsoQCHjeuK2EGUoAwy/F4y4B1uZq9A==",
             "dev": true
         },
         "npm-run-path": {
@@ -30055,12 +29859,6 @@
                 "truncate-utf8-bytes": "^1.0.0"
             }
         },
-        "sax": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-            "dev": true
-        },
         "saxes": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -30444,15 +30242,6 @@
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-expression-validate": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-2.0.0.tgz",
-            "integrity": "sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==",
-            "dev": true,
-            "requires": {
-                "spdx-expression-parse": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -32717,77 +32506,6 @@
                     "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
                     "dev": true,
                     "requires": {}
-                }
-            }
-        },
-        "webpack-license-plugin": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-license-plugin/-/webpack-license-plugin-4.2.1.tgz",
-            "integrity": "sha512-T5Q6P1rI4RwkLpo0lryYyTBNyJ/R7aimQfC5uGpOV8q2bCb5/Q5YJUQp/7H9CPR7k7M46XzFOo9J4wwfX0ropQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "^4.1.0",
-                "get-npm-tarball-url": "^2.0.1",
-                "lodash": "^4.17.20",
-                "needle": "^2.2.4",
-                "spdx-expression-validate": "^2.0.0",
-                "webpack-sources": "^3.2.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
-                "webpack-sources": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-                    "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
-                    "dev": true
                 }
             }
         },

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -134,7 +134,7 @@ export const requestInfoToHostname = (request: Request | URL | string) => {
     return hostname ? hostname : window.location.hostname;
 };
 
-export const addAmznTraceIdHeader = (
+export const addAmznTraceIdHeaderToInit = (
     init: RequestInit,
     traceId: string,
     segmentId: string
@@ -146,6 +146,14 @@ export const addAmznTraceIdHeader = (
         traceId,
         segmentId
     );
+};
+
+export const addAmznTraceIdHeaderToHeaders = (
+    headers: Headers,
+    traceId: string,
+    segmentId: string
+) => {
+    headers.set(X_AMZN_TRACE_ID, getAmznTraceIdHeaderValue(traceId, segmentId));
 };
 
 export const getAmznTraceIdHeaderValue = (


### PR DESCRIPTION
When `fetch` is called with a `Request` object as the first argument, the web client overrides the custom http headers in the `Request` object. This is because the web client adds the trace id header to a new `init` argument, which causes existing custom http headers to be overwritten.

This change modifies the behavior of the `fetch` monkey patch such that when `fetch` is called with a `Request` object, the `X-Amzn-Trace-Id` header is added directly to the `Request.header` object, instead of to a new `init` object.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
