### PR TITLE
docs: Add SPA troubleshooting

### DIFF
--- a/docs/cdn_troubleshooting.md
+++ b/docs/cdn_troubleshooting.md
@@ -206,21 +206,3 @@ application before enabling this option in a production environment.
     );
 </script>
 ```
----
-## Route change timing is not recorded for my single page application
-
-### Configuring `routeChangeTimeout`
-The current mechanism to calculate a route change (virtual page load) is the difference between the latest completion time of a DOM mutation or an outgoing AJAX request and the user interaction that triggered the route change.
-
-In cases where a route change gets stuck or takes an extremely long time to load, it can cause severe skews to the page load timing data. To mitigate this issue, we have defined a configurable value called `routeChangeTimeout`, which has a default value of 10000 (10s). As a result, any route changes that take longer than the `routeChangeTimeout` will not be recorded.
-
-If your application is heavy and takes longer than 10 seconds to load on average, increasing the `routeChangeTimeout` value will allow the web client to capture the page load timing data.
-
-### Latest Interaction Time
-Currently, CW RUM captures the latest user interaction by listening to user clicks and key presses. The latest interaction time is not guaranteed to be the real user interaction that triggered a route change. As a result, CW RUM needs to determine whether the latest user interaction is responsible for the route change.
-
-We consider two cases:
-1. Latest user interaction is older than actual user interaction: this can happen if the user navigates with the browser back/forward button, or if the interaction is not a click/keyup event.
-2. Latest user interaction is newer than actual user interaction: This can happen if the user clicks or types in the time between actual and when route change is ongoing.
-
-Case (1) has a risk of skewing the route change timing data as (1) browser navigation is common and (2) there is no limit on when the latest interaction may have occurred. To help mitigate this, we have defined a window of 1s to determine whether the latest user interaction is responsible for the route change. If the difference between the route change detection time and the latest user interaction is greater than 1s, we do not time the route change to prevent data skew.

--- a/docs/cdn_troubleshooting.md
+++ b/docs/cdn_troubleshooting.md
@@ -17,12 +17,22 @@ anonymous Cognito identity using `identityPoolId` and `guestRoleArn`, or (2)
 provide the web client with AWS credentials using the `cwr('setAwsCredentials',
 credentials);` command.
 
-### Understanding `sessionEventLimit`
-`sessionEventLimit` defines the number of events the RUM web client will record under one session, and the current default value is set to 200.
+### Event limit is reached for the session
 
-For example, if your `sessionEventLimit` is set to 200 and a user performs a series of interactions to generate more than 200 events, the web client will record and send only up to 200.
+If the the web client initially sends data, but stops sending data after a
+period of time, the likely cause is that the session event limit has been
+reached. By default, the web client limits the number of recorded events to 200
+per session.
 
-Increasing the `sessionEventLimit` has cost implications as the web client will send more events, but if you wish to record and send all events, try setting `sessionEventLimit: 0` in the web client configuration.
+The configuration field [`sessionEventLimit`](configuration.md) controls this
+limit. If you wish to remove this limit completely, set `sessionEventLimit: 0`.
+
+```typescript
+const config: AwsRumConfig = {
+  // Record an unlimited number of events per session
+  sessionEventLimit: 0
+}
+```
 
 ---
 ## CloudWatch RUM returns 403
@@ -197,7 +207,7 @@ application before enabling this option in a production environment.
 </script>
 ```
 ---
-## Cloudwatch RUM does not capture page load timing data for my single page application (SPA)
+## Route change timing is not recorded for my single page application
 
 ### Configuring `routeChangeTimeout`
 The current mechanism to calculate a route change (virtual page load) is the difference between the latest completion time of a DOM mutation or an outgoing AJAX request and the user interaction that triggered the route change.


### PR DESCRIPTION
The RUM Web Client supports SPA timing feature as of v1.5.0 release. 

This change (1) adds documentation regarding common questions customers may have regarding the SPA feature (2) adds documentation regarding `sessionEventLimit` under `Events are not being sent by the web client to CloudWatch RUM`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
