### PR TITLE
fix: Parse unhandledrejection error objects

### DIFF
--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -1,10 +1,6 @@
-import { JSErrorEvent } from '../../events/js-error-event';
 import { RecordEvent, Plugin, PluginContext } from '../Plugin';
 import { JS_ERROR_EVENT_TYPE } from '../utils/constant';
-import {
-    errorEventToJsErrorEvent,
-    buildBaseJsErrorEvent
-} from '../utils/js-error-utils';
+import { errorEventToJsErrorEvent } from '../utils/js-error-utils';
 
 export const JS_ERROR_EVENT_PLUGIN_ID = 'com.amazonaws.rum.js-error';
 

--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -69,7 +69,6 @@ export class JsErrorPlugin implements Plugin {
     };
 
     private promiseRejectEventHandler = (event: PromiseRejectionEvent) => {
-        // TODO: Improve current behavior to correctly indicate error comes from PromiseRejectionEvent
         this.eventHandler({
             type: event.type,
             error: event.reason

--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -1,7 +1,10 @@
 import { JSErrorEvent } from '../../events/js-error-event';
 import { RecordEvent, Plugin, PluginContext } from '../Plugin';
 import { JS_ERROR_EVENT_TYPE } from '../utils/constant';
-import { errorEventToJsErrorEvent } from '../utils/js-error-utils';
+import {
+    errorEventToJsErrorEvent,
+    buildBaseJsErrorEvent
+} from '../utils/js-error-utils';
 
 export const JS_ERROR_EVENT_PLUGIN_ID = 'com.amazonaws.rum.js-error';
 
@@ -70,12 +73,10 @@ export class JsErrorPlugin implements Plugin {
     };
 
     private promiseRejectEventHandler = (event: PromiseRejectionEvent) => {
-        const errorEvent: JSErrorEvent = {
-            version: '1.0.0',
+        this.eventHandler({
             type: event.type,
-            message: event.reason
-        };
-        this.recordEvent(JS_ERROR_EVENT_TYPE, errorEvent);
+            error: event.reason
+        } as ErrorEvent);
     };
 
     private addEventHandler(): void {

--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -69,6 +69,7 @@ export class JsErrorPlugin implements Plugin {
     };
 
     private promiseRejectEventHandler = (event: PromiseRejectionEvent) => {
+        // TODO: Improve current behavior to correctly indicate error comes from PromiseRejectionEvent
         this.eventHandler({
             type: event.type,
             error: event.reason

--- a/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
@@ -422,4 +422,102 @@ describe('JsErrorPlugin tests', () => {
             })
         );
     });
+
+    test('when unhandledrejection error event outputs empty object as reason then it is recorded as string', async () => {
+        // Init
+        const plugin: JsErrorPlugin = new JsErrorPlugin();
+
+        // Run
+        plugin.load(context);
+        const promiseRejectionEvent: PromiseRejectionEvent = new Event(
+            'unhandledrejection'
+        ) as PromiseRejectionEvent;
+        // JSDOM has not implemented PromiseRejectionEvent, so we 'extend'
+        // Event to have the same functionality
+        window.dispatchEvent(
+            Object.assign(promiseRejectionEvent, {
+                promise: new Promise(() => {}),
+                reason: {}
+            })
+        );
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                type: 'unhandledrejection',
+                message: 'undefined'
+            })
+        );
+    });
+
+    test('when unhandledrejection error event outputs null object as reason then it is recorded as string', async () => {
+        // Init
+        const plugin: JsErrorPlugin = new JsErrorPlugin();
+
+        // Run
+        plugin.load(context);
+        const promiseRejectionEvent: PromiseRejectionEvent = new Event(
+            'unhandledrejection'
+        ) as PromiseRejectionEvent;
+        // JSDOM has not implemented PromiseRejectionEvent, so we 'extend'
+        // Event to have the same functionality
+        window.dispatchEvent(
+            Object.assign(promiseRejectionEvent, {
+                promise: new Promise(() => {}),
+                reason: null
+            })
+        );
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                type: 'unhandledrejection',
+                message: 'undefined'
+            })
+        );
+    });
+
+    test('when unhandledrejection error event outputs error object as reason then error object is used', async () => {
+        // Init
+        const plugin: JsErrorPlugin = new JsErrorPlugin();
+
+        // Run
+        plugin.load(context);
+        const promiseRejectionEvent: PromiseRejectionEvent = new Event(
+            'unhandledrejection'
+        ) as PromiseRejectionEvent;
+        // JSDOM has not implemented PromiseRejectionEvent, so we 'extend'
+        // Event to have the same functionality
+        window.dispatchEvent(
+            Object.assign(promiseRejectionEvent, {
+                promise: new Promise(() => {}),
+                reason: {
+                    name: 'TypeError',
+                    message: 'NetworkError when attempting to fetch resource.',
+                    stack: 't/n.fetch@mock_client.js:2:104522t/n.fetchWrapper'
+                }
+            })
+        );
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(JS_ERROR_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject(
+            expect.objectContaining({
+                version: '1.0.0',
+                type: 'unhandledrejection: TypeError',
+                message: 'NetworkError when attempting to fetch resource.',
+                stack: 't/n.fetch@mock_client.js:2:104522t/n.fetchWrapper'
+            })
+        );
+    });
 });

