### PR TITLE
Ignore errors

### DIFF
--- a/app/js_error_event.html
+++ b/app/js_error_event.html
@@ -38,6 +38,18 @@
                 throw 'thrown string';
             }
 
+            function throwObserverLoopError() {
+                throw 'ResizeObserver loop limit exceeded';
+                throw new Error('ResizeObserver loop limit exceeded');
+            }
+
+            function recordObserverLoopError() {
+                cwr(
+                    'recordError',
+                    new Error('ResizeObserver loop limit exceeded')
+                );
+            }
+
             function recordCaughtError() {
                 cwr('recordError', new Error('My error message'));
             }
@@ -83,6 +95,15 @@
         </button>
         <button id="recordCaughtError" onclick="recordCaughtError()">
             Record caught error
+        </button>
+        <button id="resizeObserverLoopError" onclick="throwObserverLoopError()">
+            Throw ResizeObserverLoopError
+        </button>
+        <button
+            id="recordObserverLoopError"
+            onclick="recordObserverLoopError()"
+        >
+            Record ResizeObserverLoopError
         </button>
         <button id="disable" onclick="disable()">Disable</button>
         <button id="enable" onclick="enable()">Enable</button>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,16 @@ telemetries: [ 'errors', 'performance', 'http' ]
 ```
 ```javascript
 telemetries: [ 
-    [ 'errors', { stackTraceLength: 500 } ], 
+    [ 'errors', { 
+        stackTraceLength: 500, 
+        filter: (errorEvent) => {
+            const patternsToIgnore = [/ResizeObserver loop/, /undefined/];
+            return (
+                patternsToIgnore.filter((pattern) =>
+                    patternsToIgnore.test(errorEvent.message)
+                ).length !== 0
+            );
+        }} ], 
     'performance',
     [ 'http', { stackTraceLength: 500, addXRayTraceIdHeader: true } ]
 ]
