### PR TITLE
fix: Use PerformanceObserver to act as a second check to prevent returning 0 for duration and loadEventEnd

### DIFF
--- a/src/plugins/event-plugins/NavigationPlugin.ts
+++ b/src/plugins/event-plugins/NavigationPlugin.ts
@@ -1,6 +1,7 @@
 import { RecordEvent, Plugin, PluginContext } from '../Plugin';
 import { NavigationEvent } from '../../events/navigation-event';
 import { PERFORMANCE_NAVIGATION_EVENT_TYPE } from '../utils/constant';
+import { addAmznTraceIdHeaderToHeaders } from 'plugins/utils/http-utils';
 
 export const NAVIGATION_EVENT_PLUGIN_ID = 'com.amazonaws.rum.navigation';
 
@@ -23,16 +24,19 @@ export class NavigationPlugin implements Plugin {
     }
 
     /**
-     * If the client is initialized after the window has fired a load event,
-     * invoke the callback method directly to trigger the record event.
-     * Otherwise, keep the original implementation to add callback method to eventListener.
-     * However, if the page finishes loading right before adding addEventListener, we still cannot provide data
+     * loadEventEnd is populated as 0 if the web page has not loaded completely, even though LOAD has been fired.
+     * As a result, if loadEventEnd is populated, we can ignore eventListener and record the data directly.
+     * On the other hand, if not, we have to use eventListener to initializes PerformanceObserver.
+     * PerformanceObserver will act as a second check for the final load timings.
      */
     load(context: PluginContext): void {
         this.recordEvent = context.record;
         if (this.enabled) {
             if (this.hasTheWindowLoadEventFired()) {
-                this.eventListener();
+                const navData = window.performance.getEntriesByType(
+                    NAVIGATION
+                )[0] as PerformanceNavigationTiming;
+                this.performanceNavigationEventHandlerTimingLevel2(navData);
             } else {
                 window.addEventListener(LOAD, this.eventListener);
             }
@@ -94,9 +98,18 @@ export class NavigationPlugin implements Plugin {
         if (performance.getEntriesByType(NAVIGATION).length === 0) {
             this.performanceNavigationEventHandlerTimingLevel1();
         } else {
-            this.performanceNavigationEventHandlerTimingLevel2(
-                performance.getEntriesByType(NAVIGATION)[0]
-            );
+            const navigationObserver = new PerformanceObserver((list) => {
+                list.getEntries().forEach((event) => {
+                    if (event.entryType === NAVIGATION) {
+                        this.performanceNavigationEventHandlerTimingLevel2(
+                            event
+                        );
+                    }
+                });
+            });
+            navigationObserver.observe({
+                entryTypes: [NAVIGATION]
+            });
         }
     };
 

--- a/src/plugins/event-plugins/NavigationPlugin.ts
+++ b/src/plugins/event-plugins/NavigationPlugin.ts
@@ -1,7 +1,6 @@
 import { RecordEvent, Plugin, PluginContext } from '../Plugin';
 import { NavigationEvent } from '../../events/navigation-event';
 import { PERFORMANCE_NAVIGATION_EVENT_TYPE } from '../utils/constant';
-import { addAmznTraceIdHeaderToHeaders } from 'plugins/utils/http-utils';
 
 export const NAVIGATION_EVENT_PLUGIN_ID = 'com.amazonaws.rum.navigation';
 

--- a/src/plugins/event-plugins/__integ__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/NavigationPlugin.test.ts
@@ -122,7 +122,9 @@ test('when plugin loads after window.load then navigation timing events are reco
         .contains(DURATION)
 
         .expect(RESPONSE_STATUS.textContent)
-        .eql(STATUS_202.toString());
+        .eql(STATUS_202.toString())
+        .expect((await REQUEST_BODY.textContent).indexOf(DURATION))
+        .gt(0);
 
     /**
      * Deprecated Timing Level1 used for Safari browser do not contain following attributes

--- a/src/plugins/event-plugins/__integ__/PerformancePlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/PerformancePlugin.test.ts
@@ -131,7 +131,9 @@ test('PerformanceEvent records navigation event', async (t: TestController) => {
         .contains(DURATION)
 
         .expect(RESPONSE_STATUS.textContent)
-        .eql(STATUS_202.toString());
+        .eql(STATUS_202.toString())
+        .expect((await REQUEST_BODY.textContent).indexOf(DURATION))
+        .gt(0);
 
     /**
      * Deprecated Timing Level1 used for Safari browser do not contain following attributes


### PR DESCRIPTION
Version `1.1.0` and later has a bug which causes `com.amazon.rum.performance_navigation_event.duration` to be `0` when the web client loads before `window.load` has been fired.

Root Cause:

- Window fires `load` when the page has finished loading according to documentations, but there seems to be cases where it is actually fired before the `loadEventEnd` is fired.
- PR #81 correctly fixes the bug that did not capture when the page loads before the plugin does, but by removing PerformanceObserver, we started emitting `navigation_events` as soon as window fired `load`.
- As a result, there are times when `navigation_events` emits 0 for fields such as `duration`, `loadEventEnd`, etc.

This PR addresses the issue by doing the following:

1. No longer rely on callback when the page has already loaded (we determine by using `loadEventEnd`) and directly record the values.
2. Restore PerformanceObserver for regular scenarios where page loads after the plugin.

Verifications:
1. Unit Test
2. Integ Test
3. https://paste.amazon.com/show/renoseo/1645745904

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
