### PR TITLE
chore: Use correct config file to run lint on test files and refactor test code

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "build:dev": "npm-run-all -s build build:webpack:dev",
         "release": "npm run build",
         "version": "standard-version",
-        "lint": "npx tslint --config ./tslint.json --project ./tsconfig.webpack.json --format verbose",
+        "lint": "npx tslint --config ./tslint.json --project ./tsconfig.json --format verbose",
         "lint:fix": "npm run lint -- --fix",
         "prettier": "npx prettier --check .",
         "prettier:fix": "npm run prettier -- --write",

--- a/src/__integ__/cookiesDisabled.test.ts
+++ b/src/__integ__/cookiesDisabled.test.ts
@@ -19,7 +19,7 @@ test('when cookies are disabled, no session start event is dispatched', async (t
 
     const json = JSON.parse(await REQUEST_BODY.textContent);
     const sessionStartEvents = json.RumEvents.filter(
-        (e) => e.eventType == SESSION_START_EVENT_TYPE
+        (e) => e.eventType === SESSION_START_EVENT_TYPE
     );
 
     await t.expect(sessionStartEvents.length).eql(0);

--- a/src/__integ__/cookiesEnabled.test.ts
+++ b/src/__integ__/cookiesEnabled.test.ts
@@ -18,7 +18,7 @@ test('when page is re-loaded with cookies enabled, session start is not dispatch
 
     const jsonA = JSON.parse(await REQUEST_BODY.textContent);
     const sessionStartEventsA = jsonA.RumEvents.filter(
-        (e) => e.type == SESSION_START_EVENT_TYPE
+        (e) => e.type === SESSION_START_EVENT_TYPE
     );
 
     await t
@@ -35,7 +35,7 @@ test('when page is re-loaded with cookies enabled, session start is not dispatch
 
     const jsonB = JSON.parse(await REQUEST_BODY.textContent);
     const sessionStartEventsB = jsonB.RumEvents.filter(
-        (e) => e.type == SESSION_START_EVENT_TYPE
+        (e) => e.type === SESSION_START_EVENT_TYPE
     );
 
     await t.expect(sessionStartEventsB.length).eql(0);
@@ -52,7 +52,7 @@ test('when page is loaded with cookies enabled, session start includes meta data
 
     const json = JSON.parse(await REQUEST_BODY.textContent);
     const sessionStartEvents = json.RumEvents.filter(
-        (e) => e.type == SESSION_START_EVENT_TYPE
+        (e) => e.type === SESSION_START_EVENT_TYPE
     );
 
     const metaData = JSON.parse(sessionStartEvents[0].metadata);

--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -174,7 +174,7 @@ describe('CommandQueue tests', () => {
             expect.objectContaining({
                 dispatchInterval: 10 * 1000,
                 sessionSampleRate: 0.8,
-                enableRumClient: false //prefer snippet config
+                enableRumClient: false // prefer snippet config
             })
         );
     });

--- a/src/dispatch/__tests__/Authentication.test.ts
+++ b/src/dispatch/__tests__/Authentication.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { Authentication } from '../Authentication';
 import { CRED_KEY } from '../../utils/constants';
 import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
@@ -44,7 +45,6 @@ describe('Authentication tests', () => {
         localStorage.removeItem(CRED_KEY);
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is in localStorage then authentication chain retrieves credential from localStorage', async () => {
         // Init
         const expiration = new Date(Date.now() + 3600 * 1000);
@@ -80,7 +80,6 @@ describe('Authentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is corrupt then authentication chain retrieves credential from basic authflow', async () => {
         // Init
         const config = {
@@ -107,7 +106,6 @@ describe('Authentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is not in localStorage then authentication chain retrieves credential from basic authflow', async () => {
         // Init
         const auth = new Authentication({
@@ -131,7 +129,6 @@ describe('Authentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential expires then authentication chain retrieves credential from basic authflow', async () => {
         // Init
         const expiration = new Date(0);
@@ -168,7 +165,6 @@ describe('Authentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is retrieved from basic auth then next credential is retrieved from localStorage', async () => {
         // Init
         const expiration = new Date(Date.now() + 3600 * 1000);
@@ -267,7 +263,6 @@ describe('Authentication tests', () => {
         expect(auth.ChainAnonymousCredentialsProvider()).rejects.toEqual(e);
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is in member then authentication chain retrieves credential from member', async () => {
         // Init
         const expiration = new Date(Date.now() + 3600 * 1000);
@@ -305,7 +300,6 @@ describe('Authentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credentials expire in member variable then authentication chain retrieves credential from basic auth flow', async () => {
         // Init
         assumeRole

--- a/src/dispatch/__tests__/DataPlaneClient.test.ts
+++ b/src/dispatch/__tests__/DataPlaneClient.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import * as Utils from '../../test-utils/test-utils';
 import { BeaconHttpHandler } from '../BeaconHttpHandler';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
@@ -76,7 +77,7 @@ describe('DataPlaneClient tests', () => {
         expect(signedRequest.headers['X-Amz-Content-Sha256']).toEqual(
             '57bbd361f5c5ab66d7dafb33d6c8bf714bbb140300fad06145b8d66c388b5d43'
         );
-        expect(signedRequest.headers['authorization']).toEqual(
+        expect(signedRequest.headers.authorization).toEqual(
             'AWS4-HMAC-SHA256 Credential=abc123/19700101/us-west-2/rum/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=bf3acf587b119ab12f0f8a86bf12acf7c460eb037584feb0ab5574f297def947'
         );
     });

--- a/src/dispatch/__tests__/EnhancedAuthentication.test.ts
+++ b/src/dispatch/__tests__/EnhancedAuthentication.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { CRED_KEY } from '../../utils/constants';
 import { Credentials } from '@aws-sdk/types';
 import { EnhancedAuthentication } from '../EnhancedAuthentication';
@@ -46,7 +47,6 @@ describe('EnhancedAuthentication tests', () => {
         localStorage.removeItem(CRED_KEY);
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is in localStorage then authentication chain retrieves credential from localStorage', async () => {
         // Init
         const expiration = new Date(Date.now() + 3600 * 1000);
@@ -82,7 +82,6 @@ describe('EnhancedAuthentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is corrupt then authentication chain retrieves credential from basic authflow', async () => {
         // Init
         const config = {
@@ -110,7 +109,6 @@ describe('EnhancedAuthentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is not in the store authentication chain retrieves credential from basic authflow', async () => {
         // Init
         const auth = new EnhancedAuthentication({
@@ -133,7 +131,6 @@ describe('EnhancedAuthentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential expires then authentication chain retrieves credentials from basic authflow', async () => {
         // Init
         const expiration = new Date(0);
@@ -170,7 +167,6 @@ describe('EnhancedAuthentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is retrieved from basic auth then next credential is retrieved from localStorage', async () => {
         // Init
         const expiration = new Date(Date.now() + 3600 * 1000);
@@ -236,7 +232,9 @@ describe('EnhancedAuthentication tests', () => {
         });
 
         // Assert
-        expect(auth.ChainAnonymousCredentialsProvider()).toThrowError;
+        expect((auth: EnhancedAuthentication) => {
+            auth.ChainAnonymousCredentialsProvider();
+        }).toThrowError();
     });
 
     test('when getId fails then throw an error', async () => {
@@ -254,10 +252,11 @@ describe('EnhancedAuthentication tests', () => {
         });
 
         // Assert
-        expect(auth.ChainAnonymousCredentialsProvider()).toThrowError;
+        expect((auth: EnhancedAuthentication) => {
+            auth.ChainAnonymousCredentialsProvider();
+        }).toThrowError();
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credential is in member then authentication chain retrieves credential from member', async () => {
         // Init
         const expiration = new Date(Date.now() + 3600 * 1000);
@@ -295,7 +294,6 @@ describe('EnhancedAuthentication tests', () => {
         );
     });
 
-    // tslint:disable-next-line:max-line-length
     test('when credentials expire in member variable then authentication chain retrieves credential from basic auth flow', async () => {
         // Init
         getCredentials

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -12,7 +12,7 @@ const getSession = jest.fn(() => ({
     eventCount: 1
 }));
 const getUserId = jest.fn(() => 'b');
-const getAttributes = jest.fn(() => {});
+const getAttributes = jest.fn(() => undefined);
 const incrementSessionEventCount = jest.fn();
 jest.mock('../../sessions/SessionManager', () => ({
     SessionManager: jest.fn().mockImplementation(() => ({
@@ -304,7 +304,7 @@ describe('EventCache tests', () => {
             eventCount: 1
         }));
         const getUserId = jest.fn(() => 'b');
-        const getAttributes = jest.fn(() => {});
+        const getAttributes = jest.fn(() => undefined);
         const incrementSessionEventCount = jest.fn();
         (SessionManager as any).mockImplementation(() => ({
             getSession,
@@ -332,11 +332,11 @@ describe('EventCache tests', () => {
             return {
                 sessionId: 'a',
                 record: true,
-                eventCount: eventCount
+                eventCount
             };
         });
         const getUserId = jest.fn(() => 'b');
-        const getAttributes = jest.fn(() => {});
+        const getAttributes = jest.fn(() => undefined);
         const incrementSessionEventCount = jest.fn();
         (SessionManager as any).mockImplementation(() => ({
             getSession,
@@ -364,10 +364,10 @@ describe('EventCache tests', () => {
 
     test('when event limit is zero then recordEvent records all events', async () => {
         // Init
-        let eventCount = 0;
+        const eventCount = 0;
         const getSession = jest.fn(() => ({ sessionId: 'a', record: true }));
         const getUserId = jest.fn(() => 'b');
-        const getAttributes = jest.fn(() => {});
+        const getAttributes = jest.fn(() => undefined);
         const incrementSessionEventCount = jest.fn();
         (SessionManager as any).mockImplementation(() => ({
             getSession,

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { Orchestration } from '../Orchestration';
 import { Dispatch } from '../../dispatch/Dispatch';
 import { EventCache } from '../../event-cache/EventCache';
@@ -26,7 +27,7 @@ jest.mock('../../event-cache/EventCache', () => ({
     EventCache: jest.fn().mockImplementation(() => ({
         enable: enableEventCache,
         disable: disableEventCache,
-        recordPageView: recordPageView
+        recordPageView
     }))
 }));
 
@@ -38,10 +39,10 @@ const disablePlugins = jest.fn();
 
 jest.mock('../../plugins/PluginManager', () => ({
     PluginManager: jest.fn().mockImplementation(() => ({
-        addPlugin: addPlugin,
+        addPlugin,
         enable: enablePlugins,
         disable: disablePlugins,
-        updatePlugin: updatePlugin
+        updatePlugin
     }))
 }));
 
@@ -186,7 +187,7 @@ describe('Orchestration tests', () => {
 
     test('data collection defaults to only page views', async () => {
         // Init
-        new Orchestration('a', 'c', 'us-east-1', {});
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {});
         const expected = ['com.amazonaws.rum.page-view'];
         const actual = [];
 
@@ -224,7 +225,7 @@ describe('Orchestration tests', () => {
 
     test('when a config is passed to the http data collection then the config is added as a constructor arg', async () => {
         // Init
-        new Orchestration('a', 'c', 'us-east-1', {
+        const orchestration = new Orchestration('a', 'c', 'us-east-1', {
             telemetries: [['http', { trace: true }]]
         });
 

--- a/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/DomEventPlugin.test.ts
@@ -1,10 +1,8 @@
+// tslint:disable:max-line-length
 import { Selector } from 'testcafe';
 import { REQUEST_BODY } from '../../../test-utils/integ-test-utils';
 import { DOM_EVENT_TYPE } from '../../utils/constant';
 
-const recordDocumentClicks: Selector = Selector(`#recordDocumentClicks`);
-const recordButton1Clicks: Selector = Selector(`#recordButton1Clicks`);
-const doNotRecordClicks: Selector = Selector(`#doNotRecordClicks`);
 const disable: Selector = Selector(`#disable`);
 const enable: Selector = Selector(`#enable`);
 
@@ -20,7 +18,6 @@ const button4: Selector = Selector(`#button4`);
 const button5: Selector = Selector(`#button5`);
 
 const dispatch: Selector = Selector(`#dispatch`);
-const clear: Selector = Selector(`#clearRequestResponse`);
 
 fixture('DomEventPlugin').page('http://localhost:8080/dom_event.html');
 
@@ -193,9 +190,9 @@ test('when two elements identified by a CSS selector are clicked then CSS select
             JSON.parse(e.details).cssLocator === '[label="label1"]'
     );
 
-    for (let i = 0; i < events.length; i++) {
-        let eventType = events[i].type;
-        let eventDetails = JSON.parse(events[i].details);
+    for (const event of events) {
+        const eventType = event.type;
+        const eventDetails = JSON.parse(event.details);
 
         await t
             .expect(events.length)
@@ -283,9 +280,9 @@ test('when new DOM events are registered and then a button is clicked, the event
             JSON.parse(e.details).cssLocator === '[label="label2"]'
     );
 
-    for (let i = 0; i < events.length; i++) {
-        let eventType = events[i].type;
-        let eventDetails = JSON.parse(events[i].details);
+    for (const event of events) {
+        const eventType = event.type;
+        const eventDetails = JSON.parse(event.details);
 
         await t
             .expect(events.length)
@@ -352,9 +349,9 @@ test('when enableMutationObserver is false by default and listening for a click 
             JSON.parse(e.details).cssLocator === '[label="label1"]'
     );
 
-    for (let i = 0; i < events.length; i++) {
-        let eventType = events[i].type;
-        let eventDetails = JSON.parse(events[i].details);
+    for (const event of events) {
+        const eventType = event.type;
+        const eventDetails = JSON.parse(event.details);
 
         await t
             .expect(events.length)
@@ -388,9 +385,9 @@ test('when enableMutationObserver is false by default and listening for a click 
             JSON.parse(e.details).cssLocator === '[label="label1"]'
     );
 
-    for (let i = 0; i < events.length; i++) {
-        let eventType = events[i].type;
-        let eventDetails = JSON.parse(events[i].details);
+    for (const event of events) {
+        const eventType = event.type;
+        const eventDetails = JSON.parse(event.details);
 
         await t
             .expect(events.length)

--- a/src/plugins/event-plugins/__integ__/DomEventPluginMutationObserverEnabled.test.ts
+++ b/src/plugins/event-plugins/__integ__/DomEventPluginMutationObserverEnabled.test.ts
@@ -62,9 +62,9 @@ test('when enableMutationObserver is true by default and listening for a click o
             JSON.parse(e.details).cssLocator === '[label="label1"]'
     );
 
-    for (let i = 0; i < events.length; i++) {
-        let eventType = events[i].type;
-        let eventDetails = JSON.parse(events[i].details);
+    for (const event of events) {
+        const eventType = event.type;
+        const eventDetails = JSON.parse(event.details);
 
         await t
             .expect(events.length)
@@ -98,9 +98,9 @@ test('when enableMutationObserver is true by default and listening for a click g
             JSON.parse(e.details).cssLocator === '[label="label1"]'
     );
 
-    for (let i = 0; i < events.length; i++) {
-        let eventType = events[i].type;
-        let eventDetails = JSON.parse(events[i].details);
+    for (const event of events) {
+        const eventType = event.type;
+        const eventDetails = JSON.parse(event.details);
 
         await t
             .expect(events.length)

--- a/src/plugins/event-plugins/__integ__/WebVitalsPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/WebVitalsPlugin.test.ts
@@ -13,7 +13,8 @@ fixture('WebVitalEvent Plugin').page(
     'http://localhost:8080/web_vital_event.html'
 );
 
-// According to https://github.com/GoogleChrome/web-vitals, "FID is not reported if the user never interacts with the page."
+// According to https://github.com/GoogleChrome/web-vitals,
+// "FID is not reported if the user never interacts with the page."
 // It doesn't seem like TestCafe actions are registered as user interactions, so cannot test FID
 
 const removeUnwantedEvents = (json: any) => {
@@ -37,8 +38,8 @@ const removeUnwantedEvents = (json: any) => {
 test('WebVitalEvent records lcp and cls events', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
-    let browser = t.browser.name;
-    if (browser == 'Safari' || browser == 'Firefox') {
+    const browser = t.browser.name;
+    if (browser === 'Safari' || browser === 'Firefox') {
         return 'Test is skipped';
     }
     await t.wait(300);

--- a/src/plugins/event-plugins/__tests__/DomEventPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/DomEventPlugin.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { DomEventPlugin } from '../DomEventPlugin';
 import { context, record } from '../../../test-utils/test-utils';
 import { DOM_EVENT_TYPE } from '../../utils/constant';
@@ -111,7 +112,7 @@ describe('DomEventPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        let element: HTMLElement = document.querySelector(
+        const element: HTMLElement = document.querySelector(
             '[label="label1"]'
         ) as HTMLElement;
         element.click();
@@ -139,19 +140,21 @@ describe('DomEventPlugin tests', () => {
 
         // Run
         plugin.load(context);
-        let elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
+        const elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
             '[label="label1"]'
         ) as NodeListOf<HTMLElement>;
-        for (let i = 0; i < elementList.length; i++) {
-            elementList[i].click();
-        }
+
+        elementList.forEach((value: HTMLElement) => {
+            value.click();
+        });
+
         plugin.disable();
 
         // Assert
         expect(record).toHaveBeenCalledTimes(2);
-        for (let i = 0; i < record.mock.calls.length; i++) {
-            expect(record.mock.calls[i][0]).toEqual(DOM_EVENT_TYPE);
-            expect(record.mock.calls[i][1]).toMatchObject(
+        for (const call of record.mock.calls) {
+            expect(call[0]).toEqual(DOM_EVENT_TYPE);
+            expect(call[1]).toMatchObject(
                 expect.objectContaining({
                     version: '1.0.0',
                     event: 'click',
@@ -202,7 +205,7 @@ describe('DomEventPlugin tests', () => {
         // Run
         plugin.load(context);
         document.getElementById('button1').click();
-        let element: HTMLElement = document.querySelector(
+        const element: HTMLElement = document.querySelector(
             '[label="label1"]'
         ) as HTMLElement;
         element.click();
@@ -334,7 +337,7 @@ describe('DomEventPlugin tests', () => {
         // If we click too soon, the MutationObserver callback function will not have added the eventListener the plugin will not record the click.
         await new Promise((r) => setTimeout(r, 100));
 
-        let element: HTMLElement = document.querySelector(
+        const element: HTMLElement = document.querySelector(
             '[label="label1"]'
         ) as HTMLElement;
         element.click();
@@ -371,20 +374,21 @@ describe('DomEventPlugin tests', () => {
         // If we click too soon, the MutationObserver callback function will not have added the eventListener the plugin will not record the click.
         await new Promise((r) => setTimeout(r, 100));
 
-        let elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
+        const elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
             '#button1'
         ) as NodeListOf<HTMLElement>;
-        for (let i = 0; i < elementList.length; i++) {
-            elementList[i].click();
-        }
+
+        elementList.forEach((value: HTMLElement) => {
+            value.click();
+        });
 
         plugin.disable();
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        for (let i = 0; i < record.length; i++) {
-            expect(record.mock.calls[i][0]).toEqual(DOM_EVENT_TYPE);
-            expect(record.mock.calls[i][1]).toMatchObject(
+        for (const call of record.mock.calls) {
+            expect(call[0]).toEqual(DOM_EVENT_TYPE);
+            expect(call[1]).toMatchObject(
                 expect.objectContaining({
                     version: '1.0.0',
                     event: 'click',
@@ -413,20 +417,21 @@ describe('DomEventPlugin tests', () => {
         // If we click too soon, the MutationObserver callback function will not have added the eventListener the plugin will not record the click.
         await new Promise((r) => setTimeout(r, 100));
 
-        let elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
+        const elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
             '#button1'
         ) as NodeListOf<HTMLElement>;
-        for (let i = 0; i < elementList.length; i++) {
-            elementList[i].click();
-        }
+
+        elementList.forEach((value: HTMLElement) => {
+            value.click();
+        });
 
         plugin.disable();
 
         // Assert
         expect(record).toHaveBeenCalledTimes(2);
-        for (let i = 0; i < record.length; i++) {
-            expect(record.mock.calls[i][0]).toEqual(DOM_EVENT_TYPE);
-            expect(record.mock.calls[i][1]).toMatchObject(
+        for (const call of record.mock.calls) {
+            expect(call[0]).toEqual(DOM_EVENT_TYPE);
+            expect(call[1]).toMatchObject(
                 expect.objectContaining({
                     version: '1.0.0',
                     event: 'click',
@@ -455,12 +460,13 @@ describe('DomEventPlugin tests', () => {
 
         plugin.disable();
 
-        let elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
+        const elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
             '[label="label1"]'
         ) as NodeListOf<HTMLElement>;
-        for (let i = 0; i < elementList.length; i++) {
-            elementList[i].click();
-        }
+
+        elementList.forEach((value: HTMLElement) => {
+            value.click();
+        });
 
         // Assert
         expect(record).toHaveBeenCalledTimes(0);
@@ -487,12 +493,13 @@ describe('DomEventPlugin tests', () => {
 
         plugin.disable();
 
-        let elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
+        const elementList: NodeListOf<HTMLElement> = document.querySelectorAll(
             '[label="label1"]'
         ) as NodeListOf<HTMLElement>;
-        for (let i = 0; i < elementList.length; i++) {
-            elementList[i].click();
-        }
+
+        elementList.forEach((value: HTMLElement) => {
+            value.click();
+        });
 
         // Assert
         expect(record).toHaveBeenCalledTimes(0);

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { FetchPlugin } from '../FetchPlugin';
 import {
     PartialHttpPluginConfig,
@@ -28,10 +29,10 @@ const TRACE_ID =
 
 const Headers = function (init?: Record<string, string>) {
     const headers = init ? init : {};
-    this.get = function (name: string) {
+    this.get = (name: string) => {
         return headers[name];
     };
-    this.set = function (name: string, value: string) {
+    this.set = (name: string, value: string) => {
         headers[name] = value;
     };
 };

--- a/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/JsErrorPlugin.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { JsErrorPlugin } from '../JsErrorPlugin';
 import { context, getSession, record } from '../../../test-utils/test-utils';
 import { JS_ERROR_EVENT_TYPE } from '../../utils/constant';
@@ -99,7 +100,7 @@ describe('JsErrorPlugin tests', () => {
         // Event to have the same functionality
         window.dispatchEvent(
             Object.assign(promiseRejectionEvent, {
-                promise: new Promise(() => {}),
+                promise: new Promise(() => undefined),
                 reason: 'Something went wrong!'
             })
         );
@@ -248,7 +249,7 @@ describe('JsErrorPlugin tests', () => {
         plugin.disable();
 
         // So that the error doesn't cause the test to fail.
-        window.addEventListener('error', () => {});
+        window.addEventListener('error', () => undefined);
 
         document.getElementById('createJSError').click();
         plugin.disable();
@@ -268,11 +269,11 @@ describe('JsErrorPlugin tests', () => {
         plugin.load(context);
 
         // So that the error doesn't cause the test to fail.
-        window.addEventListener('error', () => {});
+        window.addEventListener('error', () => undefined);
         plugin.disable();
         window.dispatchEvent(
             Object.assign(promiseRejectionEvent, {
-                promise: new Promise(() => {}),
+                promise: new Promise(() => undefined),
                 reason: 'Something went wrong!'
             })
         );
@@ -436,7 +437,7 @@ describe('JsErrorPlugin tests', () => {
         // Event to have the same functionality
         window.dispatchEvent(
             Object.assign(promiseRejectionEvent, {
-                promise: new Promise(() => {}),
+                promise: new Promise(() => undefined),
                 reason: {}
             })
         );
@@ -467,7 +468,7 @@ describe('JsErrorPlugin tests', () => {
         // Event to have the same functionality
         window.dispatchEvent(
             Object.assign(promiseRejectionEvent, {
-                promise: new Promise(() => {}),
+                promise: new Promise(() => undefined),
                 reason: null
             })
         );
@@ -498,7 +499,7 @@ describe('JsErrorPlugin tests', () => {
         // Event to have the same functionality
         window.dispatchEvent(
             Object.assign(promiseRejectionEvent, {
-                promise: new Promise(() => {}),
+                promise: new Promise(() => undefined),
                 reason: {
                     name: 'TypeError',
                     message: 'NetworkError when attempting to fetch resource.',

--- a/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import {
     navigationEvent,
     performanceEvent,

--- a/src/plugins/event-plugins/__tests__/PageViewPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/PageViewPlugin.test.ts
@@ -21,7 +21,7 @@ describe('PageViewPlugin tests', () => {
     beforeEach(() => {
         (context.recordPageView as any).mockClear();
         jsdom.reconfigure({
-            url: url
+            url
         });
     });
 

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { PartialHttpPluginConfig } from '../../utils/http-utils';
 import { advanceTo } from 'jest-date-mock';
 import { XhrPlugin } from '../XhrPlugin';
@@ -272,7 +273,7 @@ describe('XhrPlugin tests', () => {
             urlsToInclude: [/response\.json/]
         };
 
-        mock.get(/.*/, () => new Promise(() => {}));
+        mock.get(/.*/, () => new Promise(() => undefined));
 
         const plugin: XhrPlugin = new XhrPlugin(config);
         plugin.load(xRayOnContext);
@@ -319,7 +320,7 @@ describe('XhrPlugin tests', () => {
             urlsToInclude: [/response\.json/]
         };
 
-        mock.get(/.*/, () => new Promise(() => {}));
+        mock.get(/.*/, () => new Promise(() => undefined));
 
         const plugin: XhrPlugin = new XhrPlugin(config);
         plugin.load(xRayOffContext);
@@ -760,17 +761,17 @@ describe('XhrPlugin tests', () => {
         plugin.load(xRayOffContext);
 
         // Run
-        const xhr_cognito = new XMLHttpRequest();
-        xhr_cognito.open(
+        const xhrCognito = new XMLHttpRequest();
+        xhrCognito.open(
             'GET',
             'https://cognito-identity.us-west-2.amazonaws.com',
             true
         );
-        xhr_cognito.send();
+        xhrCognito.send();
 
-        const xhr_sts = new XMLHttpRequest();
-        xhr_sts.open('GET', 'https://sts.us-west-2.amazonaws.com', true);
-        xhr_sts.send();
+        const xhrSts = new XMLHttpRequest();
+        xhrSts.open('GET', 'https://sts.us-west-2.amazonaws.com', true);
+        xhrSts.send();
 
         // Yield to the event queue so the event listeners can run
         await new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/remote-config/__tests__/remote-config.test.ts
+++ b/src/remote-config/__tests__/remote-config.test.ts
@@ -39,7 +39,7 @@ describe('OTA helper function tests', () => {
             u: dummyOtaConfigURL
         };
 
-        let config: PartialConfig = await getRemoteConfig(getCodeConfig);
+        const config: PartialConfig = await getRemoteConfig(getCodeConfig);
         expect(config).toEqual(mockOtaConfigObject);
     });
 
@@ -70,7 +70,7 @@ describe('OTA helper function tests', () => {
             u: dummyOtaConfigURL
         };
 
-        let config: PartialConfig = await getRemoteConfig(getCodeConfig);
+        const config: PartialConfig = await getRemoteConfig(getCodeConfig);
         expect(config).toEqual(
             expect.objectContaining({
                 sessionSampleRate: 0.8
@@ -106,7 +106,7 @@ describe('OTA helper function tests', () => {
             u: dummyOtaConfigURL
         };
 
-        let config: PartialConfig = await getRemoteConfig(getCodeConfig);
+        const config: PartialConfig = await getRemoteConfig(getCodeConfig);
         expect(config).toEqual(
             expect.objectContaining({
                 dispatchInterval: 10 * 1000,
@@ -137,7 +137,7 @@ describe('OTA helper function tests', () => {
             u: dummyOtaConfigURL
         };
 
-        let config: PartialConfig = await getRemoteConfig(configObject);
+        const config: PartialConfig = await getRemoteConfig(configObject);
         expect(config).toEqual(
             expect.objectContaining({
                 sessionSampleRate: 1,

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -108,9 +108,9 @@ test('when page is denied then page view is not recorded', async (t: TestControl
         .expect(REQUEST_BODY.textContent)
         .contains('BatchId');
 
-    const request_body = JSON.parse(await REQUEST_BODY.textContent);
+    const requestBody = JSON.parse(await REQUEST_BODY.textContent);
 
-    const pages = request_body.RumEvents.filter(
+    const pages = requestBody.RumEvents.filter(
         (e) => e.type === PAGE_VIEW_EVENT_TYPE
     ).map((e) => JSON.parse(e.details));
 

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { advanceTo } from 'jest-date-mock';
 import { PageManager } from '../PageManager';
 import { DEFAULT_CONFIG, mockFetch } from '../../test-utils/test-utils';
@@ -16,6 +17,7 @@ Object.defineProperty(document, 'referrer', {
 Object.defineProperty(document, 'title', { value: 'Amazon AWS Console' });
 global.fetch = mockFetch;
 
+/* tslint:disable:no-string-literal */
 describe('PageManager tests', () => {
     let url;
 
@@ -28,7 +30,7 @@ describe('PageManager tests', () => {
         mock.setup();
         record.mockClear();
         jsdom.reconfigure({
-            url: url
+            url
         });
     });
 

--- a/src/sessions/__tests__/VirtualPageLoadTimer.test.ts
+++ b/src/sessions/__tests__/VirtualPageLoadTimer.test.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import { advanceTo } from 'jest-date-mock';
 import { Page, PageManager } from '../PageManager';
 import {
@@ -45,6 +46,7 @@ const timeoutConfig: Config = {
 };
 const pageManager = new PageManager(config, record);
 
+/* tslint:disable:no-string-literal */
 describe('VirtualPageLoadTimer tests', () => {
     let url;
 
@@ -57,7 +59,7 @@ describe('VirtualPageLoadTimer tests', () => {
         mock.setup();
         record.mockClear();
         jsdom.reconfigure({
-            url: url
+            url
         });
     });
 
@@ -75,7 +77,7 @@ describe('VirtualPageLoadTimer tests', () => {
 
         // Adding requests to requestBuffer
         for (let i = 0; i < 3; i++) {
-            let xhr = new XMLHttpRequest();
+            const xhr = new XMLHttpRequest();
             virtualPageLoadTimer['requestBuffer'].add(xhr);
         }
 
@@ -97,7 +99,7 @@ describe('VirtualPageLoadTimer tests', () => {
 
         // Adding requests to requestBuffer
         for (let i = 0; i < 3; i++) {
-            let xhr = new XMLHttpRequest();
+            const xhr = new XMLHttpRequest();
             virtualPageLoadTimer['requestBuffer'].add(xhr);
         }
 


### PR DESCRIPTION
## Issue
Previously, we did not run `lint` on test files. After the addition of #144 and #149 , we are running `lint` on staged files and the input for `--project` was `tsconfig.webpack.json`. Even though `tsconfig.webpack.json` extended from `tsconfig.json` which defined project as all the files under `src/`, `tsconfig.webpack.json` overwrote the project to only include dependencies involved with `index-browser.ts`.

As a result, any changes/addition of test files would fail in commit sessions, as it was recognized as "not included in the project".

## Solution
There were two ways to go about this issue: (1) do not include test files (non-source code) under pre-commit (2) use `tsconfig.json` as input for `--project` and refactor our test cases.

Despite being test files, applying lint to test cases in the future and doing the refactoring will increase code quality - thus went with option (2).

## This PR
This PR makes two major changes:
1. instead of `tsconfig.webpack.json`, use `tsconfig.json` for `npm run lint`
2. refactor existing test cases

## Notes
Since TSLint is deprecated as of 2018, we should migrate to ESLint. There will be a subsequent PR to migrate from TSLint to ESLint.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
