### PR TITLE
feat: Retry fetch requests and disable dispatch on failure.

### DIFF
--- a/src/dispatch/RetryHttpHandler.ts
+++ b/src/dispatch/RetryHttpHandler.ts
@@ -1,0 +1,41 @@
+import { HttpHandler, HttpRequest, HttpResponse } from '@aws-sdk/protocol-http';
+
+/**
+ * An HttpHandler which wraps other HttpHandlers to retry requests.
+ *
+ * Requests will be retried if (1) there is an error (e.g., with the network or
+ * credentials) and the promise rejects, or (2) the response status is not 2xx.
+ */
+export class RetryHttpHandler implements HttpHandler {
+    private handler: HttpHandler;
+    private retries: number;
+
+    public constructor(handler: HttpHandler, retries: number) {
+        this.handler = handler;
+        this.retries = retries;
+    }
+
+    public async handle(
+        request: HttpRequest
+    ): Promise<{ response: HttpResponse }> {
+        let retriesLeft = this.retries;
+        while (true) {
+            try {
+                const response = await this.handler.handle(request);
+                if (this.isStatusCode2xx(response.response.statusCode)) {
+                    return response;
+                }
+                throw new Error(`${response.response.statusCode}`);
+            } catch (e) {
+                if (!retriesLeft) {
+                    throw e;
+                }
+                retriesLeft--;
+            }
+        }
+    }
+
+    private isStatusCode2xx = (statusCode: number): boolean => {
+        return statusCode >= 200 && statusCode < 300;
+    };
+}

