### PR TITLE
chore(release): 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 1.2.1 (2022-02-25)
+
+
+### Bug Fixes
+
+* Use PerformanceObserver to act as a second check to prevent returning 0 for duration and loadEventEnd ([#101](https://github.com/aws-observability/aws-rum-web/issues/101)) ([cea2c0b](https://github.com/aws-observability/aws-rum-web/commit/cea2c0bdcccdf765c26419c129a858955bde68ee))
+
 ## 1.2.0 (2022-02-23)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aws-rum-web",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-rum-web",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-rum-web",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",
     "author": "Amazon CloudWatch RUM Staff <nobody@amazon.com>",


### PR DESCRIPTION
Release v1.2.1. Added a build target to execute the [standard-version](https://github.com/conventional-changelog/standard-version) utility. This bumps the version and updates the changelog.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