@@ -78,6 +87,8 @@ telemetries: [
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | stackTraceLength | Number | `200` | The number of characters to record from a JavaScript error's stack trace (if available). |
+| filter | Function | `() => false` | By default, the web client will record all errors. If you wish to filter out certain errors, pass in a function that will return true if the error should be ignored, similar to the example above. |
+
 
 ## HTTP
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,17 +59,8 @@ For example, the following telemetry config arrays are both valid. The one on th
 telemetries: [ 'errors', 'performance', 'http' ]
 ```
 ```javascript
-telemetries: [ 
-    [ 'errors', { 
-        stackTraceLength: 500, 
-        filter: (errorEvent) => {
-            const patternsToIgnore = [/ResizeObserver loop/, /undefined/];
-            return (
-                patternsToIgnore.filter((pattern) =>
-                    patternsToIgnore.test(errorEvent.message)
-                ).length !== 0
-            );
-        }} ], 
+telemetries: [
+    [ 'errors', { stackTraceLength: 500 } ],
     'performance',
     [ 'http', { stackTraceLength: 500, addXRayTraceIdHeader: true } ]
 ]
@@ -87,8 +78,29 @@ telemetries: [
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | stackTraceLength | Number | `200` | The number of characters to record from a JavaScript error's stack trace (if available). |
-| filter | Function | `() => false` | By default, the web client will record all errors. If you wish to filter out certain errors, pass in a function that will return true if the error should be ignored, similar to the example above. |
+| ignore | Function | `() => false` | A function which accepts an [`ErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent) or a [`PromiseRejectionEvent`](https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent) and returns a value that coerces to true when the error should be ignored. By default, no errors are ignored. |
 
+For example, the following telemetry config array causes the web client to ignore all errors whose message begins with "Warning:".
+
+```javascript
+telemetries: [
+    [
+        'errors',
+        {
+            stackTraceLength: 500,
+            ignore: (errorEvent) => {
+                return (
+                    errorEvent &&
+                    errorEvent.message &&
+                    errorEvent.message.test(/^Warning:/)
+                );
+            }
+        }
+    ],
+    'performance',
+    'http'
+]
+```
 
 ## HTTP
 

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "web-vitals": "^1.1.1"
     },
     "lint-staged": {
-        "*.{js,ts}": "npm run lint",
+        "*.{ts}": "npm run lint",
         "*.{js,ts,json,html,yml,md}": "npx prettier --check"
     },
     "jest": {

--- a/src/loader/loader-js-error-event.js
+++ b/src/loader/loader-js-error-event.js
@@ -5,7 +5,18 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
     allowCookies: true,
     dispatchInterval: 0,
     metaDataPluginsToLoad: [],
-    eventPluginsToLoad: [new JsErrorPlugin()],
+    eventPluginsToLoad: [
+        new JsErrorPlugin({
+            filter: (errorEvent) => {
+                const patterns = [/ResizeObserver loop/];
+                return (
+                    patterns.filter((pattern) =>
+                        pattern.test(errorEvent.message)
+                    ).length !== 0
+                );
+            }
+        })
+    ],
     telemetries: [],
     clientBuilder: showRequestClientBuilder
 });

--- a/src/loader/loader-js-error-event.js
+++ b/src/loader/loader-js-error-event.js
@@ -7,7 +7,7 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
     metaDataPluginsToLoad: [],
     eventPluginsToLoad: [
         new JsErrorPlugin({
-            filter: (errorEvent) => {
+            ignore: (errorEvent) => {
                 const patterns = [/ResizeObserver loop/];
                 return (
                     patterns.filter((pattern) =>

--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -6,17 +6,17 @@ export const JS_ERROR_EVENT_PLUGIN_ID = 'js-error';
 
 export type PartialJsErrorPluginConfig = {
     stackTraceLength?: number;
-    filter?: (error: ErrorEvent | PromiseRejectionEvent) => boolean;
+    ignore?: (error: ErrorEvent | PromiseRejectionEvent) => boolean;
 };
 
 export type JsErrorPluginConfig = {
     stackTraceLength: number;
-    filter: (error: ErrorEvent | PromiseRejectionEvent) => boolean;
+    ignore: (error: ErrorEvent | PromiseRejectionEvent) => boolean;
 };
 
 const defaultConfig: JsErrorPluginConfig = {
     stackTraceLength: 200,
-    filter: () => false
+    ignore: () => false
 };
 
 export class JsErrorPlugin extends InternalPlugin {
@@ -56,13 +56,13 @@ export class JsErrorPlugin extends InternalPlugin {
     }
 
     private eventHandler = (errorEvent: ErrorEvent) => {
-        if (!this.config.filter(errorEvent)) {
+        if (!this.config.ignore(errorEvent)) {
             this.recordJsErrorEvent(errorEvent);
         }
     };
 
     private promiseRejectEventHandler = (event: PromiseRejectionEvent) => {
-        if (!this.config.filter(event)) {
+        if (!this.config.ignore(event)) {
             this.recordJsErrorEvent({
                 type: event.type,
                 error: event.reason

--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -71,11 +71,10 @@ export class JsErrorPlugin extends InternalPlugin {
     };
 
     private recordJsErrorEvent(error: any) {
-        const jsErrorEvent = errorEventToJsErrorEvent(
-            error,
-            this.config.stackTraceLength
+        this.context?.record(
+            JS_ERROR_EVENT_TYPE,
+            errorEventToJsErrorEvent(error, this.config.stackTraceLength)
         );
-        this.context?.record(JS_ERROR_EVENT_TYPE, jsErrorEvent);
     }
 
     private addEventHandler(): void {

--- a/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
@@ -12,7 +12,7 @@ const triggerPromiseRejection: Selector = Selector(`#uncaughtPromiseRejection`);
 const dispatch: Selector = Selector(`#dispatch`);
 
 fixture('JSErrorEvent Plugin').page(
-    'http://localhost:9000/js_error_event.html'
+    'http://localhost:8080/js_error_event.html'
 );
 
 const removeUnwantedEvents = (json: any) => {

--- a/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
@@ -171,7 +171,7 @@ test('when the application records a caught error then the plugin records the er
         .contains('My error message');
 });
 
-test('when filter function matches error then the plugin does not record the error', async (t: TestController) => {
+test('when ignore function matches error then the plugin does not record the error', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
     await t

--- a/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
@@ -4,14 +4,15 @@ import { JS_ERROR_EVENT_TYPE } from '../../utils/constant';
 
 const triggerTypeError: Selector = Selector(`#triggerTypeError`);
 const throwErrorString: Selector = Selector(`#throwErrorString`);
-const recordStackTrace: Selector = Selector(`#recordStackTrace`);
 const recordCaughtError: Selector = Selector(`#recordCaughtError`);
+const triggerResizeObserver: Selector = Selector(`#resizeObserverLoopError`);
+const recordResizeObserver: Selector = Selector(`#recordObserverLoopError`);
 const triggerPromiseRejection: Selector = Selector(`#uncaughtPromiseRejection`);
 
 const dispatch: Selector = Selector(`#dispatch`);
 
 fixture('JSErrorEvent Plugin').page(
-    'http://localhost:8080/js_error_event.html'
+    'http://localhost:9000/js_error_event.html'
 );
 
 const removeUnwantedEvents = (json: any) => {
@@ -168,4 +169,38 @@ test('when the application records a caught error then the plugin records the er
         .contains('Error')
         .expect(eventDetails.message)
         .contains('My error message');
+});
+
+test('when filter function matches error then the plugin does not record the error', async (t: TestController) => {
+    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
+    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
+    await t
+        .wait(300)
+        .click(triggerResizeObserver)
+        .click(dispatch)
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    const json = removeUnwantedEvents(
+        JSON.parse(await REQUEST_BODY.textContent)
+    );
+
+    await t.expect(json.RumEvents.length).eql(0);
+});
+
+test('when error invoked with record method then the plugin records the error', async (t: TestController) => {
+    // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
+    // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
+    await t
+        .wait(300)
+        .click(recordResizeObserver)
+        .click(dispatch)
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    const json = removeUnwantedEvents(
+        JSON.parse(await REQUEST_BODY.textContent)
+    );
+
+    await t.expect(json.RumEvents.length).eql(1);
 });


### PR DESCRIPTION
## Details
Previously, CW RUM did not provide an option to allow customers to filter out error events that provided no monitoring value. 
This PR addresses the issue by allowing the customers to pass in a function that acts similar to `Array.filter` to indicate whether the error should be recorded or not.

Resolves #119 

## Testing
Added a new unit test and an integ test to cover the new behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
