### PR TITLE
docs: Fix index, add build instructions, fix x-ray header warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ which will install the web client in your application.
 ## Documentation
 
 1. [Installing from CDN](docs/cdn_installation.md)
-2. [Executing Commands](docs/cdn_commands.md)
-3. [Using the Web Client with Angular](docs/cdn_angular.md)
-4. [Using the Web Client with React](docs/cdn_react.md)
-5. [Using the Web Client with React](docs/cdn_react.md)
-6. [Troubleshooting CDN Installations](docs/cdn_troubleshooting.md)
+1. [Executing Commands](docs/cdn_commands.md)
+1. [Using the Web Client with Angular](docs/cdn_angular.md)
+1. [Using the Web Client with React](docs/cdn_react.md)
+1. [Troubleshooting CDN Installations](docs/cdn_troubleshooting.md)
 
 ## Getting Help
 
@@ -49,26 +48,64 @@ We support and accept PRs from the community.
 
 See [CONTRIBUTING](./CONTRIBUTING.md)
 
+## Build from Source
+
+The CloudWatch RUM web client is developed and built using Node.js version 16 or higher.
+
+To build the CloudWatch RUM web client, run the release process:
+
+```
+npm install
+npm run release
+```
+
+The release process creates (1) a web bundle and a debug map for distribution via CDN, and (2) JavaScript modules and TypeScript declaration files for distribution via NPM.
+
+The CDN files are:
+
+```
+./build/assets/cwr.js
+./build/assets/cwr.map.js
+```
+
+The NPM files are:
+
+```
+./dist/es/index.js
+./dist/es/index.d.ts
+./dist/cjs/index.js
+./dist/cjs/index.d.ts
+```
+
 ## Run Tests from Source
 
 To perform exploratory testing, run the Webpack DevServer:
 
-`npm run server`
+```
+npm install
+npm run server
+```
 
 In a browser, navigate to http://localhost:9000.
 
 To run (Jest) unit tests:
 
-`npm run test`
+```
+npm run test
+```
 
 To run (TestCafe) browser integration tests:
 
-`npm run integ:local:chrome:headless`
+```
+npm run integ:local:chrome:headless
+```
 
 Some features perform monkey patching which is incompatible with TestCafe. In
 these cases, run Nightwatch as a separate browser integration test target:
 
-`npm run integ:local:nightwatch`
+```
+npm run integ:local:nightwatch
+```
 
 ## Pre-commit Tasks
 
@@ -78,11 +115,15 @@ resolved.
 
 Attempt to automatically repair linter warnings:
 
-`npm run lint:fix`
+```
+npm run lint:fix
+```
 
 Format code:
 
-`npm run prettier:fix`
+```
+npm run prettier:fix
+```
 
 ## Security
 

--- a/docs/cdn_troubleshooting.md
+++ b/docs/cdn_troubleshooting.md
@@ -167,9 +167,9 @@ configurations removed for readability.
 
 > :warning: Enabling `addXRayTraceIdHeader` will cause a new header to be added
 to all HTTP requests. Adding headers can modify CORS behavior, including causing
-the request to fail. Adding headers after SigV4 signing will invalidate the
-request signature, causing the request to fail. Test your application with this
-header enabled before enabling this option in a production environment.
+the request to fail. Adding headers may also alter  the request signature,
+causing the request to fail. Test your application with this header enabled
+before enabling this option in a production environment.
 
 ```html
 <script>


### PR DESCRIPTION
This change fixes minor doc issues:
1. The index has a duplicate entry for React
2. There are no build instructions in the README
3. The X-Ray header warning states that adding the X-Amzn-Trace-Id header invalidates the SigV4 signature, which is untrue (SigV4 ignores this header).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
