### PR TITLE
chore: Fix package version in GitHub release tag

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -3,6 +3,8 @@
 version=$(npm pkg get version | sed 's/"//g')
 bucket=$1
 
+echo ::set-output name=current-version::$version
+
 aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js --cache-control max-age=604800
 aws s3api put-object --bucket $bucket --key "content/$version/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=604800
 aws s3api put-object --bucket $bucket --key "content/$version/LICENSE" --body LICENSE --cache-control max-age=604800

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -45,6 +45,7 @@ jobs:
                   npm run release
 
             - name: Publish to CloudWatch RUM CDN
+              id: publish-cdn
               run: |
                   chmod u+x .github/scripts/deploy.sh
                   .github/scripts/deploy.sh ${{ secrets.BUCKET }}
@@ -60,8 +61,8 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
-                  tag_name: 'aws-rum-web@${{ github.event.inputs.version }}'
-                  release_name: 'Release ${{ github.event.inputs.version }}'
-                  body: 'Please see [CHANGELOG](https://github.com/aws/aws-rum-web/blob/master/CHANGELOG.md) for details.'
+                  tag_name: 'v${{ steps.publish-cdn.outputs.current-version }}'
+                  release_name: 'Release ${{ steps.publish-cdn.outputs.current-version }}'
+                  body: 'See [CHANGELOG](https://github.com/aws/aws-rum-web/blob/master/CHANGELOG.md) for details.'
                   draft: true
                   prerelease: false


### PR DESCRIPTION
The version in the GitHub release draft created by the deployment process is currently broken, as it was using a manual input value which no longer exists (the version is now read directly from the npm package).

This change fixes the version in the GitHub release draft.

### Testing

Verified deployment [succeeds in gamma](https://github.com/qhanam/aws-rum-web/actions/runs/1885731865).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
