### PR TITLE
fix: 🐛 fix issue that decrement fetch counter was called always

### DIFF
--- a/src/sessions/VirtualPageLoadTimer.ts
+++ b/src/sessions/VirtualPageLoadTimer.ts
@@ -168,7 +168,7 @@ export class VirtualPageLoadTimer extends MonkeyPatched {
             .catch((error) => {
                 throw error;
             })
-            .finally(self.decrementFetchCounter());
+            .finally(self.decrementFetchCounter.bind(self));
     };
 
     /**

--- a/src/sessions/VirtualPageLoadTimer.ts
+++ b/src/sessions/VirtualPageLoadTimer.ts
@@ -162,13 +162,12 @@ export class VirtualPageLoadTimer extends MonkeyPatched {
         input: RequestInfo,
         init?: RequestInit
     ): Promise<Response> => {
-        const self = this;
         return original
             .apply(thisArg, argsArray)
             .catch((error) => {
                 throw error;
             })
-            .finally(self.decrementFetchCounter.bind(self));
+            .finally(this.decrementFetchCounter);
     };
 
     /**
@@ -190,12 +189,12 @@ export class VirtualPageLoadTimer extends MonkeyPatched {
         };
     };
 
-    private decrementFetchCounter() {
+    private decrementFetchCounter = () => {
         if (!this.isPageLoaded) {
             this.latestEndTime = Date.now();
         }
         this.fetchCounter -= 1;
-    }
+    };
 
     /**
      * Checks whether the virtual page is still being loaded.

--- a/src/sessions/__tests__/VirtualPageLoadTimer.test.ts
+++ b/src/sessions/__tests__/VirtualPageLoadTimer.test.ts
@@ -207,6 +207,28 @@ describe('VirtualPageLoadTimer tests', () => {
         expect(virtualPageLoadTimer['ongoingRequests'].size).toEqual(0);
     });
 
+    test('when fetch is fetch counter should be updated to 1 until finished', async () => {
+        // Init
+        const virtualPageLoadTimer = new VirtualPageLoadTimer(
+            pageManager,
+            config,
+            record
+        );
+
+        // Mocking Date.now to return 100 to simulate time passed
+        Date.now = jest.fn(() => 100);
+        virtualPageLoadTimer.startTiming();
+
+        // When fetch initially is sent, fetchCounter should be incremented to 1
+        const fetching = fetch('https://aws.amazon.com');
+        expect(virtualPageLoadTimer['fetchCounter']).toEqual(1);
+
+        await fetching;
+
+        // Upon completion, fetchCounter should be decremented to 0
+        expect(virtualPageLoadTimer['fetchCounter']).toEqual(0);
+    });
+
     test('when fetch is detected during route change then latestEndTime is updated', async () => {
         // Init
         const virtualPageLoadTimer = new VirtualPageLoadTimer(


### PR DESCRIPTION
Basically the finally call of fetch was not only being called on
finally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