--- a/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
@@ -423,7 +423,7 @@ describe('JsErrorPlugin tests', () => {
         );
     });
 
-    test('when unhandledrejection error event outputs empty object as reason then it is recorded as string', async () => {
+    test('when unhandledrejection error event outputs empty object as reason then message is recorded as undefined', async () => {
         // Init
         const plugin: JsErrorPlugin = new JsErrorPlugin();
 
@@ -454,7 +454,7 @@ describe('JsErrorPlugin tests', () => {
         );
     });
 
-    test('when unhandledrejection error event outputs null object as reason then it is recorded as string', async () => {
+    test('when unhandledrejection error event outputs null object as reason then message is recorded as undefined', async () => {
         // Init
         const plugin: JsErrorPlugin = new JsErrorPlugin();
 

--- a/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
@@ -514,7 +514,7 @@ describe('JsErrorPlugin tests', () => {
         expect(record.mock.calls[0][1]).toMatchObject(
             expect.objectContaining({
                 version: '1.0.0',
-                type: 'unhandledrejection: TypeError',
+                type: 'TypeError',
                 message: 'NetworkError when attempting to fetch resource.',
                 stack: 't/n.fetch@mock_client.js:2:104522t/n.fetchWrapper'
             })

--- a/src/plugins/utils/js-error-utils.ts
+++ b/src/plugins/utils/js-error-utils.ts
@@ -20,7 +20,7 @@ const isObject = (error: any): boolean => {
     return (type === 'object' || type === 'function') && !!error;
 };
 
-export const buildBaseJsErrorEvent = (errorEvent: ErrorEvent): JSErrorEvent => {
+const buildBaseJsErrorEvent = (errorEvent: ErrorEvent): JSErrorEvent => {
     const rumEvent: JSErrorEvent = {
         version: '1.0.0',
         type: 'undefined',

--- a/src/plugins/utils/js-error-utils.ts
+++ b/src/plugins/utils/js-error-utils.ts
@@ -63,9 +63,7 @@ const appendErrorObjectDetails = (
     // error may extend Error here, but it is not guaranteed (i.e., it could
     // be any object)
     if (error.name) {
-        rumEvent.type === 'unhandledrejection'
-            ? (rumEvent.type += ': ' + error.name)
-            : (rumEvent.type = error.name);
+        rumEvent.type = error.name;
     }
     if (error.message) {
         rumEvent.message = error.message;

--- a/src/plugins/utils/js-error-utils.ts
+++ b/src/plugins/utils/js-error-utils.ts
@@ -20,7 +20,7 @@ const isObject = (error: any): boolean => {
     return (type === 'object' || type === 'function') && !!error;
 };
 
-const buildBaseJsErrorEvent = (errorEvent: ErrorEvent): JSErrorEvent => {
+export const buildBaseJsErrorEvent = (errorEvent: ErrorEvent): JSErrorEvent => {
     const rumEvent: JSErrorEvent = {
         version: '1.0.0',
         type: 'undefined',
@@ -48,7 +48,10 @@ const appendErrorPrimitiveDetails = (
     rumEvent: JSErrorEvent,
     error: any
 ): void => {
-    rumEvent.type = error.toString();
+    // Keep unhandledrejection as type as it will write to rumEvent.message
+    if (rumEvent.type !== 'unhandledrejection') {
+        rumEvent.type = error.toString();
+    }
     rumEvent.message = error.toString();
 };
 
@@ -60,7 +63,9 @@ const appendErrorObjectDetails = (
     // error may extend Error here, but it is not guaranteed (i.e., it could
     // be any object)
     if (error.name) {
-        rumEvent.type = error.name;
+        rumEvent.type === 'unhandledrejection'
+            ? (rumEvent.type += ': ' + error.name)
+            : (rumEvent.type = error.name);
     }
     if (error.message) {
         rumEvent.message = error.message;


### PR DESCRIPTION
Problem:
The current implementation to handle `unhandledrejection` events simply assumes that the `PromiseRejectEvent.reason` is a string and populates it under `js-error-event.message` as a string. 
As a result, if the `PromiseRejectEvent.reason` is actually an error object, it does not properly stringify the error object, and instead populates the `js-error-event.message` field with an empty object, `{}`.
This results in the `JsErrorEvent` being rejected by the dataplane, as the `js-error-event.message` field is expected to be a string.

Fix:
This PR addresses the issue by doing two things:
1. Reuse `eventHandler` in `JsErrorPlugin` in `promiseRejectHandler` by extracting the `event.type` and `event.reason` and casting into an `ErrorEvent`.
2. Reuse parsing methods in `js-error-util` to create a `JsErrorEvent` that properly reflects the `unhandledrejection` event.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
