### PR TITLE
feat: Capture SPA virtual page load timing (changes for manual API call to recordPageViews)

### DIFF
--- a/app/page_event.html
+++ b/app/page_event.html
@@ -68,7 +68,7 @@
             }
 
             function recordPageView() {
-                cwr('recordPageView', '/page_view_two');
+                cwr('recordPageView', ['/page_view_two', 'route_change']);
             }
 
             const parseEvents = () => {

--- a/src/CommandQueue.ts
+++ b/src/CommandQueue.ts
@@ -39,7 +39,7 @@ export class CommandQueue {
             this.orchestration.setAwsCredentials(payload);
         },
         recordPageView: (payload: string): void => {
-            this.orchestration.recordPageView(payload);
+            this.orchestration.recordPageView(payload[0], payload[1]);
         },
         recordError: (payload: any): void => {
             this.orchestration.recordError(payload);

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -1,3 +1,4 @@
+import { Assertion } from 'chai';
 import { Selector } from 'testcafe';
 import { REQUEST_BODY } from '../../test-utils/integ-test-utils';
 
@@ -21,7 +22,7 @@ test('PageViewEventPlugin records landing page view event', async (t: TestContro
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t
-        .wait(300)
+        .wait(3000)
         .click(dispatch)
         .expect(REQUEST_BODY.textContent)
         .contains('BatchId');
@@ -108,10 +109,11 @@ test('when page is denied then page view is not recorded', async (t: TestControl
         JSON.parse(await REQUEST_BODY.textContent)
     );
     const eventDetails = JSON.parse(json.RumEvents[0].details);
-
-    await t.expect(json.RumEvents.length).eql(1).expect(eventDetails).contains({
-        pageId: '/page_view_two',
-        interaction: 1,
-        pageInteractionId: '/page_view_two-1'
-    });
+    await t
+        .expect(eventDetails.pageId)
+        .eql('/page_view_two')
+        .expect(eventDetails.interaction)
+        .eql(1)
+        .expect(eventDetails.pageInteractionId)
+        .eql('/page_view_two-1');
 });


### PR DESCRIPTION
- Changes to distinguish `initial_load` vs `route_change` when invoked manually
- When the customer uses manual API instead of automatic page views, the initial page is not captured at all. As a result, assuming all recordPageView is for `route_change` may be misleading.
- Input command would be `cwr('recordPageView', ['/page_view_two', 'route_change'])`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
