### PR TITLE
chore: Update CHANGELOG link in GitHub Release workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -63,6 +63,6 @@ jobs:
               with:
                   tag_name: 'v${{ steps.publish-cdn.outputs.current-version }}'
                   release_name: 'Release ${{ steps.publish-cdn.outputs.current-version }}'
-                  body: 'See [CHANGELOG](https://github.com/aws/aws-rum-web/blob/master/CHANGELOG.md) for details.'
+                  body: 'See [CHANGELOG](https://github.com/aws-observability/aws-rum-web/blob/main/CHANGELOG.md) for details.'
                   draft: true
                   prerelease: false


### PR DESCRIPTION
### Details

The current CHANGELOG link that is generated as part of the release workflow is broken/outdated.

This PR changes the CHANGELOG link with the correct path.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
