### PR TITLE
chore: 🤖 mark package as sideEffect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "aws-rum-web",
     "version": "1.5.1",
+    "sideEffects": false,
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",
     "author": "Amazon CloudWatch RUM Staff <nobody@amazon.com>",


### PR DESCRIPTION
Can read documentation of tree-shaking here: https://webpack.js.org/guides/tree-shaking/

and you can see here that even though we are using es2015, it will not really use tree-shaking until it is marked as sideEffect free


[<img width="853" alt="image" src="https://user-images.githubusercontent.com/539579/170358618-22381d47-ebc7-4180-818b-01a09049faf5.png">](https://bundlephobia.com/package/aws-rum-web)


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
