### PR TITLE
fix: Add version property to http-event schema and convert PromiseRejection.reason into string

### DIFF
--- a/src/event-schemas/http-event.json
+++ b/src/event-schemas/http-event.json
@@ -30,6 +30,10 @@
         "error": {
             "type": "object",
             "properties": {
+                "version": {
+                    "type": "string",
+                    "description": "JSErrorEvent schema version."
+                },
                 "type": {
                     "type": "string",
                     "description": "Error type (eg., TypeError, ParseError, etc)."

--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -73,7 +73,10 @@ export class JsErrorPlugin implements Plugin {
         const errorEvent: JSErrorEvent = {
             version: '1.0.0',
             type: event.type,
-            message: event.reason
+            message:
+                typeof event.reason === 'string'
+                    ? event.reason
+                    : JSON.stringify(event.reason)
         };
         this.recordEvent(JS_ERROR_EVENT_TYPE, errorEvent);
     };

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -513,6 +513,7 @@ describe('FetchPlugin tests', () => {
                 method: 'GET'
             },
             error: {
+                version: '1.0.0',
                 type: 'FetchError',
                 message: 'timeout',
                 stack: 'stack trace'

--- a/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
@@ -422,4 +422,66 @@ describe('JsErrorPlugin tests', () => {
             })
         );
     });
+
+    test('when unhandledrejection error event outputs empty object as reason then it is recorded as string', async () => {
+        // Init
+        const plugin: JsErrorPlugin = new JsErrorPlugin();
+
+        // Run
+        plugin.load(context);
+        const promiseRejectionEvent: PromiseRejectionEvent = new Event(
+            'unhandledrejection'
+        ) as PromiseRejectionEvent;
+        // JSDOM has not implemented PromiseRejectionEvent, so we 'extend'
+        // Event to have the same functionality
+        window.dispatchEvent(
+            Object.assign(promiseRejectionEvent, {
+                promise: new Promise(() => {}),
+                reason: {}
+            })
+        );
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                type: 'unhandledrejection',
+                message: '{}'
+            })
+        );
+    });
+
+    test('when unhandledrejection error event outputs null object as reason then it is recorded as string', async () => {
+        // Init
+        const plugin: JsErrorPlugin = new JsErrorPlugin();
+
+        // Run
+        plugin.load(context);
+        const promiseRejectionEvent: PromiseRejectionEvent = new Event(
+            'unhandledrejection'
+        ) as PromiseRejectionEvent;
+        // JSDOM has not implemented PromiseRejectionEvent, so we 'extend'
+        // Event to have the same functionality
+        window.dispatchEvent(
+            Object.assign(promiseRejectionEvent, {
+                promise: new Promise(() => {}),
+                reason: null
+            })
+        );
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                type: 'unhandledrejection',
+                message: 'null'
+            })
+        );
+    });
 });


### PR DESCRIPTION
Problem
- When HTTP Event with an error is created, it uses `js-error-event` to populate the error field. `js-error-event` contains the field `version`, which is not included `http-event`'s `error` field. Due to this inconsistency that is also reflected on the dataplane's validation, any HTTP event with an error field is rejected. 
- When JSErrorPlugin handles `unhandledrejection` event, it adds `PromiseRejectionEvent.reason` as the `message` field. However, if the `PromiseRejectionEvent.reason` is an empty object rather than a string message, it is returned in the form of `{}`, which fails dataplane's validation for JsErrorEvents.

Fix
- This PR contains changes to `JsErrorPlugin` and its unit test cases to handle situations where the `PromiseRejectionEvent.reason` is an empty object, and also changes the event schema for `http-event`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
