### PR TITLE
docs: Add JS module (npm) install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,40 +5,42 @@ JavaScript library which performs real user monitoring (RUM) telemetry on web
 applications. Data collected by the RUM web client includes page load timing,
 JavaScript errors and HTTP requests.
 
-## Installing
+## Install as a JavaScript Module
 
-The latest stable version of the web client is hosted on a content delivery
-network (CDN) hosted by CloudWatch RUM. See the [CloudWatch RUM
-documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM.html)
-for instructions on how to create an AppMonitor and generate a code snippet
-which will install the web client in your application.
+See [Installing as a JavaScript Module](docs/npm_installation.md).
 
-## Documentation
+## Install as an Embedded Script
 
-1. [Installing from CDN](docs/cdn_installation.md)
-1. [Executing Commands](docs/cdn_commands.md)
-1. [Using the Web Client with Angular](docs/cdn_angular.md)
-1. [Using the Web Client with React](docs/cdn_react.md)
-1. [Troubleshooting CDN Installations](docs/cdn_troubleshooting.md)
+See [Installing as an Embedded Script](docs/cdn_installation.md).
+
+## Additional Documentation:
+
+1. [Configuring the web client](docs/configuration.md)
+1. [Executing commands](docs/cdn_commands.md)
+1. [Using the web client with Angular](docs/cdn_angular.md)
+1. [Using the web client with React](docs/cdn_react.md)
+1. [Troubleshooting](docs/cdn_troubleshooting.md)
 
 ## Getting Help
 
 Use the following community resources for getting help with the SDK. We use the GitHub issues for tracking bugs and feature requests.
 
 -   View the [CloudWatch RUM documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM.html).
