### PR TITLE
chore: Write current version to CDN

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -9,6 +9,8 @@ aws s3api put-object --bucket $bucket --key "content/$version/LICENSE" --body LI
 
 if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 then
+    echo $version | aws s3 cp - s3://$bucket/content/current
+
     minorUpdate=$(echo $version | sed -En "s/^([0-9]+\.)[0-9]+\.[0-9]+/\1x/p")
     aws s3api put-object --bucket $bucket --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200
     aws s3api put-object --bucket $bucket --key "content/$minorUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=7200


### PR DESCRIPTION
There is currently no way for RUM client CDN consumers to know what the current (stable) version of the RUM web client is. For example, this is important when generating the code snippet which applications use to install the RUM web client.

This change writes the current version to CDN during deployment.

### Testing

Verified deployment [succeeds in gamma](https://github.com/qhanam/aws-rum-web/actions/runs/1885731865).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
