### PR TITLE
fix: Add content-type in deploy script to support compression

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -5,7 +5,7 @@ bucket=$1
 
 echo ::set-output name=current-version::$version
 
-aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js --cache-control max-age=604800
+aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js --cache-control max-age=604800 --content-type "text/javascript"
 aws s3api put-object --bucket $bucket --key "content/$version/cwr.js.map" --body build/assets/cwr.js.map --cache-control max-age=604800
 aws s3api put-object --bucket $bucket --key "content/$version/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=604800
 aws s3api put-object --bucket $bucket --key "content/$version/LICENSE" --body LICENSE --cache-control max-age=604800
@@ -15,13 +15,13 @@ then
     echo $version | aws s3 cp - s3://$bucket/content/current
 
     minorUpdate=$(echo $version | sed -En "s/^([0-9]+\.)[0-9]+\.[0-9]+/\1x/p")
-    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200
+    aws s3api put-object --bucket $bucket --key "content/$minorUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200 --content-type "text/javascript"
     aws s3api put-object --bucket $bucket --key "content/$minorUpdate/cwr.js.map" --body build/assets/cwr.js.map --cache-control max-age=7200
     aws s3api put-object --bucket $bucket --key "content/$minorUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=7200
     aws s3api put-object --bucket $bucket --key "content/$minorUpdate/LICENSE" --body LICENSE --cache-control max-age=7200
 
     patchUpdate=$(echo $version | sed -En "s/^([0-9]+\.[0-9]+\.)[0-9]+/\1x/p")
-    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200
+    aws s3api put-object --bucket $bucket --key "content/$patchUpdate/cwr.js" --body build/assets/cwr.js --cache-control max-age=7200 --content-type "text/javascript"
     aws s3api put-object --bucket $bucket --key "content/$patchUpdate/cwr.js.map" --body build/assets/cwr.js.map --cache-control max-age=7200
     aws s3api put-object --bucket $bucket --key "content/$patchUpdate/LICENSE-THIRD-PARTY" --body LICENSE-THIRD-PARTY --cache-control max-age=7200
     aws s3api put-object --bucket $bucket --key "content/$patchUpdate/LICENSE" --body LICENSE --cache-control max-age=7200


### PR DESCRIPTION
Problem:
- Even though the CloudFront compression settings were correctly in place, the `cwr.js` files uploaded to S3 via GitHub release process had the default mime type of `binary/octet-stream`. As a result, users would always have to download the full sized web client in their applications.

Fix:
- CloudFront does not support compression of `binary/octet-stream`, so this fix adds an extra parameter in the `deploy.sh` for all major/minor/patch web client versions to set the mime type to `text/javascript`.

Test:
- Created a mock release version of 1.4.0 that included the fix and released in Gamma
- All major/minor/patch versions had the mime type of `text/javascript`
- Smoke test file was configured to use web client `v1.4.0`
- The web client's transferred size is 28.74kb instead of 113.52kb
![Screen Shot 2022-03-16 at 12 23 16 PM](https://user-images.githubusercontent.com/7401997/158675840-64fd63de-f817-47a6-940a-0e0f1266b1da.png)

Gamma CDN Cleanup:
- Once PR is approved and merged, will remove 1.4.x versions in Gamma CDN, trigger release workflow with existing 1.3.x version commit to reset the files.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