+-   Ask a question in the [Amazon CloudWatch forum](https://forums.aws.amazon.com/forum.jspa?forumID=138)
 -   Open a support ticket with [AWS Support](https://docs.aws.amazon.com/awssupport/latest/user/getting-started.html).
 -   If you think you may have found a bug, open an [issue](https://github.com/aws-observability/aws-rum-web/issues/new).
 
 ## Opening Issues
 
-If you encounter a bug with the CloudWatch RUM web client, we want to hear
-about it. Before opening a new issue, search the existing issues to see if
-others are also experiencing the issue. Include the version of the CloudWatch
-RUM Web Client, Node.js runtime, and other dependencies if applicable. In
-addition, include the repro case when appropriate.
+If you encounter a bug with the CloudWatch RUM web client, we want to hear about
+it. Before opening a new issue, [search the existing
+issues](https://github.com/aws-observability/aws-rum-web/issues?q=is%3Aissue) to
+see if others are also experiencing the issue. Include the version of the
+CloudWatch RUM web client, Node.js runtime, and other dependencies if
+applicable. In addition, include the repro case when appropriate.
 
 The GitHub issues are intended for bug reports and feature requests. For help
-and questions about using the CloudWatch RUM Web Client, use the resources
+and questions about using the CloudWatch RUM web client, use the resources
 listed in the Getting Help section. Keeping the list of open issues lean helps
 us respond in a timely manner.
 
@@ -109,9 +111,9 @@ npm run integ:local:nightwatch
 
 ## Pre-commit Tasks
 
-The RUM Web Client uses pre-commit tasks to lint and format its source code.
-Before submitting code, check that all linter and formatter warnings have been
-resolved.
+The CloudWatch RUM web client uses pre-commit tasks to lint and format its
+source code. Before submitting code, check that all linter and formatter
+warnings have been resolved.
 
 Attempt to automatically repair linter warnings:
 

--- a/docs/cdn_commands.md
+++ b/docs/cdn_commands.md
@@ -1,10 +1,22 @@
 # Executing Commands
 
-Applications which install the web client using CDN must interact with the web client through its command queue. The command queue is a function which stores commands that will be executed asynchronously by the web client.
+Applications interact with the web client either through its command queue (embedded script install), or its API (JavaScript module install).
 
-## Commands
+**Embedded script command queue**
 
-Commands may be sent to the web client after the snippet has executed. In the following example, the snippet has disabled automated page view recording and has not provided AWS credentials. Following the snippet, the application manually records a page view and forwards AWS credentials to the web client.
+The command queue is accessed through a global variable (named `cwr` by default). The command queue is a function which stores commands that will be executed asynchronously by the web client. Commands may be sent to the web client using the command queue after the snippet has executed.
+
+**JavaScript module API**
+
+Commands may be sent to the web client using the API after the `AwsRum` class has been instantiated.
+
+## Examples
+
+In the following example, the snippet has disabled automated page view recording
+and has not provided AWS credentials. Following the snippet, the application
+manually records a page view and forwards AWS credentials to the web client.
+
+**Embedded script example**
 ```html
 <script>
     (function(n,i,v,r,s,c,u,x,z){...})(
@@ -23,14 +35,29 @@ Commands may be sent to the web client after the snippet has executed. In the fo
 </script>
 ```
 
+**JavaScript module example**
+```typescript
+const awsRum: AwsRum = new AwsRum(
+    APPLICATION_ID,
+    APPLICATION_VERSION,
+    APPLICATION_REGION,
+    { disableAutoPageView: true }
+);
+awsRum.recordPageView(window.location.hash);
+const credentialProvider = new CustomCredentialProvider();
+if(awsCreds) awsRum.setAwsCredentials(credentialProvider);
+```
+
+## Commands
+
 | Command | Parameter Type | Example <div style="width:265px"></div> | Description |
 | --- | --- | --- | --- |
-| allowCookies | Boolean | `cwr('allowCookies', true);` | Enable the web client to set and read two cookies: a session cookie named `cwr_s` and a user cookie named `cwr_u`.<br/><br/>`cwr_s` stores session data including an anonymous session ID (uuid v4) created by the web client. This allows CloudWatch RUM to compute sessionized metrics like errors per session.<br/><br/>`cwr_u` stores an anonymous user ID (uuid v4) created by the web client. This allows CloudWatch RUM to count return visitors.<br/><br/>`true`: the web client will use cookies<br/>`false`: the web client will not use cookies
-| disable | None | `cwr('disable');` | Stop recording and dispatching RUM events.
-| dispatch | None | `cwr('dispatch');` | Flush RUM events from the cache and dispatch them to CloudWatch RUM using [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). 
-| dispatchBeacon | None | `cwr('dispatchBeacon');` | Flush RUM events from the cache and dispatch them to CloudWatch RUM using [`sendBeacon`](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API). 
-| enable | None | `cwr('enable');` | Start recording and dispatching RUM events.
-| recordPageView | String | `cwr('recordPageView', '/home');` | Record a page view event.<br/><br/>By default, the web client records page views when (1) the page first loads and (2) the browser's [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) is called. The page ID is `window.location.pathname`.<br/><br/>In some cases, the web client's instrumentation will not record the desired page ID. In this case, the web client's page view automation must be disabled using the `disableAutoPageView` configuration, and the application must be instrumented to record page views using this command.
-| recordError | Error \|&nbsp;ErrorEvent \|&nbsp;String | `try {...} catch(e) { cwr('recordError', e); }` | Record a caught error.
-| registerDomEvents | Array | `cwr('registerDomEvents', [{ event: 'click', cssLocator: '[label="label1"]' }]);` | Register target DOM events to record. The target DOM events will be added to existing target DOM events. The parameter type is equivalent to the `events` property type of the [interaction telemetry configuration](https://github.com/aws-observability/aws-rum-web/blob/main/docs/cdn_installation.md#interaction).
-| setAwsCredentials | [Credentials](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html) \|&nbsp;[CredentialProvider](https://www.npmjs.com/package/@aws-sdk/credential-providers) | `cwr('setAwsCredentials', cred);` | Forward AWS credentials to the web client. The web client requires AWS credentials with permission to call the `PutRumEvents` API. If you have not set `identityPoolId` and `guestRoleArn` in the web client configuration, you must forward AWS credentials to the web client using this command.
+| allowCookies | Boolean | `cwr('allowCookies', true);`<br/><br/>`awsRum.allowCookies(true)` | Enable the web client to set and read two cookies: a session cookie named `cwr_s` and a user cookie named `cwr_u`.<br/><br/>`cwr_s` stores session data including an anonymous session ID (uuid v4) created by the web client. This allows CloudWatch RUM to compute sessionized metrics like errors per session.<br/><br/>`cwr_u` stores an anonymous user ID (uuid v4) created by the web client. This allows CloudWatch RUM to count return visitors.<br/><br/>`true`: the web client will use cookies<br/>`false`: the web client will not use cookies
+| disable | None | `cwr('disable');`<br/><br/>`awsRum.disable();` | Stop recording and dispatching RUM events.
+| dispatch | None | `cwr('dispatch');`<br/><br/>`awsRum.dispatch();` | Flush RUM events from the cache and dispatch them to CloudWatch RUM using [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). 
+| dispatchBeacon | None | `cwr('dispatchBeacon');`<br/><br/>`awsRum.dispatchBeacon();` | Flush RUM events from the cache and dispatch them to CloudWatch RUM using [`sendBeacon`](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API). 
+| enable | None | `cwr('enable');`<br/><br/>`awsRum.enable();` | Start recording and dispatching RUM events.
+| recordPageView | String | `cwr('recordPageView', '/home');`<br/><br/>`awsRum.recordPageView('/home');` | Record a page view event.<br/><br/>By default, the web client records page views when (1) the page first loads and (2) the browser's [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) is called. The page ID is `window.location.pathname`.<br/><br/>In some cases, the web client's instrumentation will not record the desired page ID. In this case, the web client's page view automation must be disabled using the `disableAutoPageView` configuration, and the application must be instrumented to record page views using this command.
+| recordError | Error \|&nbsp;ErrorEvent \|&nbsp;String | `try {...} catch(e) { cwr('recordError', e); }`<br/><br/>`try {...} catch(e) { awsRum.recordError(e); }` | Record a caught error.
+| registerDomEvents | Array | `cwr('registerDomEvents', [{ event: 'click', cssLocator: '[label="label1"]' }]);`<br/><br/>`awsRum.registerDomEvent([{ event: 'click', cssLocator: '[label="label1"]' }]);` | Register target DOM events to record. The target DOM events will be added to existing target DOM events. The parameter type is equivalent to the `events` property type of the [interaction telemetry configuration](https://github.com/aws-observability/aws-rum-web/blob/main/docs/cdn_installation.md#interaction).
+| setAwsCredentials | [Credentials](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html) \|&nbsp;[CredentialProvider](https://www.npmjs.com/package/@aws-sdk/credential-providers) | `cwr('setAwsCredentials', cred);`<br/><br/>`awsRum.setAwsCredentials(cred);` | Forward AWS credentials to the web client. The web client requires AWS credentials with permission to call the `PutRumEvents` API. If you have not set `identityPoolId` and `guestRoleArn` in the web client configuration, you must forward AWS credentials to the web client using this command.

--- a/docs/cdn_installation.md
+++ b/docs/cdn_installation.md
@@ -1,18 +1,50 @@
-# Installing from CDN
+# Installing as an Embedded Script
 
-Applications may use a code snippet to install the web client from a content
-delivery network (CDN). The snippet is a self-executing function created by the
-CloudWatch RUM console. The snippet must be added to the \<head\> tag of each
-HTML file in your web application. The snippet dynamically installs the web
-client by (1) downloading the web client from a CDN, and (2) configuring the web
-client for the application it is monitoring. The snippet will look similar to
-the following:
+The CloudWatch RUM web client can be dynamically loaded into the application
+using a code snippet. The code snippet is a self-executing function created by
+the CloudWatch RUM console. The snippet (1) asynchronously downloads the web
+client from a content delivery network (CDN) or the application server and (2)
+configures the web client for the application it is monitoring.
+
+## Generate a code snippet
+
+Use the CloudWatch RUM console to generate a code snippet. See the [CloudWatch
+RUM documentation
+](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM.html)
+for instructions on how to create an AppMonitor and generate a code snippet.
+
+The snippet will look similar to the following:
 
 ```html
 <script>
 (function(n,i,v,r,s,c,u,x,z){x=window.AwsRumClient={q:[],n:n,i:i,v:v,r:r,c:c,u:u};window[n]=function(c,p){x.q.push({c:c,p:p});};z=document.createElement('script');z.async=true;z.src=s;document.head.insertBefore(z,document.getElementsByTagName('script')[0]);})('cwr','00000000-0000-0000-0000-000000000000','1.0.0','us-west-2','https://client.rum.us-east-1.amazonaws.com/1.0.2/cwr.js',{sessionSampleRate:1,guestRoleArn:'arn:aws:iam::000000000000:role/RUM-Monitor-us-west-2-000000000000-00xx-Unauth',identityPoolId:'us-west-2:00000000-0000-0000-0000-000000000000',endpoint:'https://dataplane.rum.us-west-2.amazonaws.com',telemetries:['errors','http','performance'],allowCookies:true});
 </script>
 ```
+
+## Instrument the application
+
+Copy the code snippet into the `<head>` tag of each HTML file in the web
+application.
+
+Modify the arguments to match your AppMonitor. See [Arguments](#arguments) for details.
+
+> **:warning: Ad blockers may block the default CDN**
+>
+> For convenience, AWS distributes a copy of the CloudWatch RUM web client
+through a content delivery network (CDN). The generated code snippet uses this
+CDN by default. However, ad blockers may block this CDN's domain. This disables
+application monitoring for users with ad blockers.
+>
+> To mitigate this we recommend one of the following:
+> 1. Have the web application host the CloudWatch RUM web client:<br/>
+>    a) Copy [`cwr.js`](https://client.rum.us-east-1.amazonaws.com/1.x/cwr.js) to the assets directory of the web application<br/>
+>    b) Modify the code snippet to use the copy of `cwr.js` from (a).
+> 2. Install the CloudWatch RUM web client as a [JavaScript module](https://www.npmjs.com/package/aws-rum-web).
+
+Modify the `config` object to configure how the web client should behave. At a
+minimum, configure the following: (1) how the data will be authenticated, and
+(2) what aspects of the application will be monitored. See
+[Application-specific Configurations](configuration.md) for details.
 
 ## Arguments
 
@@ -25,7 +57,7 @@ The code snippet accepts six arguments. The snippet below shows these arguments 
         '1.0.0',
         'us-west-2',
         'https://client.rum.us-east-1.amazonaws.com/1.0.2/cwr.js',
-        { /* Configuration */ }
+        { /* configuration */ }
     );
 </script>
 ```
@@ -37,9 +69,9 @@ The code snippet accepts six arguments. The snippet below shows these arguments 
 | 3 | Application Version | String | Your application's semantic version. If you do not wish to use this field then add any placeholder, such as `'0.0.0'`. |
 | 4 | Region | String |  The AWS region of the AppMonitor. For example, `'us-east-1'` or '`eu-west-2'`. |
 | 5 | Web Client URL | String |  The URL of the web client bundle. For example, `'https://client.rum.us-east-1.amazonaws.com/1.0.2/cwr.js'`|
-| 6 | Configuration | [Configuration](#configuration) | An application-specific configuration for the web client. |
+| 6 | Configuration | [Configuration](configuration.md) | An application-specific configuration for the web client. |
 
-## Configuration
+## Configuring the CloudWatch RUM web client
 
 The application-specific web client configuration is a JavaScript object whose fields are all optional. While these fields are optional, depending on your application the web client may not function properly if certain fields are omitted. For example, `identityPoolId` and `guestRoleArn` are both required unless your application performs its own AWS authentication and passes the credentials to the web client using the command `cwr('setAwsCredentials', {...});`.
 
@@ -64,83 +96,4 @@ The snippet below shows several configuration options with the body of the snipp
 </script>
 ```
 
-| Field Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| allowCookies | Boolean | `false` | Enable the web client to set and read two cookies: a session cookie named `cwr_s` and a user cookie named `cwr_u`.<br/><br/>`cwr_s` stores session data including an anonymous session ID (uuid v4) created by the web client. This allows CloudWatch RUM to compute sessionized metrics like errors per session.<br/><br/>`cwr_u` stores an anonymous user ID (uuid v4) created by the web client. This allows CloudWatch RUM to count return visitors.<br/><br/>`true`: the web client will use cookies<br/>`false`: the web client will not use cookies. |
-| cookieAttributes | [CookieAttributes](#cookieattributes) | `{ domain: window.location.hostname, path: '/', sameSite: 'Strict', secure: true } ` | Cookie attributes are applied to all cookies stored by the web client, including `cwr_s` and `cwr_u`. |
-| disableAutoPageView | Boolean | `false` | When this field is `false`, the web client will automatically record page views.<br/><br/>By default, the web client records page views when (1) the page first loads and (2) the browser's [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) is called. The page ID is `window.location.pathname`.<br/><br/>In some cases, the web client's instrumentation will not record the desired page ID. In this case, the web client's page view automation must be disabled using the `disableAutoPageView` configuration, and the application must be instrumented to record page views using the `recordPageView` command. |
-| enableRumClient | Boolean | `true` | When this field is `true`, the web client will record and dispatch RUM events. |
-| enableXRay | Boolean | `false` | When this field is `true` **and** the `http` telemetry is used, the web client will record X-Ray traces for HTTP requests.<br/><br/>See the [HTTP telemetry configuration](#http) for more information, including how to connect client-side and server-side traces. |
-| endpoint | String | `'https://dataplane.rum.[region].amazonaws.com'` | The URL of the CloudWatch RUM API where data will be sent. |
-| guestRoleArn | String | `undefined` | The ARN of the AWS IAM role that will be assumed during anonymous authorization.<br/><br/>When this field is set (along with `identityPoolId`), the web client will attempt to retrieve temporary AWS credentials through Cognito using `AssumeRoleWithWebIdentity`. If this field is not set, you must forward credentials to the web client using the `setAwsCredentials` command. |
-| identityPoolId | String | `undefined` | The Amazon Cognito Identity Pool ID that will be used during anonymous authorization.<br/><br/>When this field is set (along with `guestRoleArn`), the web client will attempt to retrieve temporary AWS credentials through Cognito using `AssumeRoleWithWebIdentity`. If this field is not set, you must forward credentials to the web client using the `setAwsCredentials` command. |
-| pageIdFormat | String | `'PATH'` | The portion of the `window.location` that will be used as the page ID. Options include `PATH`, `HASH` and `PATH_AND_HASH`.<br/><br/>For example, consider the URL `https://amazonaws.com/home?param=true#content`<br/><br/>`PATH`: `/home`<br/>`HASH`: `#content`<br/>`PATH_AND_HASH`: `/home#content` |
-| pagesToInclude | RegExp[] | `[]` | A list of regular expressions which specify the `window.location` values for which the web client will record data. Pages are matched using the `RegExp.test()` function.<br/><br/>For example, when `pagesToInclude: [ /\/home/ ]`, then data from `https://amazonaws.com/home` will be included,  and `https://amazonaws.com/` will not be included. |
-| pagesToExclude | RegExp[] | `[]` | A list of regular expressions which specify the `window.location` values for which the web client will record data. Pages are matched using the `RegExp.test()` function.<br/><br/>For example, when `pagesToExclude: [ /\/home/ ]`, then data from `https://amazonaws.com/home` will be excluded,  and `https://amazonaws.com/` will not be excluded. |
-| recordResourceUrl | Boolean | `true` | When this field is `false`, the web client will not record the URLs of resources downloaded by your application.<br/><br/> Some types of resources (e.g., profile images) may be referenced by URLs which contain PII. If this applies to your application, you must set this field to `false` to comply with CloudWatch RUM's shared responsibility model. |
-| sessionEventLimit | Number | `200` | The maximum number of events to record during a single session. |
-| sessionSampleRate | Number | `1` | The proportion of sessions that will be recorded by the web client, specified as a unit interval (a number greater than or equal to 0 and less than or equal to 1). When this field is `0`, no sessions will be recorded. When this field is `1`, all sessions will be recorded. |
-| telemetries | [Telemetry Config Array](#telemetry-config-array) | `[]` | See [Telemetry Config Array](#telemetry-config-array) |
-
-## CookieAttributes
-
-| Field Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| domain | String | `window.location.hostname` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
-| path | String | `/` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
-| sameSite | Boolean | `true` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
-| secure | Boolean | `true` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
-| unique | Boolean | `false` | When this field is `false`, the session cookie name is `cwr_s`. When this field is true `true`, the session cookie name is `cwr_s_[AppMonitor Id]`.<br/><br/>Set this field to `true` when multiple AppMonitors will monitor the same page. For example, this might be the case if one AppMonitor is used for logged-in users, and a second AppMonitor is used for guest users.  |
-
-## Telemetry Config Array
-
-You must configure the types of RUM telemetry you wish to perform on your application. Each telemetry records a different category of data. Specifically, performance (load timing), errors, HTTP requests and DOM events.
-
-The telemetry config array is an array of telemetry configurations. A telemetry configuration is either (1) a string containing the telemetry's name, or (2) an array containing the telemetry's name in position 0 and an object containing the telemetry's configuration in position 1.
-
-For example, the following telemetry config arrays are both valid. The one on the top uses default configurations while the one on the bottom provides partial configurations for the `'errors'` and `'http'` telemetries.
-```javascript
-telemetries: [ 'errors', 'performance', 'http' ]
-```
-```javascript
-telemetries: [ 
-    [ 'errors', { stackTraceLength: 500 } ], 
-    'performance',
-    [ 'http', { stackTraceLength: 500, addXRayTraceIdHeader: true } ]
-]
-```
-
-| Telemetry&nbsp;Name | Description |
-| ----------- | ----------- |
-| errors | Record JavaScript errors. By default, this telemetry will only record unhandled JavaScript errors. See [Errors](#errors). |
-| http | Record HTTP requests. By default, this telemetry will only record failed requests; i.e., requests that have network failures, or whose responses contain a non-2xx status code. See [HTTP](#http) <br/><br/> This telemetry is required to enable  X-Ray tracing. |
-| interaction | Record DOM events. By default, this telemetry will not record data. The telemetry must be configured to record specific DOM events. See [Interaction](#interaction) |
-| performance | Record performance data including page load timing, web vitals, and resource load timing. See [Performance](#performance) |
-
-## Errors
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| stackTraceLength | Number | `200` | The number of characters to record from a JavaScript error's stack trace (if available). |
-
-## HTTP
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| urlsToInclude | RegExp[] | `[/.*/]` | A list of HTTP request (`XMLHttpRequest` or `fetch`) URLs. These requests will be recorded, unless explicitly excluded by `urlsToExclude`. |
-| urlsToExclude | RegExp[] | `[]` | A list of HTTP request (`XMLHttpRequest` or `fetch`) URLs. These requests will not be recorded. |
-| stackTraceLength | Number | `200 ` | The number of characters to record from a JavaScript error's stack trace (if available). |
-| recordAllRequests | boolean | `false` | By default, only HTTP failed requests (i.e., those with network errors or status codes which are not 2xx) are recorded. When this field is `true`, the http telemetry will record all requests, including those with successful 2xx status codes. <br/><br/>This field does **does not apply** to X-Ray traces, where all requests are recorded. |
-| addXRayTraceIdHeader | boolean | `false` | By default, the `X-Amzn-Trace-Id` header will not be added to the HTTP request. This means that the client-side trace and server-side trace will **not be linked** in X-Ray or the ServiceLens graph.<br/><br/> When this field is `true`, the `X-Amzn-Trace-Id` header will be added to HTTP requests (`XMLHttpRequest` or `fetch`). **Adding the header is dangerous and you must test your application before setting this field to `true` in a production environment.** The header could cause CORS to fail or invalidate the request's signature if the request is signed with sigv4.
-
-## Interaction
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| events | Array | `[]` | An array of target DOM events to record. Each DOM event is defined by an *event* and a *selector*. The event must be a [DOM event](https://www.w3schools.com/jsref/dom_obj_event.asp). The selector must be one of (1) `cssLocator`, (2) `elementId` or (3) `element`.<br/><br/>When two or more selectors are provided for a target DOM event, only one selector will be used. The selectors will be honored with the following precedence: (1) `cssLocator`, (2) `elementId` or (3) `element`. For example, if both `cssLocator` and `elementId` are provided, only the `cssLocator` selector will be used.<br/><br/>**Examples:**<br/>Record all elements identified by CSS selector `[label="label1"]`:<br/> `[{ event: 'click', cssLocator: '[label="label1"]' }]`<br/><br/>Record a single element with ID `mybutton`:<br/>`[{ event: 'click', elementId: 'mybutton' }]`<br/><br/>Record a complete clickstream<br/>`[{ event: 'click', element: document }]`. |
-
-## Performance
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| eventLimit | Number | `10` | The maximum number of resources to record load timing. <br/><br/>There may be many similar resources on a page (e.g., images) and recording all resources may add expense without adding value. The web client records all HTML files and JavaScript files, while recording a sample of stylesheets, images and fonts. Increasing the event limit increases the maximum number of sampled resources. |
+For a complete list of configuration options, see [Application-specific Configurations](docs/configuration.md).

--- a/docs/cdn_troubleshooting.md
+++ b/docs/cdn_troubleshooting.md
@@ -165,11 +165,12 @@ client will then add the `X-Amzn-Trace-Id` header in each HTTP request. The
 example below shows what this configuration looks like, with all other
 configurations removed for readability.
 
-> :warning: Enabling `addXRayTraceIdHeader` will cause a new header to be added
-to all HTTP requests. Adding headers can modify CORS behavior, including causing
-the request to fail. Adding headers may also alter  the request signature,
-causing the request to fail. Test your application with this header enabled
-before enabling this option in a production environment.
+> **:warning: Enabling `addXRayTraceIdHeader` may cause HTTP requests to fail.**
+>
+> Enabling `addXRayTraceIdHeader` adds a header to HTTP requests. Adding headers
+can modify CORS behavior, including causing the request to fail. Adding headers
+may also alter  the request signature, causing the request to fail. Test your
+application before enabling this option in a production environment.
 
 ```html
 <script>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,100 @@
+# Application-specific Configurations
+
+The application being monitored must provided an application-specific
+configuration to the CloudWatch RUM web client. The configuration tells the web
+client what to monitor and how to monitor.
+
+For example, the config object may look similar to the following:
+```javascript
+{
+    allowCookies: true,
+    endpoint: "https://dataplane.rum.us-west-2.amazonaws.com",
+    guestRoleArn: "arn:aws:iam::000000000000:role/RUM-Monitor-us-west-2-000000000000-00xx-Unauth",
+    identityPoolId: "us-west-2:00000000-0000-0000-0000-000000000000",
+    sessionSampleRate: 1,
+    telemetries: ['errors', 'performance', 'http']
+}
+```
+
+## Configuration Options
+
+| Field Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| allowCookies | Boolean | `false` | Enable the web client to set and read two cookies: a session cookie named `cwr_s` and a user cookie named `cwr_u`.<br/><br/>`cwr_s` stores session data including an anonymous session ID (uuid v4) created by the web client. This allows CloudWatch RUM to compute sessionized metrics like errors per session.<br/><br/>`cwr_u` stores an anonymous user ID (uuid v4) created by the web client. This allows CloudWatch RUM to count return visitors.<br/><br/>`true`: the web client will use cookies<br/>`false`: the web client will not use cookies. |
+| cookieAttributes | [CookieAttributes](#cookieattributes) | `{ domain: window.location.hostname, path: '/', sameSite: 'Strict', secure: true } ` | Cookie attributes are applied to all cookies stored by the web client, including `cwr_s` and `cwr_u`. |
+| disableAutoPageView | Boolean | `false` | When this field is `false`, the web client will automatically record page views.<br/><br/>By default, the web client records page views when (1) the page first loads and (2) the browser's [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) is called. The page ID is `window.location.pathname`.<br/><br/>In some cases, the web client's instrumentation will not record the desired page ID. In this case, the web client's page view automation must be disabled using the `disableAutoPageView` configuration, and the application must be instrumented to record page views using the `recordPageView` command. |
+| enableRumClient | Boolean | `true` | When this field is `true`, the web client will record and dispatch RUM events. |
+| enableXRay | Boolean | `false` | When this field is `true` **and** the `http` telemetry is used, the web client will record X-Ray traces for HTTP requests.<br/><br/>See the [HTTP telemetry configuration](#http) for more information, including how to connect client-side and server-side traces. |
+| endpoint | String | `'https://dataplane.rum.[region].amazonaws.com'` | The URL of the CloudWatch RUM API where data will be sent. |
+| guestRoleArn | String | `undefined` | The ARN of the AWS IAM role that will be assumed during anonymous authorization.<br/><br/>When this field is set (along with `identityPoolId`), the web client will attempt to retrieve temporary AWS credentials through Cognito using `AssumeRoleWithWebIdentity`. If this field is not set, you must forward credentials to the web client using the `setAwsCredentials` command. |
+| identityPoolId | String | `undefined` | The Amazon Cognito Identity Pool ID that will be used during anonymous authorization.<br/><br/>When this field is set (along with `guestRoleArn`), the web client will attempt to retrieve temporary AWS credentials through Cognito using `AssumeRoleWithWebIdentity`. If this field is not set, you must forward credentials to the web client using the `setAwsCredentials` command. |
+| pageIdFormat | String | `'PATH'` | The portion of the `window.location` that will be used as the page ID. Options include `PATH`, `HASH` and `PATH_AND_HASH`.<br/><br/>For example, consider the URL `https://amazonaws.com/home?param=true#content`<br/><br/>`PATH`: `/home`<br/>`HASH`: `#content`<br/>`PATH_AND_HASH`: `/home#content` |
+| pagesToInclude | RegExp[] | `[]` | A list of regular expressions which specify the `window.location` values for which the web client will record data. Pages are matched using the `RegExp.test()` function.<br/><br/>For example, when `pagesToInclude: [ /\/home/ ]`, then data from `https://amazonaws.com/home` will be included,  and `https://amazonaws.com/` will not be included. |
+| pagesToExclude | RegExp[] | `[]` | A list of regular expressions which specify the `window.location` values for which the web client will record data. Pages are matched using the `RegExp.test()` function.<br/><br/>For example, when `pagesToExclude: [ /\/home/ ]`, then data from `https://amazonaws.com/home` will be excluded,  and `https://amazonaws.com/` will not be excluded. |
+| recordResourceUrl | Boolean | `true` | When this field is `false`, the web client will not record the URLs of resources downloaded by your application.<br/><br/> Some types of resources (e.g., profile images) may be referenced by URLs which contain PII. If this applies to your application, you must set this field to `false` to comply with CloudWatch RUM's shared responsibility model. |
+| sessionEventLimit | Number | `200` | The maximum number of events to record during a single session. |
+| sessionSampleRate | Number | `1` | The proportion of sessions that will be recorded by the web client, specified as a unit interval (a number greater than or equal to 0 and less than or equal to 1). When this field is `0`, no sessions will be recorded. When this field is `1`, all sessions will be recorded. |
+| telemetries | [Telemetry Config Array](#telemetry-config-array) | `[]` | See [Telemetry Config Array](#telemetry-config-array) |
+
+## CookieAttributes
+
+| Field Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| domain | String | `window.location.hostname` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
+| path | String | `/` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
+| sameSite | Boolean | `true` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
+| secure | Boolean | `true` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
+| unique | Boolean | `false` | When this field is `false`, the session cookie name is `cwr_s`. When this field is true `true`, the session cookie name is `cwr_s_[AppMonitor Id]`.<br/><br/>Set this field to `true` when multiple AppMonitors will monitor the same page. For example, this might be the case if one AppMonitor is used for logged-in users, and a second AppMonitor is used for guest users.  |
+
+## Telemetry Config Array
+
+You must configure the types of RUM telemetry you wish to perform on your application. Each telemetry records a different category of data. Specifically, performance (load timing), errors, HTTP requests and DOM events.
+
+The telemetry config array is an array of telemetry configurations. A telemetry configuration is either (1) a string containing the telemetry's name, or (2) an array containing the telemetry's name in position 0 and an object containing the telemetry's configuration in position 1.
+
+For example, the following telemetry config arrays are both valid. The one on the top uses default configurations while the one on the bottom provides partial configurations for the `'errors'` and `'http'` telemetries.
+```javascript
+telemetries: [ 'errors', 'performance', 'http' ]
+```
+```javascript
+telemetries: [ 
+    [ 'errors', { stackTraceLength: 500 } ], 
+    'performance',
+    [ 'http', { stackTraceLength: 500, addXRayTraceIdHeader: true } ]
+]
+```
+
+| Telemetry&nbsp;Name | Description |
+| ----------- | ----------- |
+| errors | Record JavaScript errors. By default, this telemetry will only record unhandled JavaScript errors. See [Errors](#errors). |
+| http | Record HTTP requests. By default, this telemetry will only record failed requests; i.e., requests that have network failures, or whose responses contain a non-2xx status code. See [HTTP](#http) <br/><br/> This telemetry is required to enable  X-Ray tracing. |
+| interaction | Record DOM events. By default, this telemetry will not record data. The telemetry must be configured to record specific DOM events. See [Interaction](#interaction) |
+| performance | Record performance data including page load timing, web vitals, and resource load timing. See [Performance](#performance) |
+
+## Errors
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| stackTraceLength | Number | `200` | The number of characters to record from a JavaScript error's stack trace (if available). |
+
+## HTTP
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| urlsToInclude | RegExp[] | `[/.*/]` | A list of HTTP request (`XMLHttpRequest` or `fetch`) URLs. These requests will be recorded, unless explicitly excluded by `urlsToExclude`. |
+| urlsToExclude | RegExp[] | `[]` | A list of HTTP request (`XMLHttpRequest` or `fetch`) URLs. These requests will not be recorded. |
+| stackTraceLength | Number | `200 ` | The number of characters to record from a JavaScript error's stack trace (if available). |
+| recordAllRequests | boolean | `false` | By default, only HTTP failed requests (i.e., those with network errors or status codes which are not 2xx) are recorded. When this field is `true`, the http telemetry will record all requests, including those with successful 2xx status codes. <br/><br/>This field does **does not apply** to X-Ray traces, where all requests are recorded. |
+| addXRayTraceIdHeader | boolean | `false` | By default, the `X-Amzn-Trace-Id` header will not be added to the HTTP request. This means that the client-side trace and server-side trace will **not be linked** in X-Ray or the ServiceLens graph.<br/><br/> When this field is `true`, the `X-Amzn-Trace-Id` header will be added to HTTP requests (`XMLHttpRequest` or `fetch`). **Adding the header is dangerous and you must test your application before setting this field to `true` in a production environment.** The header could cause CORS to fail or invalidate the request's signature if the request is signed with sigv4.
+
+## Interaction
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| events | Array | `[]` | An array of target DOM events to record. Each DOM event is defined by an *event* and a *selector*. The event must be a [DOM event](https://www.w3schools.com/jsref/dom_obj_event.asp). The selector must be one of (1) `cssLocator`, (2) `elementId` or (3) `element`.<br/><br/>When two or more selectors are provided for a target DOM event, only one selector will be used. The selectors will be honored with the following precedence: (1) `cssLocator`, (2) `elementId` or (3) `element`. For example, if both `cssLocator` and `elementId` are provided, only the `cssLocator` selector will be used.<br/><br/>**Examples:**<br/>Record all elements identified by CSS selector `[label="label1"]`:<br/> `[{ event: 'click', cssLocator: '[label="label1"]' }]`<br/><br/>Record a single element with ID `mybutton`:<br/>`[{ event: 'click', elementId: 'mybutton' }]`<br/><br/>Record a complete clickstream<br/>`[{ event: 'click', element: document }]`. |
+
+## Performance
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| eventLimit | Number | `10` | The maximum number of resources to record load timing. <br/><br/>There may be many similar resources on a page (e.g., images) and recording all resources may add expense without adding value. The web client records all HTML files and JavaScript files, while recording a sample of stylesheets, images and fonts. Increasing the event limit increases the maximum number of sampled resources. |

--- a/docs/npm_installation.md
+++ b/docs/npm_installation.md
@@ -1,0 +1,81 @@
+# Installing as a JavaScript Module
+
+The CloudWatch RUM web client can be built into the application's JavaScript
+bundle using the provided CommonJS or ES modules. The recommended method to
+consume and manage the web client dependency is to use the web client's [NPM
+package](https://www.npmjs.com/package/aws-rum-web).
+
+## Install the package from NPM
+
+```bash
+npm install --save aws-rum-web
+```
+
+## Instrument the application
+
+The following code shows an example of how to instrument an application. This code should run as early as possible in the application's lifecycle.
+
+```typescript
+import { AwsRum, AwsRumConfig } from 'aws-rum-web';
+
+try {
+  const config: AwsRumConfig = {
+    allowCookies: true,
+    endpoint: "https://dataplane.rum.us-west-2.amazonaws.com",
+    guestRoleArn: "arn:aws:iam::000000000000:role/RUM-Monitor-us-west-2-000000000000-00xx-Unauth",
+    identityPoolId: "us-west-2:00000000-0000-0000-0000-000000000000",
+    sessionSampleRate: 1,
+    telemetries: ['errors', 'performance']
+  };
+
+  const APPLICATION_ID: string = '00000000-0000-0000-0000-000000000000';
+  const APPLICATION_VERSION: string = '1.0.0';
+  const APPLICATION_REGION: string = 'us-west-2';
+
+  const awsRum: AwsRum = new AwsRum(
+    APPLICATION_ID,
+    APPLICATION_VERSION,
+    APPLICATION_REGION,
+    config
+  );
+} catch (error) {
+  // Ignore errors thrown during CloudWatch RUM web client initialization
+}
+```
+
+Modify the `AwsRum` constructor arguments to match your AppMonitor. See [Arguments](#arguments) for details.
+
+Modify the `config` object to configure how the web client should behave. For
+example, you should minimally configure (1) how the data will be authenticated,
+and (2) what aspects of the application will be monitored. See
+[Configuration](#configuration) for details.
+
+## Arguments
+
+| Argument&nbsp;Name | Type | Description |
+| --- | --- | --- |
+| AppMonitor ID | String | A globally unique identifier for the CloudWatch RUM AppMonitor which monitors your application. |
+| Application Version | String | The application's semantic version. If you do not wish to use this field then add any placeholder, such as `'0.0.0'`. |
+| Region | String | The AWS region of the AppMonitor. For example, `'us-east-1'` or '`eu-west-2'`. |
+| Configuration | [Configuration](#configuration) | The application-specific configuration for the web client. |
+
+## Configuration
+
+The application-specific web client configuration is a JavaScript object whose fields are all optional. While these fields are optional, depending on your application the web client may not function properly if certain fields are omitted. For example, `identityPoolId` and `guestRoleArn` are both required unless your application performs its own AWS authentication and passes the credentials to the web client using the command `awsRum.setAwsCredentials({...});`.
+
+To get started, we recommend using the following configuration. The
+`guestRoleArn` and `identityPoolId` shown are dummy values. Modify these to
+match the resources created when setting up the AppMonitor:
+
+```typescript
+const config: AwsRumConfig = {
+    allowCookies: true,
+    endpoint: "https://dataplane.rum.us-west-2.amazonaws.com",
+    guestRoleArn: "arn:aws:iam::000000000000:role/RUM-Monitor-us-west-2-000000000000-00xx-Unauth",
+    identityPoolId: "us-west-2:00000000-0000-0000-0000-000000000000",
+    sessionSampleRate: 1,
+    telemetries: ['errors', 'performance']
+};
+```
+
+For a complete list of configuration options, see [Application-specific Configurations](docs/configuration.md).


### PR DESCRIPTION
The RUM web client has been added to one or more ad-block lists. This can disable telemetry for browsers with ad blockers installed.

This change (1) adds documentation on the NPM installation process, and (2) adds guidance to application owners to work around this issue by either hosting the web client bundle as an application assets, or importing the web client into the application code as a JavaScript module.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