--- a/src/dispatch/RetryHttpHandler.ts
+++ b/src/dispatch/RetryHttpHandler.ts
@@ -46,9 +46,7 @@ export class RetryHttpHandler implements HttpHandler {
 
     private async sleep(milliseconds): Promise<void> {
         return new Promise<void>((resolve) =>
-            setTimeout(() => {
-                resolve();
-            }, milliseconds)
+            setTimeout(resolve, milliseconds)
         );
     }
 

--- a/src/dispatch/__tests__/RetryHttpHandler.test.ts
+++ b/src/dispatch/__tests__/RetryHttpHandler.test.ts
@@ -12,6 +12,8 @@ jest.mock('@aws-sdk/fetch-http-handler', () => ({
         .mockImplementation(() => ({ handle: fetchHandler }))
 }));
 
+const mockBackoff = () => 0;
+
 describe('RetryHttpHandler tests', () => {
     beforeEach(() => {
         advanceTo(0);
@@ -31,7 +33,8 @@ describe('RetryHttpHandler tests', () => {
         const retries = 1;
         const retryHandler = new RetryHttpHandler(
             new FetchHttpHandler(),
-            retries
+            retries,
+            mockBackoff
         );
 
         const client: DataPlaneClient = new DataPlaneClient({
@@ -66,7 +69,8 @@ describe('RetryHttpHandler tests', () => {
         const retries = 1;
         const retryHandler = new RetryHttpHandler(
             new FetchHttpHandler(),
-            retries
+            retries,
+            mockBackoff
         );
 
         const client: DataPlaneClient = new DataPlaneClient({
@@ -94,7 +98,8 @@ describe('RetryHttpHandler tests', () => {
         const retries = 0;
         const retryHandler = new RetryHttpHandler(
             new FetchHttpHandler(),
-            retries
+            retries,
+            mockBackoff
         );
 
         const client: DataPlaneClient = new DataPlaneClient({
@@ -128,7 +133,8 @@ describe('RetryHttpHandler tests', () => {
         const retries = 1;
         const retryHandler = new RetryHttpHandler(
             new FetchHttpHandler(),
-            retries
+            retries,
+            mockBackoff
         );
 
         const client: DataPlaneClient = new DataPlaneClient({

--- a/src/dispatch/__tests__/RetryHttpHandler.test.ts
+++ b/src/dispatch/__tests__/RetryHttpHandler.test.ts
@@ -1,0 +1,150 @@
+import * as Utils from '../../test-utils/test-utils';
+import { DataPlaneClient } from '../DataPlaneClient';
+import { HttpResponse } from '@aws-sdk/protocol-http';
+import { advanceTo } from 'jest-date-mock';
+import { RetryHttpHandler } from '../RetryHttpHandler';
+import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
+
+const fetchHandler = jest.fn<Promise<{}>, []>(() => Promise.resolve({}));
+jest.mock('@aws-sdk/fetch-http-handler', () => ({
+    FetchHttpHandler: jest
+        .fn()
+        .mockImplementation(() => ({ handle: fetchHandler }))
+}));
+
+describe('RetryHttpHandler tests', () => {
+    beforeEach(() => {
+        advanceTo(0);
+        fetchHandler.mockClear();
+        (FetchHttpHandler as jest.Mock).mockImplementation(() => {
+            return {
+                handle: fetchHandler
+            };
+        });
+    });
+
+    test('when retries run out then request fails', async () => {
+        // Init
+        const error = 'Something went wrong!';
+        fetchHandler.mockReturnValue(Promise.reject(error));
+
+        const retries = 1;
+        const retryHandler = new RetryHttpHandler(
+            new FetchHttpHandler(),
+            retries
+        );
+
+        const client: DataPlaneClient = new DataPlaneClient({
+            fetchRequestHandler: retryHandler,
+            beaconRequestHandler: undefined,
+            endpoint: Utils.AWS_RUM_ENDPOINT,
+            region: Utils.AWS_RUM_REGION,
+            credentials: Utils.createAwsCredentials()
+        });
+
+        try {
+            // Run
+            await client.sendFetch(Utils.PUT_RUM_EVENTS_REQUEST);
+        } catch (e) {
+            // Assert
+            expect(e).toEqual(error);
+            expect(fetchHandler).toHaveBeenCalledTimes(2);
+            return;
+        }
+
+        fail('Request should fail');
+    });
+
+    test('when second attempt succeeds then request succeeds', async () => {
+        // Init
+        const error = 'Something went wrong!';
+        const success = { response: { statusCode: 200 } };
+        fetchHandler
+            .mockReturnValueOnce(Promise.reject(error))
+            .mockReturnValue(Promise.resolve(success));
+
+        const retries = 1;
+        const retryHandler = new RetryHttpHandler(
+            new FetchHttpHandler(),
+            retries
+        );
+
+        const client: DataPlaneClient = new DataPlaneClient({
+            fetchRequestHandler: retryHandler,
+            beaconRequestHandler: undefined,
+            endpoint: Utils.AWS_RUM_ENDPOINT,
+            region: Utils.AWS_RUM_REGION,
+            credentials: Utils.createAwsCredentials()
+        });
+
+        // Run
+        const response: Promise<{ response: HttpResponse }> = client.sendFetch(
+            Utils.PUT_RUM_EVENTS_REQUEST
+        );
+
+        // Assert
+        expect(response).resolves.toBe(success);
+    });
+
+    test('when status code is not 2xx then request fails', async () => {
+        // Init
+        const success = { response: { statusCode: 500 } };
+        fetchHandler.mockReturnValue(Promise.resolve(success));
+
+        const retries = 0;
+        const retryHandler = new RetryHttpHandler(
+            new FetchHttpHandler(),
+            retries
+        );
+
+        const client: DataPlaneClient = new DataPlaneClient({
+            fetchRequestHandler: retryHandler,
+            beaconRequestHandler: undefined,
+            endpoint: Utils.AWS_RUM_ENDPOINT,
+            region: Utils.AWS_RUM_REGION,
+            credentials: Utils.createAwsCredentials()
+        });
+
+        try {
+            // Run
+            await client.sendFetch(Utils.PUT_RUM_EVENTS_REQUEST);
+        } catch (e) {
+            // Assert
+            expect(e.message).toEqual('500');
+            return;
+        }
+
+        fail('Request should fail');
+    });
+
+    test('when status code is not 2xx then request retries', async () => {
+        // Init
+        const badStatus = { response: { statusCode: 500 } };
+        const okStatus = { response: { statusCode: 200 } };
+        fetchHandler
+            .mockReturnValueOnce(Promise.resolve(badStatus))
+            .mockReturnValue(Promise.resolve(okStatus));
+
+        const retries = 1;
+        const retryHandler = new RetryHttpHandler(
+            new FetchHttpHandler(),
+            retries
+        );
+
+        const client: DataPlaneClient = new DataPlaneClient({
+            fetchRequestHandler: retryHandler,
+            beaconRequestHandler: undefined,
+            endpoint: Utils.AWS_RUM_ENDPOINT,
+            region: Utils.AWS_RUM_REGION,
+            credentials: Utils.createAwsCredentials()
+        });
+
+        // Run
+        const response: Promise<{ response: HttpResponse }> = client.sendFetch(
+            Utils.PUT_RUM_EVENTS_REQUEST
+        );
+
+        // Assert
+        expect(response).resolves.toBe(okStatus);
+    });
+});

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -124,7 +124,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         pagesToExclude: [],
         pagesToInclude: [],
         recordResourceUrl: true,
-        retries: 3,
+        retries: 2,
         routeChangeComplete: 100,
         routeChangeTimeout: 10000,
         sessionEventLimit: 200,

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -124,6 +124,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         pagesToExclude: [],
         pagesToInclude: [],
         recordResourceUrl: true,
+        retries: 3,
         routeChangeComplete: 100,
         routeChangeTimeout: 10000,
         sessionEventLimit: 200,
@@ -170,6 +171,7 @@ export type Config = {
     pagesToExclude: RegExp[];
     pagesToInclude: RegExp[];
     recordResourceUrl: boolean;
+    retries: number;
     routeChangeComplete: number;
     routeChangeTimeout: number;
     sessionEventLimit: number;

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -159,7 +159,7 @@ describe('Orchestration tests', () => {
             pagesToExclude: [],
             pagesToInclude: [],
             recordResourceUrl: true,
-            retries: 3,
+            retries: 2,
             routeChangeComplete: 100,
             routeChangeTimeout: 10000,
             sessionEventLimit: 200,

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -159,6 +159,7 @@ describe('Orchestration tests', () => {
             pagesToExclude: [],
             pagesToInclude: [],
             recordResourceUrl: true,
+            retries: 3,
             routeChangeComplete: 100,
             routeChangeTimeout: 10000,
             sessionEventLimit: 200,


### PR DESCRIPTION
The RUM web client does not currently have mechanisms to (1) retry failed requests, and (2) cease sending requests when there are repeated failures. This is problematic because repeating failed requests can negatively impact application and is unlikely to change the outcome of the requests.

This change causes the web client to retry failed fetch requests up to three times. If a request fails after three retries, the web client will cease sending data to the CloudWatch RUM service.

For example, failures may include: failure to retrieve credentials (e.g., from cognito/sts), failure to sign request (e.g., from malformed credentials), data plane authentication failure (i.e., 403 response code) and network failures (e.g., poor connectivity).

Related to #21

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
