### PR TITLE
feat: Page tagging

### DIFF
--- a/app/page_event.html
+++ b/app/page_event.html
@@ -71,6 +71,22 @@
                 cwr('recordPageView', '/page_view_two');
             }
 
+            function recordPageViewWithPageAttributes() {
+                cwr('recordPageView', {
+                    pageId: '/page_view_two',
+                    pageTags: ['pageGroup1']
+                });
+            }
+
+            function setCustomAttributes() {
+                cwr('setCustomAttributes', {
+                    pageAttributes: {
+                        pageId: '/page_view_two',
+                        pageTags: ['pageGroup1']
+                    }
+                });
+            }
+
             const parseEvents = () => {
                 const requestBody = document.getElementById('request_body');
                 const events = JSON.parse(requestBody.innerText).batch.events;
@@ -144,6 +160,15 @@
         <button id="clean-data" onclick="parseEvents()">Parse events</button>
         <button id="recordPageView" onclick="recordPageView()">
             Record Page View
+        </button>
+        <button
+            id="recordPageViewWithPageAttributes"
+            onclick="recordPageViewWithPageAttributes()"
+        >
+            Record Page View with page attributes
+        </button>
+        <button id="setCustomAttributes" onclick="setCustomAttributes()">
+            Set custom page attributes
         </button>
         <button id="doNotRecordPageView" onclick="doNotRecordPageView()">
             Do Not Record Page View

--- a/app/page_event.html
+++ b/app/page_event.html
@@ -78,15 +78,6 @@
                 });
             }
 
