### PR TITLE
fix: Add version property to http-event-schema

### DIFF
--- a/src/event-schemas/http-event.json
+++ b/src/event-schemas/http-event.json
@@ -30,6 +30,10 @@
         "error": {
             "type": "object",
             "properties": {
+                "version": {
+                    "type": "string",
+                    "description": "JSErrorEvent schema version."
+                },
                 "type": {
                     "type": "string",
                     "description": "Error type (eg., TypeError, ParseError, etc)."

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -163,6 +163,7 @@ describe('FetchPlugin tests', () => {
                 method: 'GET'
             },
             error: {
+                version: '1.0.0',
                 type: 'Timeout'
             }
         });
@@ -194,6 +195,7 @@ describe('FetchPlugin tests', () => {
                 method: 'GET'
             },
             error: {
+                version: '1.0.0',
                 type: 'Error',
                 message: 'Timeout',
                 stack: expect.stringContaining('FetchPlugin.test.ts')
@@ -513,6 +515,7 @@ describe('FetchPlugin tests', () => {
                 method: 'GET'
             },
             error: {
+                version: '1.0.0',
                 type: 'FetchError',
                 message: 'timeout',
                 stack: 'stack trace'
@@ -547,6 +550,7 @@ describe('FetchPlugin tests', () => {
                 method: 'GET'
             },
             error: {
+                version: '1.0.0',
                 type: 'FetchError',
                 message: 'timeout'
             }

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -258,6 +258,7 @@ describe('XhrPlugin tests', () => {
                 method: 'GET'
             },
             error: {
+                version: '1.0.0',
                 type: 'XMLHttpRequest error',
                 message: '0'
             }
@@ -342,6 +343,7 @@ describe('XhrPlugin tests', () => {
                 method: 'GET'
             },
             error: {
+                version: '1.0.0',
                 type: 'XMLHttpRequest timeout'
             }
         });
@@ -428,6 +430,7 @@ describe('XhrPlugin tests', () => {
                 method: 'GET'
             },
             error: {
+                version: '1.0.0',
                 type: 'XMLHttpRequest abort'
             }
         });


### PR DESCRIPTION
Problem:
- When the web client creates an HTTP event that contains an error, it relies on `errorEventToJsErrorEvent` that creates a `JsErrorEvent` to populate the `error` field in the `http-event`. `JsErrorEvent` by default adds `version`, which does not exist in the webclient's and dataplane's `http-event` schema.
- This was not caught on the web client as the `FetchPlugin` and `XhrPlugin` are unaware of the property details within the `error` object created by `errorEventToJsErrorEvent`.
- As a result, any HTTP events that contains an error was rejected by the dataplane due to this event schema discrepancy.

Fix:
- Dataplane event schema changes have been merged in.
- This PR updates the `http-event` schema to eliminate the schema difference between dataplane and web client and edits existing unit tests to check for the `version` property in `FetchPlugin.test` and `XhrPlugin.test`.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
