### PR TITLE
test: Add Xray, DOM, and CLS smoke test cases

### DIFF
--- a/app/smoke.html
+++ b/app/smoke.html
@@ -31,9 +31,9 @@
                 guestRoleArn: $GUEST_ARN,
                 identityPoolId: $IDENTITY_POOL,
                 endpoint: $ENDPOINT,
-                telemetries: ['performance', 'errors', 'http'],
+                telemetries: ['performance', 'errors', 'http', 'interaction'],
                 allowCookies: true,
-                enableXRay: false
+                enableXRay: true
             });
         </script>
 
@@ -153,6 +153,24 @@
                 });
                 xhr.send();
             }
+
+            function dispatchCLS() {
+                Object.defineProperty(document, 'visibilityState', {
+                    value: 'hidden',
+                    writable: true
+                });
+                Object.defineProperty(document, 'hidden', {
+                    value: true,
+                    writable: true
+                });
+                document.dispatchEvent(new Event('visibilitychange'));
+            }
+
+            function registerDomEvents() {
+                cwr('registerDomEvents', [
+                    { event: 'click', cssLocator: '[label="triggerDom"]' }
+                ]);
+            }
         </script>
 
         <style nonce="smokeTest">
@@ -212,6 +230,11 @@
         <button id="httpStatXhr500" onclick="httpStatXhr500()">
             httpstat xhr 500
         </button>
+        <button id="dispatchCLS" onclick="dispatchCLS()">dispatch CLS</button>
+        <button id="registerDomEvents" onclick="registerDomEvents()">
+            Update DOM Plugin
+        </button>
+        <button id="triggerDom" label="triggerDom">Trigger DOM Event</button>
         <hr />
         <button id="disable" onclick="disable()">Disable</button>
         <button id="enable" onclick="enable()">Enable</button>

--- a/src/__smoke-test__/ingestion-integ.spec.ts
+++ b/src/__smoke-test__/ingestion-integ.spec.ts
@@ -5,10 +5,13 @@ import {
     JS_ERROR_EVENT_TYPE,
     LCP_EVENT_TYPE,
     FID_EVENT_TYPE,
+    CLS_EVENT_TYPE,
     PERFORMANCE_NAVIGATION_EVENT_TYPE,
     PERFORMANCE_RESOURCE_EVENT_TYPE,
     PAGE_VIEW_EVENT_TYPE,
-    SESSION_START_EVENT_TYPE
+    SESSION_START_EVENT_TYPE,
+    DOM_EVENT_TYPE,
+    XRAY_TRACE_EVENT_TYPE
 } from '../plugins/utils/constant';
 import {
     getEventIds,
@@ -279,8 +282,108 @@ test('when http events are sent then the events are ingested', async ({
     const httpEvents = getEventsByType(requestBody, HTTP_EVENT_TYPE);
     const eventIds = getEventIds(httpEvents);
 
-    // Expect three js error events
+    // Expect two http events
     expect(eventIds.length).toEqual(2);
+    const isIngestionCompleted = await verifyIngestionWithRetry(
+        rumClient,
+        eventIds,
+        timestamp,
+        MONITOR_NAME,
+        5
+    );
+    expect(isIngestionCompleted).toEqual(true);
+});
+
+test('when CLS event is sent then the event is ingested', async ({ page }) => {
+    const timestamp = Date.now() - 30000;
+
+    // Open page
+    await page.goto(TEST_URL);
+    const cls = page.locator('[id=dispatchCLS]');
+    await cls.click();
+
+    // CLS is reported only when the page is background or unloaded (visibilitychange)
+    // Thus, while triggering CLS, Web client will use beacon instead of fetch
+    // As a result, we need to take a substring of the existing target url
+    const response = await page.waitForResponse(async (response) =>
+        isDataPlaneRequest(
+            response,
+            TARGET_URL.substring(0, TARGET_URL.length - 1)
+        )
+    );
+
+    // Parse payload to verify event count
+    const requestBody = JSON.parse(response.request().postData());
+
+    const clsEvents = getEventsByType(requestBody, CLS_EVENT_TYPE);
+    const eventIds = getEventIds(clsEvents);
+
+    // Expect one cls event
+    expect(eventIds.length).toEqual(1);
+    const isIngestionCompleted = await verifyIngestionWithRetry(
+        rumClient,
+        eventIds,
+        timestamp,
+        MONITOR_NAME,
+        5
+    );
+    expect(isIngestionCompleted).toEqual(true);
+});
+
+test('when dom event is sent then the event is ingested', async ({ page }) => {
+    const timestamp = Date.now() - 30000;
+
+    // Open page
+    await page.goto(TEST_URL);
+    const registerDom = page.locator('[id=registerDomEvents]');
+    const triggerDom = page.locator('[id=triggerDom]');
+    await registerDom.click();
+    await triggerDom.click();
+
+    // Test will timeout if no successful dataplane request is found
+    const response = await page.waitForResponse(async (response) =>
+        isDataPlaneRequest(response, TARGET_URL)
+    );
+
+    // Parse payload to verify event count
+    const requestBody = JSON.parse(response.request().postData());
+
+    const domEvent = getEventsByType(requestBody, DOM_EVENT_TYPE);
+    const eventIds = getEventIds(domEvent);
+
+    // Expect one dom event
+    expect(eventIds.length).toEqual(1);
+    const isIngestionCompleted = await verifyIngestionWithRetry(
+        rumClient,
+        eventIds,
+        timestamp,
+        MONITOR_NAME,
+        5
+    );
+    expect(isIngestionCompleted).toEqual(true);
+});
+
+test('when xray event is sent then the event is ingested', async ({ page }) => {
+    const timestamp = Date.now() - 30000;
+
+    // Open page
+    await page.goto(TEST_URL);
+    const http200 = page.locator('[id=httpStatFetch200]');
+    await http200.click();
+
+    // Test will timeout if no successful dataplane request is found
+    const response = await page.waitForResponse(async (response) =>
+        isDataPlaneRequest(response, TARGET_URL)
+    );
+
+    // Parse payload to verify event count
+    const requestBody = JSON.parse(response.request().postData());
+
+    const xrayEvent = getEventsByType(requestBody, XRAY_TRACE_EVENT_TYPE);
+    const eventIds = getEventIds(xrayEvent);
+
+    // Except one xray event
+    expect(eventIds.length).toEqual(1);
     const isIngestionCompleted = await verifyIngestionWithRetry(
         rumClient,
         eventIds,

--- a/src/test-utils/smoke-test-utils.ts
+++ b/src/test-utils/smoke-test-utils.ts
@@ -34,7 +34,7 @@ export const isDataPlaneRequest = (response, targetUrl) => {
     return (
         request.method() === 'POST' &&
         response.status() === 200 &&
-        response.url() === targetUrl
+        response.url().includes(targetUrl)
     );
 };
 


### PR DESCRIPTION
## Details
Previously in our smoke test, we covered most of the events we generated, except for `CLS_EVENT_TYPE`, `XRAY_TRACE_EVENT_TYPE`, and `DOM_EVENT_TYPE`.

This PR adds these test cases to verify ingestion behavior on the three missing event types and updates the smoke test application accordingly.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
