### PR TITLE
fix: Remove duplicate PageIdFormat type in orchestration

### DIFF
--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -48,8 +48,6 @@ export type Telemetry = string | (string | object)[];
 
 export type PageIdFormat = 'PATH' | 'HASH' | 'PATH_AND_HASH';
 
-export type PageIdFormat = 'PATH' | 'HASH' | 'PATH_AND_HASH';
-
 export type PartialCookieAttributes = {
     unique?: boolean;
     domain?: string;


### PR DESCRIPTION
## Problem
While merging #156 and #153 , there is a duplicate line of code that initializes `PageIdFormat`, which is breaking all tests that are run as part of CI.
This PR fixes the issue by removing the duplicate initialization.

## Test
Tested on local

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