-            function setCustomAttributes() {
-                cwr('setCustomAttributes', {
-                    pageAttributes: {
-                        pageId: '/page_view_two',
-                        pageTags: ['pageGroup1']
-                    }
-                });
-            }
-
             const parseEvents = () => {
                 const requestBody = document.getElementById('request_body');
                 const events = JSON.parse(requestBody.innerText).batch.events;
@@ -166,9 +157,6 @@
             onclick="recordPageViewWithPageAttributes()"
         >
             Record Page View with page attributes
-        </button>
-        <button id="setCustomAttributes" onclick="setCustomAttributes()">
-            Set custom page attributes
         </button>
         <button id="doNotRecordPageView" onclick="doNotRecordPageView()">
             Do Not Record Page View

--- a/src/CommandQueue.ts
+++ b/src/CommandQueue.ts
@@ -38,7 +38,7 @@ export class CommandQueue {
         ): void => {
             this.orchestration.setAwsCredentials(payload);
         },
-        recordPageView: (payload: string | any): void => {
+        recordPageView: (payload: any): void => {
             this.orchestration.recordPageView(payload);
         },
         recordError: (payload: any): void => {
@@ -46,9 +46,6 @@ export class CommandQueue {
         },
         registerDomEvents: (payload: any): void => {
             this.orchestration.registerDomEvents(payload);
-        },
-        setCustomAttributes: (payload: any): void => {
-            this.orchestration.setCustomAttributes(payload);
         },
         dispatch: (): void => {
             this.orchestration.dispatch();

--- a/src/CommandQueue.ts
+++ b/src/CommandQueue.ts
@@ -38,7 +38,7 @@ export class CommandQueue {
         ): void => {
             this.orchestration.setAwsCredentials(payload);
         },
-        recordPageView: (payload: string): void => {
+        recordPageView: (payload: string | any): void => {
             this.orchestration.recordPageView(payload);
         },
         recordError: (payload: any): void => {
@@ -46,6 +46,9 @@ export class CommandQueue {
         },
         registerDomEvents: (payload: any): void => {
             this.orchestration.registerDomEvents(payload);
+        },
+        setCustomAttributes: (payload: any): void => {
+            this.orchestration.setCustomAttributes(payload);
         },
         dispatch: (): void => {
             this.orchestration.dispatch();

--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -46,7 +46,6 @@ const allowCookies = jest.fn();
 const recordPageView = jest.fn();
 const recordError = jest.fn();
 const registerDomEvents = jest.fn();
-const setCustomAttributes = jest.fn();
 jest.mock('../orchestration/Orchestration', () => ({
     Orchestration: jest.fn().mockImplementation(() => ({
         disable,
@@ -57,8 +56,7 @@ jest.mock('../orchestration/Orchestration', () => ({
         allowCookies,
         recordPageView,
         recordError,
-        registerDomEvents,
-        setCustomAttributes
+        registerDomEvents
     }))
 }));
 
@@ -285,16 +283,6 @@ describe('CommandQueue tests', () => {
         });
         expect(Orchestration).toHaveBeenCalled();
         expect(registerDomEvents).toHaveBeenCalled();
-    });
-
-    test('setCustomAttributes calls Orchestration.setCustomAttributes', async () => {
-        const cq: CommandQueue = getCommandQueue();
-        await cq.push({
-            c: 'setCustomAttributes',
-            p: false
-        });
-        expect(Orchestration).toHaveBeenCalled();
-        expect(setCustomAttributes).toHaveBeenCalled();
     });
 
     test('allowCookies fails when paylod is non-boolean', async () => {

--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -46,6 +46,7 @@ const allowCookies = jest.fn();
 const recordPageView = jest.fn();
 const recordError = jest.fn();
 const registerDomEvents = jest.fn();
+const setCustomAttributes = jest.fn();
 jest.mock('../orchestration/Orchestration', () => ({
     Orchestration: jest.fn().mockImplementation(() => ({
         disable,
@@ -56,7 +57,8 @@ jest.mock('../orchestration/Orchestration', () => ({
         allowCookies,
         recordPageView,
         recordError,
-        registerDomEvents
+        registerDomEvents,
+        setCustomAttributes
     }))
 }));
 
@@ -259,7 +261,7 @@ describe('CommandQueue tests', () => {
         const cq: CommandQueue = getCommandQueue();
         await cq.push({
             c: 'recordPageView',
-            p: 'page1'
+            p: '/console/home'
         });
         expect(Orchestration).toHaveBeenCalled();
         expect(recordPageView).toHaveBeenCalled();
@@ -283,6 +285,16 @@ describe('CommandQueue tests', () => {
         });
         expect(Orchestration).toHaveBeenCalled();
         expect(registerDomEvents).toHaveBeenCalled();
+    });
+
+    test('setCustomAttributes calls Orchestration.setCustomAttributes', async () => {
+        const cq: CommandQueue = getCommandQueue();
+        await cq.push({
+            c: 'setCustomAttributes',
+            p: false
+        });
+        expect(Orchestration).toHaveBeenCalled();
+        expect(setCustomAttributes).toHaveBeenCalled();
     });
 
     test('allowCookies fails when paylod is non-boolean', async () => {

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -1,8 +1,8 @@
 import { Session, SessionManager } from '../sessions/SessionManager';
 import { v4 } from 'uuid';
 import { MetaData } from '../events/meta-data';
-import { Config } from '../orchestration/Orchestration';
-import { PageManager } from '../sessions/PageManager';
+import { Config, CustomAttributes } from '../orchestration/Orchestration';
+import { PageAttributes, PageManager } from '../sessions/PageManager';
 import {
     AppMonitorDetails,
     UserDetails,
@@ -65,9 +65,20 @@ export class EventCache {
     /**
      * Update the current page interaction for the session.
      */
-    public recordPageView = (pageId: string) => {
+    public recordPageView = (payload: string | PageAttributes) => {
         if (this.isCurrentUrlAllowed()) {
-            this.pageManager.recordPageView(pageId);
+            this.pageManager.recordPageView(payload);
+        }
+    };
+
+    /**
+     * Update the current page interaction for the session.
+     */
+    public setCustomAttributes = (customAttributes: CustomAttributes) => {
+        if (customAttributes.pageAttributes) {
+            this.pageManager.setCustomAttributes(
+                customAttributes.pageAttributes
+            );
         }
     };
 

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -1,7 +1,7 @@
 import { Session, SessionManager } from '../sessions/SessionManager';
 import { v4 } from 'uuid';
 import { MetaData } from '../events/meta-data';
-import { Config, CustomAttributes } from '../orchestration/Orchestration';
+import { Config } from '../orchestration/Orchestration';
 import { PageAttributes, PageManager } from '../sessions/PageManager';
 import {
     AppMonitorDetails,
@@ -68,17 +68,6 @@ export class EventCache {
     public recordPageView = (payload: string | PageAttributes) => {
         if (this.isCurrentUrlAllowed()) {
             this.pageManager.recordPageView(payload);
-        }
-    };
-
-    /**
-     * Update the current page interaction for the session.
-     */
-    public setCustomAttributes = (customAttributes: CustomAttributes) => {
-        if (customAttributes.pageAttributes) {
-            this.pageManager.setCustomAttributes(
-                customAttributes.pageAttributes
-            );
         }
     };
 

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -255,38 +255,6 @@ describe('EventCache tests', () => {
         );
     });
 
-    test('when pageTag attribute is set through setCustomAttributes API, event metadata records the page tag data', async () => {
-        // Init
-        const EVENT1_SCHEMA = 'com.amazon.rum.page_view_event';
-        const eventCache: EventCache = Utils.createEventCache({
-            ...DEFAULT_CONFIG
-        });
-        const expectedEvents: RumEvent[] = [
-            {
-                id: expect.stringMatching(/[0-9a-f\-]+/),
-                timestamp: new Date(),
-                type: EVENT1_SCHEMA,
-                metadata:
-                    '{"version":"1.0.0","title":"","pageId":"/rum/home","pageTags":["pageGroup1"]}',
-                details: '{"version":"1.0.0","pageId":"/rum/home"}'
-            }
-        ];
-
-        // Run
-        eventCache.setCustomAttributes({
-            pageAttributes: {
-                pageId: '/rum/home',
-                pageTags: ['pageGroup1']
-            }
-        });
-
-        eventCache.recordPageView('/rum/home');
-        // Assert
-        expect(await eventCache.getEventBatch()).toEqual(
-            expect.arrayContaining(expectedEvents)
-        );
-    });
-
     test('when page matches both allowed and denied, recordEvent does not record the event', async () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -226,6 +226,67 @@ describe('EventCache tests', () => {
         );
     });
 
+    test('when page is recorded with page tags provided, event metadata records the page tag data', async () => {
+        // Init
+        const EVENT1_SCHEMA = 'com.amazon.rum.page_view_event';
+        const eventCache: EventCache = Utils.createEventCache({
+            ...DEFAULT_CONFIG
+        });
+        const expectedEvents: RumEvent[] = [
+            {
+                id: expect.stringMatching(/[0-9a-f\-]+/),
+                timestamp: new Date(),
+                type: EVENT1_SCHEMA,
+                metadata:
+                    '{"version":"1.0.0","title":"","pageId":"/rum/home","pageTags":["pageGroup1"]}',
+                details: '{"version":"1.0.0","pageId":"/rum/home"}'
+            }
+        ];
+
+        // Run
+        eventCache.recordPageView({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1']
+        });
+
+        // Assert
+        expect(await eventCache.getEventBatch()).toEqual(
+            expect.arrayContaining(expectedEvents)
+        );
+    });
+
+    test('when pageTag attribute is set through setCustomAttributes API, event metadata records the page tag data', async () => {
+        // Init
+        const EVENT1_SCHEMA = 'com.amazon.rum.page_view_event';
+        const eventCache: EventCache = Utils.createEventCache({
+            ...DEFAULT_CONFIG
+        });
+        const expectedEvents: RumEvent[] = [
+            {
+                id: expect.stringMatching(/[0-9a-f\-]+/),
+                timestamp: new Date(),
+                type: EVENT1_SCHEMA,
+                metadata:
+                    '{"version":"1.0.0","title":"","pageId":"/rum/home","pageTags":["pageGroup1"]}',
+                details: '{"version":"1.0.0","pageId":"/rum/home"}'
+            }
+        ];
+
+        // Run
+        eventCache.setCustomAttributes({
+            pageAttributes: {
+                pageId: '/rum/home',
+                pageTags: ['pageGroup1']
+            }
+        });
+
+        eventCache.recordPageView('/rum/home');
+        // Assert
+        expect(await eventCache.getEventBatch()).toEqual(
+            expect.arrayContaining(expectedEvents)
+        );
+    });
+
     test('when page matches both allowed and denied, recordEvent does not record the event', async () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';

--- a/src/event-schemas/meta-data.json
+++ b/src/event-schemas/meta-data.json
@@ -62,7 +62,8 @@
         },
         "domain": {
             "type": "string"
-        }
+        },
+        "pageTags": { "type": "array", "items": { "type": "string" } }
     },
     "additionalProperties": false,
     "required": ["version", "domain"]

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -20,6 +20,7 @@ import { WebVitalsPlugin } from '../plugins/event-plugins/WebVitalsPlugin';
 import { XhrPlugin } from '../plugins/event-plugins/XhrPlugin';
 import { FetchPlugin } from '../plugins/event-plugins/FetchPlugin';
 import { PageViewPlugin } from '../plugins/event-plugins/PageViewPlugin';
+import { PageAttributes } from '../sessions/PageManager';
 
 const DATA_PLANE_REGION_PLACEHOLDER = '${REGION}';
 const DATA_PLANE_DEFAULT_ENDPOINT =
@@ -131,6 +132,10 @@ export type CookieAttributes = {
     path: string;
     sameSite: string;
     secure: boolean;
+};
+
+export type CustomAttributes = {
+    pageAttributes?: PageAttributes;
 };
 
 export type Config = {
@@ -284,10 +289,12 @@ export class Orchestration {
 
     /**
      * Update the current page the user is interacting with.
-     * @param pageId The unique ID for the page within the application.
+     * @param payload Can be string or PageAttributes object
+     *      If string, payload is pageId (The unique ID for the page within the application).
+     *      If PageAttributes, payload contains pageId as well as page attributes to include in events with pageId
      */
-    public recordPageView(pageId: string) {
-        this.eventCache.recordPageView(pageId);
+    public recordPageView(payload: string | PageAttributes) {
+        this.eventCache.recordPageView(payload);
     }
 
     /**
@@ -304,6 +311,14 @@ export class Orchestration {
      */
     public registerDomEvents(events: TargetDomEvent[]) {
         this.pluginManager.updatePlugin(DOM_EVENT_PLUGIN_ID, events);
+    }
+
+    /**
+     * Set custom attributes for page and/or session
+     * @param customAttributes page and/or session attributes to add to event metadata
+     */
+    public setCustomAttributes(customAttributes: CustomAttributes) {
+        this.eventCache.setCustomAttributes(customAttributes);
     }
 
     private initEventCache(

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -134,10 +134,6 @@ export type CookieAttributes = {
     secure: boolean;
 };
 
-export type CustomAttributes = {
-    pageAttributes?: PageAttributes;
-};
-
 export type Config = {
     allowCookies: boolean;
     batchLimit: number;
@@ -311,14 +307,6 @@ export class Orchestration {
      */
     public registerDomEvents(events: TargetDomEvent[]) {
         this.pluginManager.updatePlugin(DOM_EVENT_PLUGIN_ID, events);
-    }
-
-    /**
-     * Set custom attributes for page and/or session
-     * @param customAttributes page and/or session attributes to add to event metadata
-     */
-    public setCustomAttributes(customAttributes: CustomAttributes) {
-        this.eventCache.setCustomAttributes(customAttributes);
     }
 
     private initEventCache(

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -19,14 +19,12 @@ jest.mock('../../dispatch/Dispatch', () => ({
 
 const enableEventCache = jest.fn();
 const disableEventCache = jest.fn();
-const setCustomAttributes = jest.fn();
 const recordPageView = jest.fn();
 
 jest.mock('../../event-cache/EventCache', () => ({
     EventCache: jest.fn().mockImplementation(() => ({
         enable: enableEventCache,
         disable: disableEventCache,
-        setCustomAttributes: setCustomAttributes,
         recordPageView: recordPageView
     }))
 }));
@@ -373,27 +371,6 @@ describe('Orchestration tests', () => {
         // Assert
         expect(recordPageView).toHaveBeenCalledTimes(1);
         actual = recordPageView.mock.calls[0][0];
-
-        expect(actual).toEqual(expected);
-    });
-
-    test('when page tag attribute is set then EventCache.setCustomAttributes() is called', async () => {
-        // Init
-        const orchestration = new Orchestration('a', 'c', 'us-east-1', {});
-
-        const expected = {
-            pageAttributes: {
-                pageId: '/rum/home',
-                pageTags: ['pageGroup1']
-            }
-        };
-        orchestration.setCustomAttributes(expected);
-
-        let actual;
-
-        // Assert
-        expect(setCustomAttributes).toHaveBeenCalledTimes(1);
-        actual = setCustomAttributes.mock.calls[0][0];
 
         expect(actual).toEqual(expected);
     });

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -19,11 +19,15 @@ jest.mock('../../dispatch/Dispatch', () => ({
 
 const enableEventCache = jest.fn();
 const disableEventCache = jest.fn();
+const setCustomAttributes = jest.fn();
+const recordPageView = jest.fn();
 
 jest.mock('../../event-cache/EventCache', () => ({
     EventCache: jest.fn().mockImplementation(() => ({
         enable: enableEventCache,
-        disable: disableEventCache
+        disable: disableEventCache,
+        setCustomAttributes: setCustomAttributes,
+        recordPageView: recordPageView
     }))
 }));
 
@@ -350,6 +354,46 @@ describe('Orchestration tests', () => {
         updatePlugin.mock.calls.forEach((call) => {
             actual = call[1][0];
         });
+
+        expect(actual).toEqual(expected);
+    });
+
+    test('when the page is manually recorded with pageTag attribute then EventCache.recordPageView() is called', async () => {
+        // Init
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {});
+
+        const expected = {
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1']
+        };
+        orchestration.recordPageView(expected);
+
+        let actual;
+
+        // Assert
+        expect(recordPageView).toHaveBeenCalledTimes(1);
+        actual = recordPageView.mock.calls[0][0];
+
+        expect(actual).toEqual(expected);
+    });
+
+    test('when page tag attribute is set then EventCache.setCustomAttributes() is called', async () => {
+        // Init
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {});
+
+        const expected = {
+            pageAttributes: {
+                pageId: '/rum/home',
+                pageTags: ['pageGroup1']
+            }
+        };
+        orchestration.setCustomAttributes(expected);
+
+        let actual;
+
+        // Assert
+        expect(setCustomAttributes).toHaveBeenCalledTimes(1);
+        actual = setCustomAttributes.mock.calls[0][0];
 
         expect(actual).toEqual(expected);
     });

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -40,7 +40,6 @@ export class PageManager {
     private page: Page | undefined;
     private resumed: Page | undefined;
     private attributes: Attributes | undefined;
-    private customPageAttributes: PageAttributes | undefined;
 
     /**
      * A flag which keeps track of whether or not cookies have been enabled.
@@ -98,21 +97,13 @@ export class PageManager {
             return;
         }
 
-        this.setCustomAttributes(
+        // Attributes will be added to all events as meta data
+        this.collectAttributes(
             typeof payload === 'object' ? payload : undefined
         );
 
-        // Attributes will be added to all events as meta data
-        this.collectAttributes();
-
         // The SessionManager will update its cookie with the new page
         this.recordPageViewEvent();
-    }
-
-    public setCustomAttributes(customPageAttributes: PageAttributes) {
-        if (customPageAttributes) {
-            this.customPageAttributes = customPageAttributes;
-        }
     }
 
     private createResumedPage(pageId: string) {
@@ -142,11 +133,10 @@ export class PageManager {
         };
     }
 
-    private collectAttributes() {
-        const pageId = this.page.pageId;
+    private collectAttributes(customPageAttributes?: PageAttributes) {
         this.attributes = {
             title: document.title,
-            pageId
+            pageId: this.page.pageId
         };
 
         if (this.recordInteraction) {
@@ -156,11 +146,9 @@ export class PageManager {
             }
         }
 
-        if (this.customPageAttributes) {
-            Object.keys(this.customPageAttributes).forEach((attribute) => {
-                this.attributes[attribute] = this.customPageAttributes[
-                    attribute
-                ];
+        if (customPageAttributes) {
+            Object.keys(customPageAttributes).forEach((attribute) => {
+                this.attributes[attribute] = customPageAttributes[attribute];
             });
         }
     }

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -5,7 +5,6 @@ const recordPageView: Selector = Selector(`#recordPageView`);
 const recordPageViewWithPageAttributes: Selector = Selector(
     `#recordPageViewWithPageAttributes`
 );
-const setCustomAttributes: Selector = Selector(`#setCustomAttributes`);
 const dispatch: Selector = Selector(`#dispatch`);
 const clear: Selector = Selector(`#clearRequestResponse`);
 const doNotRecordPageView = Selector(`#doNotRecordPageView`);
@@ -131,48 +130,6 @@ test('when pageTag attribute is passed in when manually recording page view even
         .contains('BatchId')
         .click(clear)
         .click(recordPageViewWithPageAttributes)
-        .click(dispatch)
-        .expect(REQUEST_BODY.textContent)
-        .contains('BatchId');
-
-    const json = removeUnwantedEvents(
-        JSON.parse(await REQUEST_BODY.textContent)
-    );
-    const eventType = json.RumEvents[0].type;
-    const eventDetails = JSON.parse(json.RumEvents[0].details);
-    const metaData = JSON.parse(json.RumEvents[0].metadata);
-
-    await t
-        .expect(eventType)
-        .eql('com.amazon.rum.page_view_event')
-        .expect(eventDetails)
-        .contains({
-            pageId: '/page_view_two',
-            interaction: 1,
-            pageInteractionId: '/page_view_two-1',
-            parentPageInteractionId: '/page_event.html-0'
-        })
-        .expect(metaData)
-        .contains({
-            pageId: '/page_view_two',
-            title: 'RUM Integ Test'
-        })
-        .expect(metaData.pageTags[0])
-        .eql('pageGroup1');
-});
-
-test('when the pageTag attribute is added to the page, then PageViewEventPlugin records pageTag data in metadata', async (t: TestController) => {
-    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
-    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
-
-    await t
-        .wait(300)
-        .click(dispatch)
-        .expect(REQUEST_BODY.textContent)
-        .contains('BatchId')
-        .click(clear)
-        .click(setCustomAttributes)
-        .click(recordPageView)
         .click(dispatch)
         .expect(REQUEST_BODY.textContent)
         .contains('BatchId');

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -196,4 +196,63 @@ describe('PageManager tests', () => {
             (pageManager as any).popstateListener
         );
     });
+    test('when the page is manually recorded with pageTag attribute then page attributes contains pageTag attribute data', async () => {
+        // Init
+        const pageManager: PageManager = new PageManager(
+            {
+                ...DEFAULT_CONFIG,
+                allowCookies: true
+            },
+            record
+        );
+
+        // Run
+        pageManager.recordPageView({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1']
+        });
+
+        // Assert
+        expect(record.mock.calls[0][0]).toEqual(PAGE_VIEW_TYPE);
+        expect(pageManager.getAttributes()).toMatchObject({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1']
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
+
+    test('when the pageTag attribute is added to the page then page attributes contains pageTag attribute data', async () => {
+        // Init
+        const pageManager: PageManager = new PageManager(
+            {
+                ...DEFAULT_CONFIG,
+                allowCookies: true
+            },
+            record
+        );
+
+        // Run
+        pageManager.setCustomAttributes({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1', 'pageGroup2']
+        });
+
+        pageManager.recordPageView('/rum/home');
+
+        // Assert
+        expect(record.mock.calls[0][0]).toEqual(PAGE_VIEW_TYPE);
+        expect(pageManager.getAttributes()).toMatchObject({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1', 'pageGroup2']
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
 });

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -224,35 +224,4 @@ describe('PageManager tests', () => {
             (pageManager as any).popstateListener
         );
     });
-
-    test('when the pageTag attribute is added to the page then page attributes contains pageTag attribute data', async () => {
-        // Init
-        const pageManager: PageManager = new PageManager(
-            {
-                ...DEFAULT_CONFIG,
-                allowCookies: true
-            },
-            record
-        );
-
-        // Run
-        pageManager.setCustomAttributes({
-            pageId: '/rum/home',
-            pageTags: ['pageGroup1', 'pageGroup2']
-        });
-
-        pageManager.recordPageView('/rum/home');
-
-        // Assert
-        expect(record.mock.calls[0][0]).toEqual(PAGE_VIEW_TYPE);
-        expect(pageManager.getAttributes()).toMatchObject({
-            pageId: '/rum/home',
-            pageTags: ['pageGroup1', 'pageGroup2']
-        });
-
-        window.removeEventListener(
-            'popstate',
-            (pageManager as any).popstateListener
-        );
-    });
 });


### PR DESCRIPTION
Users want to add tags to pages so that data from RUM events can be separated into different groups for analysis, metric aggregation, etc. Currently, users are unable to add tags to pages. This feature will allow them to add tags and will store the page tag data in the event metadata. Users can pass in the page tag data:
(1) when manually recording page view events using `recordPageView()`
(2) by manually setting the page tag data using `setCustomAttributes()`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
