### PR TITLE
feat: 🎸 cancel ci runs that are currently running on push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     unit-test:
         name: Check Format and Run Unit Tests


### PR DESCRIPTION
See docs here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Prevents multiple runs of a branch running at the same time

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
