### PR TITLE
feat: Custom attributes

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,7 +32,7 @@ jobs:
                   curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
 
             - name: Cache NPM modules
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: AWS RUM Web Client Continuous Build
 
 on:
     push:
-        branches: [main, feature-custom-attributes-part-2]
+        branches: [main, release-*.*.*, release-*.*.*-alpha]
     pull_request:
-        branches: [main, feature-custom-attributes-part-2]
+        branches: [main, release-*.*.*, release-*.*.*-alpha]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: AWS RUM Web Client Continuous Build
 
 on:
     push:
-        branches: [main]
+        branches: [main, feature-custom-attributes-part-2]
     pull_request:
-        branches: [main]
+        branches: [main, feature-custom-attributes-part-2]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
                   node-version: '16.x'
 
             - name: Cache NPM modules
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -64,7 +64,7 @@ jobs:
                   node-version: '16.x'
 
             - name: Cache NPM modules
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/app/index.html
+++ b/app/index.html
@@ -87,12 +87,31 @@
                 cwr('allowCookies', false);
             }
         </script>
+        <script>
+            function recordPageView() {
+                cwr('recordPageView', '/page_view_one');
+            }
+
+            function setCustomAttributes() {
+                cwr('setCustomAttributes', {
+                    customPageAttributeAtRuntimeString: 'stringCustomAttributeAtRunTimeValue',
+                    customPageAttributeAtRuntimeNumber: 1,
+                    customPageAttributeAtRuntimeBoolean: true,
+                });
+            }
+        </script>
         <button id="createHTTPError" onclick="createHTTPError()">
             Create HTTP Error
         </button>
         <button id="randomSessionClick">Random Session click</button>
         <button id="disallowCookies" onclick="disallowCookies()">
             Disallow Cookies
+        </button>
+        <button id="setCustomAttributes" onclick="setCustomAttributes()">
+            Set Custom Attributes
+        </button>
+        <button id="recordPageView" onclick="recordPageView()">
+            Record Page View
         </button>
         <span id="request"></span>
         <span id="response"></span>

--- a/app/index.html
+++ b/app/index.html
@@ -92,8 +92,8 @@
                 cwr('recordPageView', '/page_view_one');
             }
 
-            function setCustomAttributes() {
-                cwr('setCustomAttributes', {
+            function addSessionAttributes() {
+                cwr('addSessionAttributes', {
                     customPageAttributeAtRuntimeString:
                         'stringCustomAttributeAtRunTimeValue',
                     customPageAttributeAtRuntimeNumber: 1,
@@ -108,7 +108,7 @@
         <button id="disallowCookies" onclick="disallowCookies()">
             Disallow Cookies
         </button>
-        <button id="setCustomAttributes" onclick="setCustomAttributes()">
+        <button id="addSessionAttributes" onclick="addSessionAttributes()">
             Set Custom Attributes
         </button>
         <button id="recordPageView" onclick="recordPageView()">

--- a/app/index.html
+++ b/app/index.html
@@ -94,9 +94,10 @@
 
             function setCustomAttributes() {
                 cwr('setCustomAttributes', {
-                    customPageAttributeAtRuntimeString: 'stringCustomAttributeAtRunTimeValue',
+                    customPageAttributeAtRuntimeString:
+                        'stringCustomAttributeAtRunTimeValue',
                     customPageAttributeAtRuntimeNumber: 1,
-                    customPageAttributeAtRuntimeBoolean: true,
+                    customPageAttributeAtRuntimeBoolean: true
                 });
             }
         </script>

--- a/app/page_event.html
+++ b/app/page_event.html
@@ -71,10 +71,20 @@
                 cwr('recordPageView', '/page_view_two');
             }
 
-            function recordPageViewWithPageAttributes() {
+            function recordPageViewWithPageTagAttribute() {
                 cwr('recordPageView', {
                     pageId: '/page_view_two',
                     pageTags: ['pageGroup1']
+                });
+            }
+
+            function recordPageViewWithCustomPageAttributes() {
+                cwr('recordPageView', {
+                    pageId: '/page_view_two',
+                    pageTags: ['pageGroup1'],
+                    customPageAttributeString: 'customPageAttributeValue',
+                    customPageAttributeNumber: 1,
+                    customPageAttributeBoolean: true
                 });
             }
 
@@ -153,10 +163,16 @@
             Record Page View
         </button>
         <button
-            id="recordPageViewWithPageAttributes"
-            onclick="recordPageViewWithPageAttributes()"
+            id="recordPageViewWithPageTagAttribute"
+            onclick="recordPageViewWithPageTagAttribute()"
         >
-            Record Page View with page attributes
+            Record Page View with page tag attribute
+        </button>
+        <button
+            id="recordPageViewWithCustomPageAttributes"
+            onclick="recordPageViewWithCustomPageAttributes()"
+        >
+            Record Page View with custom page attributes
         </button>
         <button id="doNotRecordPageView" onclick="doNotRecordPageView()">
             Do Not Record Page View

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,11 +171,11 @@
             }
         },
         "node_modules/@aws-sdk/abort-controller": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.55.0.tgz",
-            "integrity": "sha512-rCcTxJDEFnmvo/PgbhCRv24/Uv03lEGfRslKZq7SjaMcOubflS/ZXYaMEgsjYHgAT0zlpSsyCIkJXmhFaM7H7w==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
+            "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -188,42 +188,43 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/client-rum": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-rum/-/client-rum-3.76.0.tgz",
-            "integrity": "sha512-Z/QAGFaAv11Lv/yoGnbyjTTc0SCqUMiruGyhrlMgDSSNVpXf0t6L3Tgg59gzBlF/ZFI/ZrqhE6TCrI9X5PdycQ==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-rum/-/client-rum-3.154.0.tgz",
+            "integrity": "sha512-FSyBRF2f3+mz198/ub87cb1bmpgC/e9wuG6oSnPB6wPycy4F5L9/yeaPvNoSIL7aQ6T1LbXurujmkwDJEBM8kw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.76.0",
-                "@aws-sdk/config-resolver": "3.75.0",
-                "@aws-sdk/credential-provider-node": "3.76.0",
-                "@aws-sdk/fetch-http-handler": "3.58.0",
-                "@aws-sdk/hash-node": "3.55.0",
-                "@aws-sdk/invalid-dependency": "3.55.0",
-                "@aws-sdk/middleware-content-length": "3.58.0",
-                "@aws-sdk/middleware-host-header": "3.58.0",
-                "@aws-sdk/middleware-logger": "3.55.0",
-                "@aws-sdk/middleware-retry": "3.75.0",
-                "@aws-sdk/middleware-serde": "3.55.0",
-                "@aws-sdk/middleware-signing": "3.58.0",
-                "@aws-sdk/middleware-stack": "3.55.0",
-                "@aws-sdk/middleware-user-agent": "3.58.0",
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/node-http-handler": "3.76.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/smithy-client": "3.72.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/url-parser": "3.55.0",
-                "@aws-sdk/util-base64-browser": "3.58.0",
+                "@aws-sdk/client-sts": "3.154.0",
+                "@aws-sdk/config-resolver": "3.130.0",
+                "@aws-sdk/credential-provider-node": "3.154.0",
+                "@aws-sdk/fetch-http-handler": "3.131.0",
+                "@aws-sdk/hash-node": "3.127.0",
+                "@aws-sdk/invalid-dependency": "3.127.0",
+                "@aws-sdk/middleware-content-length": "3.127.0",
+                "@aws-sdk/middleware-host-header": "3.127.0",
+                "@aws-sdk/middleware-logger": "3.127.0",
+                "@aws-sdk/middleware-recursion-detection": "3.127.0",
+                "@aws-sdk/middleware-retry": "3.127.0",
+                "@aws-sdk/middleware-serde": "3.127.0",
+                "@aws-sdk/middleware-signing": "3.130.0",
+                "@aws-sdk/middleware-stack": "3.127.0",
+                "@aws-sdk/middleware-user-agent": "3.127.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/node-http-handler": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/smithy-client": "3.142.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/url-parser": "3.127.0",
+                "@aws-sdk/util-base64-browser": "3.109.0",
                 "@aws-sdk/util-base64-node": "3.55.0",
-                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.154.0",
                 "@aws-sdk/util-body-length-node": "3.55.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.72.0",
-                "@aws-sdk/util-defaults-mode-node": "3.75.0",
-                "@aws-sdk/util-user-agent-browser": "3.58.0",
-                "@aws-sdk/util-user-agent-node": "3.75.0",
-                "@aws-sdk/util-utf8-browser": "3.55.0",
-                "@aws-sdk/util-utf8-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+                "@aws-sdk/util-defaults-mode-node": "3.142.0",
+                "@aws-sdk/util-user-agent-browser": "3.127.0",
+                "@aws-sdk/util-user-agent-node": "3.127.0",
+                "@aws-sdk/util-utf8-browser": "3.109.0",
+                "@aws-sdk/util-utf8-node": "3.109.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -266,39 +267,40 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.76.0.tgz",
-            "integrity": "sha512-trwzJWGxeagYAzo+1/JgcU/pM1vpKHW5rkbasDO5ZC4zHAlSwVhlU7yxGjYXsnobjkvf7zqTQhAxmOuMNWMFew==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.154.0.tgz",
+            "integrity": "sha512-v5pJOkCxtxcSX1Cflskz9w+7kbP3PDsE6ce3zvmdCghCRAdM0SoJMffGlg/08VXwqW+GMJTZu+i+ojXMXhZTJw==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.75.0",
-                "@aws-sdk/fetch-http-handler": "3.58.0",
-                "@aws-sdk/hash-node": "3.55.0",
-                "@aws-sdk/invalid-dependency": "3.55.0",
-                "@aws-sdk/middleware-content-length": "3.58.0",
-                "@aws-sdk/middleware-host-header": "3.58.0",
-                "@aws-sdk/middleware-logger": "3.55.0",
-                "@aws-sdk/middleware-retry": "3.75.0",
-                "@aws-sdk/middleware-serde": "3.55.0",
-                "@aws-sdk/middleware-stack": "3.55.0",
-                "@aws-sdk/middleware-user-agent": "3.58.0",
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/node-http-handler": "3.76.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/smithy-client": "3.72.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/url-parser": "3.55.0",
-                "@aws-sdk/util-base64-browser": "3.58.0",
+                "@aws-sdk/config-resolver": "3.130.0",
+                "@aws-sdk/fetch-http-handler": "3.131.0",
+                "@aws-sdk/hash-node": "3.127.0",
+                "@aws-sdk/invalid-dependency": "3.127.0",
+                "@aws-sdk/middleware-content-length": "3.127.0",
+                "@aws-sdk/middleware-host-header": "3.127.0",
+                "@aws-sdk/middleware-logger": "3.127.0",
+                "@aws-sdk/middleware-recursion-detection": "3.127.0",
+                "@aws-sdk/middleware-retry": "3.127.0",
+                "@aws-sdk/middleware-serde": "3.127.0",
+                "@aws-sdk/middleware-stack": "3.127.0",
+                "@aws-sdk/middleware-user-agent": "3.127.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/node-http-handler": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/smithy-client": "3.142.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/url-parser": "3.127.0",
+                "@aws-sdk/util-base64-browser": "3.109.0",
                 "@aws-sdk/util-base64-node": "3.55.0",
-                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.154.0",
                 "@aws-sdk/util-body-length-node": "3.55.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.72.0",
-                "@aws-sdk/util-defaults-mode-node": "3.75.0",
-                "@aws-sdk/util-user-agent-browser": "3.58.0",
-                "@aws-sdk/util-user-agent-node": "3.75.0",
-                "@aws-sdk/util-utf8-browser": "3.55.0",
-                "@aws-sdk/util-utf8-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+                "@aws-sdk/util-defaults-mode-node": "3.142.0",
+                "@aws-sdk/util-user-agent-browser": "3.127.0",
+                "@aws-sdk/util-user-agent-node": "3.127.0",
+                "@aws-sdk/util-utf8-browser": "3.109.0",
+                "@aws-sdk/util-utf8-node": "3.109.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -341,42 +343,43 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.76.0.tgz",
-            "integrity": "sha512-rrzau4y7VO9q/F6ZRuJAdZV5oKggjgJuUKGSGssYkLgO2BDblcR1ObUNetSyFsGPoSWnDhg0TjFJnlFFlIBplA==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.154.0.tgz",
+            "integrity": "sha512-YFyyJ6GJbd0DpLqByqG7DXf/b6bEfzWer+MqUEdkomEy5smCPMfqlZOXrm1cCcqZbJiOb5ASJslQr6TLllLNIg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.75.0",
-                "@aws-sdk/credential-provider-node": "3.76.0",
-                "@aws-sdk/fetch-http-handler": "3.58.0",
-                "@aws-sdk/hash-node": "3.55.0",
-                "@aws-sdk/invalid-dependency": "3.55.0",
-                "@aws-sdk/middleware-content-length": "3.58.0",
-                "@aws-sdk/middleware-host-header": "3.58.0",
-                "@aws-sdk/middleware-logger": "3.55.0",
-                "@aws-sdk/middleware-retry": "3.75.0",
-                "@aws-sdk/middleware-sdk-sts": "3.58.0",
-                "@aws-sdk/middleware-serde": "3.55.0",
-                "@aws-sdk/middleware-signing": "3.58.0",
-                "@aws-sdk/middleware-stack": "3.55.0",
-                "@aws-sdk/middleware-user-agent": "3.58.0",
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/node-http-handler": "3.76.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/smithy-client": "3.72.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/url-parser": "3.55.0",
-                "@aws-sdk/util-base64-browser": "3.58.0",
+                "@aws-sdk/config-resolver": "3.130.0",
+                "@aws-sdk/credential-provider-node": "3.154.0",
+                "@aws-sdk/fetch-http-handler": "3.131.0",
+                "@aws-sdk/hash-node": "3.127.0",
+                "@aws-sdk/invalid-dependency": "3.127.0",
+                "@aws-sdk/middleware-content-length": "3.127.0",
+                "@aws-sdk/middleware-host-header": "3.127.0",
+                "@aws-sdk/middleware-logger": "3.127.0",
+                "@aws-sdk/middleware-recursion-detection": "3.127.0",
+                "@aws-sdk/middleware-retry": "3.127.0",
+                "@aws-sdk/middleware-sdk-sts": "3.130.0",
+                "@aws-sdk/middleware-serde": "3.127.0",
+                "@aws-sdk/middleware-signing": "3.130.0",
+                "@aws-sdk/middleware-stack": "3.127.0",
+                "@aws-sdk/middleware-user-agent": "3.127.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/node-http-handler": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/smithy-client": "3.142.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/url-parser": "3.127.0",
+                "@aws-sdk/util-base64-browser": "3.109.0",
                 "@aws-sdk/util-base64-node": "3.55.0",
-                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.154.0",
                 "@aws-sdk/util-body-length-node": "3.55.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.72.0",
-                "@aws-sdk/util-defaults-mode-node": "3.75.0",
-                "@aws-sdk/util-user-agent-browser": "3.58.0",
-                "@aws-sdk/util-user-agent-node": "3.75.0",
-                "@aws-sdk/util-utf8-browser": "3.55.0",
-                "@aws-sdk/util-utf8-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+                "@aws-sdk/util-defaults-mode-node": "3.142.0",
+                "@aws-sdk/util-user-agent-browser": "3.127.0",
+                "@aws-sdk/util-user-agent-node": "3.127.0",
+                "@aws-sdk/util-utf8-browser": "3.109.0",
+                "@aws-sdk/util-utf8-node": "3.109.0",
                 "entities": "2.2.0",
                 "fast-xml-parser": "3.19.0",
                 "tslib": "^2.3.1"
@@ -421,30 +424,14 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/config-resolver": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.75.0.tgz",
-            "integrity": "sha512-sM1tygyXTEU8+UXAOs9353+lYoaWdtxPtxfC4zQsQUi0zUYCyO8jO7bNBo277uF82jkGwkraUL/F0ZN7KyzjSQ==",
+            "version": "3.130.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.130.0.tgz",
+            "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
             "dependencies": {
-                "@aws-sdk/signature-v4": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-config-provider": "3.55.0",
-                "@aws-sdk/util-middleware": "3.55.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/signature-v4": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-            "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
-            "dependencies": {
-                "@aws-sdk/is-array-buffer": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-hex-encoding": "3.58.0",
-                "@aws-sdk/util-middleware": "3.55.0",
-                "@aws-sdk/util-uri-escape": "3.55.0",
+                "@aws-sdk/signature-v4": "3.130.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/util-config-provider": "3.109.0",
+                "@aws-sdk/util-middleware": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -457,12 +444,12 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.55.0.tgz",
-            "integrity": "sha512-4AIIXEdvinLlWNFtrUbUgoB7dkuV04RTcTruVWI4Ub4WSsuSCa72ZU1vqyvcEAOgGGLBmcSaGTWByjiD2sGcGA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.127.0.tgz",
+            "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -475,14 +462,14 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/credential-provider-imds": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.75.0.tgz",
-            "integrity": "sha512-woqM/cZCnPvlel6t5o79CqT8doXe/7tSH5j8RPpfkYUwfdQwQqpjNqcO2QfkVzq4WsKfRZ92U00BhXsWDUZRfg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
+            "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/url-parser": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/url-parser": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -495,17 +482,17 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.76.0.tgz",
-            "integrity": "sha512-2je7+yjAilgwB/jZwPnhW0P8McmuZoY29A9v45SZxRSW2yABuEUJ3EvcoieUXXNRRnEz96BrldpUHDC8VhXPJw==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.154.0.tgz",
+            "integrity": "sha512-5p8vueRuAMo3cMBAHQCgAu6Kr+K6R64Bm1yccQu72HEy8zoyQsCKMV0tQS7dYbObfOGpIXZbHyESyTon0khI0g==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.55.0",
-                "@aws-sdk/credential-provider-imds": "3.75.0",
-                "@aws-sdk/credential-provider-sso": "3.76.0",
-                "@aws-sdk/credential-provider-web-identity": "3.55.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/credential-provider-env": "3.127.0",
+                "@aws-sdk/credential-provider-imds": "3.127.0",
+                "@aws-sdk/credential-provider-sso": "3.154.0",
+                "@aws-sdk/credential-provider-web-identity": "3.127.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -518,19 +505,19 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.76.0.tgz",
-            "integrity": "sha512-PCBB4sj/t5oatxuqogfB/TANMJWjE8zIAwJJagJdXgyo4vMZ8IsSjnkpMwXdUoyPq+rUx6zFq8XagJF+WW0PBw==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.154.0.tgz",
+            "integrity": "sha512-pNxKtf/ye2574+QT2aKykSzKo3RnwCtWB7Tduo/8YlmQZL+/vX53BLcGj+fLOE1h7RbY5psF02dzbanvb4CVGg==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.55.0",
-                "@aws-sdk/credential-provider-imds": "3.75.0",
-                "@aws-sdk/credential-provider-ini": "3.76.0",
-                "@aws-sdk/credential-provider-process": "3.75.0",
-                "@aws-sdk/credential-provider-sso": "3.76.0",
-                "@aws-sdk/credential-provider-web-identity": "3.55.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/credential-provider-env": "3.127.0",
+                "@aws-sdk/credential-provider-imds": "3.127.0",
+                "@aws-sdk/credential-provider-ini": "3.154.0",
+                "@aws-sdk/credential-provider-process": "3.127.0",
+                "@aws-sdk/credential-provider-sso": "3.154.0",
+                "@aws-sdk/credential-provider-web-identity": "3.127.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -543,13 +530,13 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.75.0.tgz",
-            "integrity": "sha512-G5dvX37AvS+oLGpka2JXv9wS6uViYQnspJ/56RDmXQElE7ChHBRz89GB4lOOowVQMROzpP96LARr8XNJ4iFq/w==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.127.0.tgz",
+            "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -562,14 +549,14 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.76.0.tgz",
-            "integrity": "sha512-i2vD1nrq72dNOhfsNI2iRvmI+eaxZeXQCkE5WUqURT8nHCloEkKDPchWWY2obUCVAnL1EPEoSKHyAETl1uSYew==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.154.0.tgz",
+            "integrity": "sha512-w3EZo1IKLyE7rhurq56e8IZuMxr0bc3Qvkq+AJnDwTR4sm5TPp9RNJwo+/A0i7GOdhNufcTlaciZT9Izi3g4+A==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.76.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/client-sso": "3.154.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -582,12 +569,12 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.55.0.tgz",
-            "integrity": "sha512-aKnXfZNGohTuF9rCGYLg4JEIOvWIZ/sb66XMq7bOUrx13KRPDwL/eUQL8quS5jGRLpjXVNvrS17AFf65GbdUBg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
+            "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -600,14 +587,14 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/fetch-http-handler": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
-            "integrity": "sha512-timF3FjPV5Bd+Kgph83LIKVlPCFObVYzious1a6doeLAT6YFwZpRrWbfP/HzS+DCoYiwUsH69oVJ91BoV66oyA==",
+            "version": "3.131.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+            "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/querystring-builder": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-base64-browser": "3.58.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/querystring-builder": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/util-base64-browser": "3.109.0",
                 "tslib": "^2.3.1"
             }
         },
@@ -617,11 +604,11 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@aws-sdk/hash-node": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
-            "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.127.0.tgz",
+            "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "@aws-sdk/util-buffer-from": "3.55.0",
                 "tslib": "^2.3.1"
             },
@@ -635,11 +622,11 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/invalid-dependency": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.55.0.tgz",
-            "integrity": "sha512-delH0lV+78fdD/8MXIt9kTLS6IwHvdhqq9dw/ow5VjTUw+xBwUlfPfZplaai+3hKTKWh6a2WZCeDasNItBv9aA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.127.0.tgz",
+            "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             }
         },
@@ -665,12 +652,12 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/middleware-content-length": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
-            "integrity": "sha512-h/BypPkhjv2CpCUbXA8Fa2s7V2GPiz9l11XhYK+sKSuQvQ7Lbq6VhaKaLqfeD3gLVZHgJZSLGl2btdHV1qHNNA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.127.0.tgz",
+            "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -683,12 +670,12 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
-            "integrity": "sha512-q/UKGcanm9e6DBRNN6UKhVqLvpRRdZWbmmPCeDNr4HqhCmgT6i1OvWdhAMOnT++hvCX8DpTsIXzNSlY6zWAxBg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.127.0.tgz",
+            "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -701,11 +688,11 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
-            "integrity": "sha512-PtRbVrxEzDmeV9prBIP4/9or7R5Dj66mjbFSvNRGZ0n+UBfBFfVRfNrhQPNzQpfV9A3KVl9YyWCVXDSW+/rk9Q==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.127.0.tgz",
+            "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -717,15 +704,33 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
-        "node_modules/@aws-sdk/middleware-retry": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.75.0.tgz",
-            "integrity": "sha512-6aQqeasv31d3Iu9t5YyrbbG5m8VKvjTJ+Aeio976ImhZZEEHeh6Hl2i6yX1DvOALIZmFjjMFNHwJkNOVuxXrXg==",
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
+            "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/service-error-classification": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-middleware": "3.55.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "node_modules/@aws-sdk/middleware-retry": {
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.127.0.tgz",
+            "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/service-error-classification": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/util-middleware": "3.127.0",
                 "tslib": "^2.3.1",
                 "uuid": "^8.3.2"
             },
@@ -739,31 +744,15 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.58.0.tgz",
-            "integrity": "sha512-HUz7MhcsSDDTGygOwL61l4voc0pZco06J3z06JjTX19D5XxcQ7hSCtkHHHz0oMb9M1himVSiEon2tjhjsnB99g==",
+            "version": "3.130.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
+            "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
             "dependencies": {
-                "@aws-sdk/middleware-signing": "3.58.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/signature-v4": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/signature-v4": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-            "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
-            "dependencies": {
-                "@aws-sdk/is-array-buffer": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-hex-encoding": "3.58.0",
-                "@aws-sdk/util-middleware": "3.55.0",
-                "@aws-sdk/util-uri-escape": "3.55.0",
+                "@aws-sdk/middleware-signing": "3.130.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/signature-v4": "3.130.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -776,11 +765,11 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.55.0.tgz",
-            "integrity": "sha512-NkEbTDrSZcC2NhuvfjXHKJEl0xgI2B5tMAwi/rMOq/TEnARwVUL9qAy+5lgeiPCqebiNllWatARrFgAaYf0VeA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.127.0.tgz",
+            "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -793,30 +782,14 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.58.0.tgz",
-            "integrity": "sha512-4FXubHB66GbhyZUlo6YPQoWpYfED15GNbEmHbJLSONzrVzZR3IkViSPLasDngVm1a050JqKuqNkFYGJBP4No/Q==",
+            "version": "3.130.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.130.0.tgz",
+            "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/signature-v4": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/signature-v4": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-            "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
-            "dependencies": {
-                "@aws-sdk/is-array-buffer": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-hex-encoding": "3.58.0",
-                "@aws-sdk/util-middleware": "3.55.0",
-                "@aws-sdk/util-uri-escape": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/signature-v4": "3.130.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -829,9 +802,9 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.55.0.tgz",
-            "integrity": "sha512-ouD+wFz8W2R0ZQ8HrbhgN8tg1jyINEg9lPEEXY79w1Q5sf94LJ90XKAMVk02rw3dJalUWjLHf0OQe1/qxZfHyA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+            "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -845,12 +818,12 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.58.0.tgz",
-            "integrity": "sha512-1c69bIWM63JwXijXvb9IWwcwQ/gViKMZ1lhxv52NvdG5VSxWXXsFJ2jETEXZoAypwT97Hmf3xo9SYuaHcKoq+g==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
+            "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -863,13 +836,13 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/node-config-provider": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.75.0.tgz",
-            "integrity": "sha512-eSR0HtqBwRp71d7Cp9fWzC+jtM5sDBcnp4vIQDIBPnHVzvMFwo2YPG0eF5SoYUgboHasHW8VGx9dUsKJ/qTcOg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.127.0.tgz",
+            "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -882,14 +855,14 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.76.0.tgz",
-            "integrity": "sha512-zPWPoaFC5n71efREtpSF1seijZ2E+Wsxz56EK3G55BY7WcSlLgdPXtOS1GXCFtq9Ce6gNALhYvaIryITrbtWsw==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
+            "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
             "dependencies": {
-                "@aws-sdk/abort-controller": "3.55.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/querystring-builder": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/abort-controller": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/querystring-builder": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -902,11 +875,11 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/property-provider": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.55.0.tgz",
-            "integrity": "sha512-o7cKFJSHq5WOhwPsspYrzNto35oKKZvESZuWDtLxaZKSI6l7zpA366BI4kDG6Tc9i2+teV553MbxyZ9eya5A8g==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
+            "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -919,11 +892,11 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/protocol-http": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.58.0.tgz",
-            "integrity": "sha512-0yFFRPbR+CCa9eOQBBQ2qtrIDLYqSMN0y7G4iqVM8wQdIw7n3QK1PsTI3RNPGJ3Oi2krFTw5uUKqQQZPZEBuVQ==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+            "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -936,11 +909,11 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@aws-sdk/querystring-builder": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.55.0.tgz",
-            "integrity": "sha512-/ZAXNipt9nRR8k+eowwukE/YjXnQ49p5w/MkaQxsBk3IuIf7MAcgVg8glHr0igH84GfUQ7ZVP8v+G2S3tKUG+Q==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+            "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "@aws-sdk/util-uri-escape": "3.55.0",
                 "tslib": "^2.3.1"
             },
@@ -954,11 +927,11 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.55.0.tgz",
-            "integrity": "sha512-e+2FLgo+eDx7oh7ap5HngN9XSVMxredAVztLHxCcSN0lFHHHzMa8b2SpXbaowUxQHh7ziymSqvOrPYFQ71Filg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
+            "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -971,17 +944,17 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/service-error-classification": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
-            "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.127.0.tgz",
+            "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ==",
             "engines": {
                 "node": ">= 12.0.0"
             }
         },
         "node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.75.0.tgz",
-            "integrity": "sha512-xNeBKoEqBWTdlSNhd0oA0ToA915zvKuAYHppOqJlAHpXQhjZN+Jtz31Rlor/EKZbHSMmZX7YzYMHhYWtY8aeCA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
+            "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1010,29 +983,10 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
-            "version": "3.127.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-            "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
         "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-hex-encoding": {
             "version": "3.109.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
             "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.127.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
-            "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1046,12 +1000,12 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@aws-sdk/smithy-client": {
-            "version": "3.72.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.72.0.tgz",
-            "integrity": "sha512-eQ2pEzxtS1Vz1XyNKzG4Z+mtfwRzcAs4FUQP0wrrYVJMsIdI0X4vvro8gYGoBbQtOz65uY3XqQdLuXX/SabTQg==",
+            "version": "3.142.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
+            "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
             "dependencies": {
-                "@aws-sdk/middleware-stack": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/middleware-stack": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -1064,20 +1018,20 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-            "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+            "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
             "engines": {
                 "node": ">= 12.0.0"
             }
         },
         "node_modules/@aws-sdk/url-parser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.55.0.tgz",
-            "integrity": "sha512-qrTwN5xIgTLreqLnZ+x3cAudjNKfxi6srW1H/px2mk4lb2U9B4fpGjZ6VU+XV8U2kR+YlT8J6Jo5iwuVGfC91A==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.127.0.tgz",
+            "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
             "dependencies": {
-                "@aws-sdk/querystring-parser": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/querystring-parser": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             }
         },
@@ -1087,9 +1041,9 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-base64-browser": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
-            "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
+            "version": "3.109.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
+            "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -1117,9 +1071,9 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-body-length-browser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
-            "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.154.0.tgz",
+            "integrity": "sha512-TUuy7paVkBRQrB/XFCsL8iTW6g/ma0S3N8dYOiIMJdeTqTFryeyOGkBpYBgYFQL6zRMZpyu0jOM7GYEffGFOXw==",
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -1163,9 +1117,9 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-config-provider": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
-            "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+            "version": "3.109.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
+            "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1179,12 +1133,12 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.72.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.72.0.tgz",
-            "integrity": "sha512-xeoh4jdq+tpZWDwGeXeoAQI+rZaCBEicjumBcqfzkRFE3DyaeyPHn3hiKGSR13R+P6Uf86aqaRNmWAeZZjeE0w==",
+            "version": "3.142.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.142.0.tgz",
+            "integrity": "sha512-vVB/CrodMmIfv4v54MyBlKO0sQSI/+Mvs4g5gMyVjmT4a+1gnktJQ9R6ZHQ2/ErGewcra6eH9MU5T0r1kYe0+w==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.3.1"
             },
@@ -1198,15 +1152,15 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.75.0.tgz",
-            "integrity": "sha512-zR53YinMCSVcdXumxBMdnZANl5ld0riuEoDwgKIivag/5xOAp/r+PziYvaMDbIvdqtkwwMBXf+WAc9jb0/D7sg==",
+            "version": "3.142.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.142.0.tgz",
+            "integrity": "sha512-13d5RZLO13EDwll3COUq3D4KVsqM63kdf+YjG5mzXR1eXo6GVjghfQfiy0MYM6YbAjTfJxZQkc0nFgWLU8jdyg==",
             "dependencies": {
-                "@aws-sdk/config-resolver": "3.75.0",
-                "@aws-sdk/credential-provider-imds": "3.75.0",
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/config-resolver": "3.130.0",
+                "@aws-sdk/credential-provider-imds": "3.127.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -1251,9 +1205,9 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-middleware": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.55.0.tgz",
-            "integrity": "sha512-82fW2XV+rUalv8lkd4VlhpPp6xnXO5n9sckMp1N+TrQ+p8eqxqT0+o8n1/6s9Qsnkw64Y3m6+EfCdc8/uFOY2g==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+            "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1283,11 +1237,11 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.58.0.tgz",
-            "integrity": "sha512-aJpqCvT09giJRg5xFTBDBRAVF0k0yq3OEf6UTuiOVf5azlL2MGp6PJ/xkJp9Z06PuQQkwBJ/2nIQZemo02a5Sw==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
+            "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
             "dependencies": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.3.1"
             }
@@ -1298,16 +1252,24 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.75.0.tgz",
-            "integrity": "sha512-tUKI/WIhPjGwIxFZIApWz64/JwJwwzt55Rxp8kv0cP/rYVjfCZafokUKLRwJaOBWi79luvNKV7V6lXY7RjT61A==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
+            "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
                 "node": ">= 12.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
@@ -1316,9 +1278,9 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
-            "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+            "version": "3.109.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+            "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -1329,9 +1291,9 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@aws-sdk/util-utf8-node": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
-            "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
+            "version": "3.109.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
+            "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.55.0",
                 "tslib": "^2.3.1"
@@ -20010,11 +19972,11 @@
             }
         },
         "@aws-sdk/abort-controller": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.55.0.tgz",
-            "integrity": "sha512-rCcTxJDEFnmvo/PgbhCRv24/Uv03lEGfRslKZq7SjaMcOubflS/ZXYaMEgsjYHgAT0zlpSsyCIkJXmhFaM7H7w==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
+            "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20026,42 +19988,43 @@
             }
         },
         "@aws-sdk/client-rum": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-rum/-/client-rum-3.76.0.tgz",
-            "integrity": "sha512-Z/QAGFaAv11Lv/yoGnbyjTTc0SCqUMiruGyhrlMgDSSNVpXf0t6L3Tgg59gzBlF/ZFI/ZrqhE6TCrI9X5PdycQ==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-rum/-/client-rum-3.154.0.tgz",
+            "integrity": "sha512-FSyBRF2f3+mz198/ub87cb1bmpgC/e9wuG6oSnPB6wPycy4F5L9/yeaPvNoSIL7aQ6T1LbXurujmkwDJEBM8kw==",
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.76.0",
-                "@aws-sdk/config-resolver": "3.75.0",
-                "@aws-sdk/credential-provider-node": "3.76.0",
-                "@aws-sdk/fetch-http-handler": "3.58.0",
-                "@aws-sdk/hash-node": "3.55.0",
-                "@aws-sdk/invalid-dependency": "3.55.0",
-                "@aws-sdk/middleware-content-length": "3.58.0",
-                "@aws-sdk/middleware-host-header": "3.58.0",
-                "@aws-sdk/middleware-logger": "3.55.0",
-                "@aws-sdk/middleware-retry": "3.75.0",
-                "@aws-sdk/middleware-serde": "3.55.0",
-                "@aws-sdk/middleware-signing": "3.58.0",
-                "@aws-sdk/middleware-stack": "3.55.0",
-                "@aws-sdk/middleware-user-agent": "3.58.0",
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/node-http-handler": "3.76.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/smithy-client": "3.72.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/url-parser": "3.55.0",
-                "@aws-sdk/util-base64-browser": "3.58.0",
+                "@aws-sdk/client-sts": "3.154.0",
+                "@aws-sdk/config-resolver": "3.130.0",
+                "@aws-sdk/credential-provider-node": "3.154.0",
+                "@aws-sdk/fetch-http-handler": "3.131.0",
+                "@aws-sdk/hash-node": "3.127.0",
+                "@aws-sdk/invalid-dependency": "3.127.0",
+                "@aws-sdk/middleware-content-length": "3.127.0",
+                "@aws-sdk/middleware-host-header": "3.127.0",
+                "@aws-sdk/middleware-logger": "3.127.0",
+                "@aws-sdk/middleware-recursion-detection": "3.127.0",
+                "@aws-sdk/middleware-retry": "3.127.0",
+                "@aws-sdk/middleware-serde": "3.127.0",
+                "@aws-sdk/middleware-signing": "3.130.0",
+                "@aws-sdk/middleware-stack": "3.127.0",
+                "@aws-sdk/middleware-user-agent": "3.127.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/node-http-handler": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/smithy-client": "3.142.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/url-parser": "3.127.0",
+                "@aws-sdk/util-base64-browser": "3.109.0",
                 "@aws-sdk/util-base64-node": "3.55.0",
-                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.154.0",
                 "@aws-sdk/util-body-length-node": "3.55.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.72.0",
-                "@aws-sdk/util-defaults-mode-node": "3.75.0",
-                "@aws-sdk/util-user-agent-browser": "3.58.0",
-                "@aws-sdk/util-user-agent-node": "3.75.0",
-                "@aws-sdk/util-utf8-browser": "3.55.0",
-                "@aws-sdk/util-utf8-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+                "@aws-sdk/util-defaults-mode-node": "3.142.0",
+                "@aws-sdk/util-user-agent-browser": "3.127.0",
+                "@aws-sdk/util-user-agent-node": "3.127.0",
+                "@aws-sdk/util-utf8-browser": "3.109.0",
+                "@aws-sdk/util-utf8-node": "3.109.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20107,39 +20070,40 @@
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.76.0.tgz",
-            "integrity": "sha512-trwzJWGxeagYAzo+1/JgcU/pM1vpKHW5rkbasDO5ZC4zHAlSwVhlU7yxGjYXsnobjkvf7zqTQhAxmOuMNWMFew==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.154.0.tgz",
+            "integrity": "sha512-v5pJOkCxtxcSX1Cflskz9w+7kbP3PDsE6ce3zvmdCghCRAdM0SoJMffGlg/08VXwqW+GMJTZu+i+ojXMXhZTJw==",
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.75.0",
-                "@aws-sdk/fetch-http-handler": "3.58.0",
-                "@aws-sdk/hash-node": "3.55.0",
-                "@aws-sdk/invalid-dependency": "3.55.0",
-                "@aws-sdk/middleware-content-length": "3.58.0",
-                "@aws-sdk/middleware-host-header": "3.58.0",
-                "@aws-sdk/middleware-logger": "3.55.0",
-                "@aws-sdk/middleware-retry": "3.75.0",
-                "@aws-sdk/middleware-serde": "3.55.0",
-                "@aws-sdk/middleware-stack": "3.55.0",
-                "@aws-sdk/middleware-user-agent": "3.58.0",
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/node-http-handler": "3.76.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/smithy-client": "3.72.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/url-parser": "3.55.0",
-                "@aws-sdk/util-base64-browser": "3.58.0",
+                "@aws-sdk/config-resolver": "3.130.0",
+                "@aws-sdk/fetch-http-handler": "3.131.0",
+                "@aws-sdk/hash-node": "3.127.0",
+                "@aws-sdk/invalid-dependency": "3.127.0",
+                "@aws-sdk/middleware-content-length": "3.127.0",
+                "@aws-sdk/middleware-host-header": "3.127.0",
+                "@aws-sdk/middleware-logger": "3.127.0",
+                "@aws-sdk/middleware-recursion-detection": "3.127.0",
+                "@aws-sdk/middleware-retry": "3.127.0",
+                "@aws-sdk/middleware-serde": "3.127.0",
+                "@aws-sdk/middleware-stack": "3.127.0",
+                "@aws-sdk/middleware-user-agent": "3.127.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/node-http-handler": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/smithy-client": "3.142.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/url-parser": "3.127.0",
+                "@aws-sdk/util-base64-browser": "3.109.0",
                 "@aws-sdk/util-base64-node": "3.55.0",
-                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.154.0",
                 "@aws-sdk/util-body-length-node": "3.55.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.72.0",
-                "@aws-sdk/util-defaults-mode-node": "3.75.0",
-                "@aws-sdk/util-user-agent-browser": "3.58.0",
-                "@aws-sdk/util-user-agent-node": "3.75.0",
-                "@aws-sdk/util-utf8-browser": "3.55.0",
-                "@aws-sdk/util-utf8-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+                "@aws-sdk/util-defaults-mode-node": "3.142.0",
+                "@aws-sdk/util-user-agent-browser": "3.127.0",
+                "@aws-sdk/util-user-agent-node": "3.127.0",
+                "@aws-sdk/util-utf8-browser": "3.109.0",
+                "@aws-sdk/util-utf8-node": "3.109.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20185,42 +20149,43 @@
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.76.0.tgz",
-            "integrity": "sha512-rrzau4y7VO9q/F6ZRuJAdZV5oKggjgJuUKGSGssYkLgO2BDblcR1ObUNetSyFsGPoSWnDhg0TjFJnlFFlIBplA==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.154.0.tgz",
+            "integrity": "sha512-YFyyJ6GJbd0DpLqByqG7DXf/b6bEfzWer+MqUEdkomEy5smCPMfqlZOXrm1cCcqZbJiOb5ASJslQr6TLllLNIg==",
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.75.0",
-                "@aws-sdk/credential-provider-node": "3.76.0",
-                "@aws-sdk/fetch-http-handler": "3.58.0",
-                "@aws-sdk/hash-node": "3.55.0",
-                "@aws-sdk/invalid-dependency": "3.55.0",
-                "@aws-sdk/middleware-content-length": "3.58.0",
-                "@aws-sdk/middleware-host-header": "3.58.0",
-                "@aws-sdk/middleware-logger": "3.55.0",
-                "@aws-sdk/middleware-retry": "3.75.0",
-                "@aws-sdk/middleware-sdk-sts": "3.58.0",
-                "@aws-sdk/middleware-serde": "3.55.0",
-                "@aws-sdk/middleware-signing": "3.58.0",
-                "@aws-sdk/middleware-stack": "3.55.0",
-                "@aws-sdk/middleware-user-agent": "3.58.0",
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/node-http-handler": "3.76.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/smithy-client": "3.72.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/url-parser": "3.55.0",
-                "@aws-sdk/util-base64-browser": "3.58.0",
+                "@aws-sdk/config-resolver": "3.130.0",
+                "@aws-sdk/credential-provider-node": "3.154.0",
+                "@aws-sdk/fetch-http-handler": "3.131.0",
+                "@aws-sdk/hash-node": "3.127.0",
+                "@aws-sdk/invalid-dependency": "3.127.0",
+                "@aws-sdk/middleware-content-length": "3.127.0",
+                "@aws-sdk/middleware-host-header": "3.127.0",
+                "@aws-sdk/middleware-logger": "3.127.0",
+                "@aws-sdk/middleware-recursion-detection": "3.127.0",
+                "@aws-sdk/middleware-retry": "3.127.0",
+                "@aws-sdk/middleware-sdk-sts": "3.130.0",
+                "@aws-sdk/middleware-serde": "3.127.0",
+                "@aws-sdk/middleware-signing": "3.130.0",
+                "@aws-sdk/middleware-stack": "3.127.0",
+                "@aws-sdk/middleware-user-agent": "3.127.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/node-http-handler": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/smithy-client": "3.142.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/url-parser": "3.127.0",
+                "@aws-sdk/util-base64-browser": "3.109.0",
                 "@aws-sdk/util-base64-node": "3.55.0",
-                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.154.0",
                 "@aws-sdk/util-body-length-node": "3.55.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.72.0",
-                "@aws-sdk/util-defaults-mode-node": "3.75.0",
-                "@aws-sdk/util-user-agent-browser": "3.58.0",
-                "@aws-sdk/util-user-agent-node": "3.75.0",
-                "@aws-sdk/util-utf8-browser": "3.55.0",
-                "@aws-sdk/util-utf8-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+                "@aws-sdk/util-defaults-mode-node": "3.142.0",
+                "@aws-sdk/util-user-agent-browser": "3.127.0",
+                "@aws-sdk/util-user-agent-node": "3.127.0",
+                "@aws-sdk/util-utf8-browser": "3.109.0",
+                "@aws-sdk/util-utf8-node": "3.109.0",
                 "entities": "2.2.0",
                 "fast-xml-parser": "3.19.0",
                 "tslib": "^2.3.1"
@@ -20268,30 +20233,17 @@
             }
         },
         "@aws-sdk/config-resolver": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.75.0.tgz",
-            "integrity": "sha512-sM1tygyXTEU8+UXAOs9353+lYoaWdtxPtxfC4zQsQUi0zUYCyO8jO7bNBo277uF82jkGwkraUL/F0ZN7KyzjSQ==",
+            "version": "3.130.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.130.0.tgz",
+            "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
             "requires": {
-                "@aws-sdk/signature-v4": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-config-provider": "3.55.0",
-                "@aws-sdk/util-middleware": "3.55.0",
+                "@aws-sdk/signature-v4": "3.130.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/util-config-provider": "3.109.0",
+                "@aws-sdk/util-middleware": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
-                "@aws-sdk/signature-v4": {
-                    "version": "3.58.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-                    "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
-                    "requires": {
-                        "@aws-sdk/is-array-buffer": "3.55.0",
-                        "@aws-sdk/types": "3.55.0",
-                        "@aws-sdk/util-hex-encoding": "3.58.0",
-                        "@aws-sdk/util-middleware": "3.55.0",
-                        "@aws-sdk/util-uri-escape": "3.55.0",
-                        "tslib": "^2.3.1"
-                    }
-                },
                 "tslib": {
                     "version": "2.4.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -20300,12 +20252,12 @@
             }
         },
         "@aws-sdk/credential-provider-env": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.55.0.tgz",
-            "integrity": "sha512-4AIIXEdvinLlWNFtrUbUgoB7dkuV04RTcTruVWI4Ub4WSsuSCa72ZU1vqyvcEAOgGGLBmcSaGTWByjiD2sGcGA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.127.0.tgz",
+            "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
             "requires": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20317,14 +20269,14 @@
             }
         },
         "@aws-sdk/credential-provider-imds": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.75.0.tgz",
-            "integrity": "sha512-woqM/cZCnPvlel6t5o79CqT8doXe/7tSH5j8RPpfkYUwfdQwQqpjNqcO2QfkVzq4WsKfRZ92U00BhXsWDUZRfg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
+            "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
             "requires": {
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/url-parser": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/url-parser": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20336,17 +20288,17 @@
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.76.0.tgz",
-            "integrity": "sha512-2je7+yjAilgwB/jZwPnhW0P8McmuZoY29A9v45SZxRSW2yABuEUJ3EvcoieUXXNRRnEz96BrldpUHDC8VhXPJw==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.154.0.tgz",
+            "integrity": "sha512-5p8vueRuAMo3cMBAHQCgAu6Kr+K6R64Bm1yccQu72HEy8zoyQsCKMV0tQS7dYbObfOGpIXZbHyESyTon0khI0g==",
             "requires": {
-                "@aws-sdk/credential-provider-env": "3.55.0",
-                "@aws-sdk/credential-provider-imds": "3.75.0",
-                "@aws-sdk/credential-provider-sso": "3.76.0",
-                "@aws-sdk/credential-provider-web-identity": "3.55.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/credential-provider-env": "3.127.0",
+                "@aws-sdk/credential-provider-imds": "3.127.0",
+                "@aws-sdk/credential-provider-sso": "3.154.0",
+                "@aws-sdk/credential-provider-web-identity": "3.127.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20358,19 +20310,19 @@
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.76.0.tgz",
-            "integrity": "sha512-PCBB4sj/t5oatxuqogfB/TANMJWjE8zIAwJJagJdXgyo4vMZ8IsSjnkpMwXdUoyPq+rUx6zFq8XagJF+WW0PBw==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.154.0.tgz",
+            "integrity": "sha512-pNxKtf/ye2574+QT2aKykSzKo3RnwCtWB7Tduo/8YlmQZL+/vX53BLcGj+fLOE1h7RbY5psF02dzbanvb4CVGg==",
             "requires": {
-                "@aws-sdk/credential-provider-env": "3.55.0",
-                "@aws-sdk/credential-provider-imds": "3.75.0",
-                "@aws-sdk/credential-provider-ini": "3.76.0",
-                "@aws-sdk/credential-provider-process": "3.75.0",
-                "@aws-sdk/credential-provider-sso": "3.76.0",
-                "@aws-sdk/credential-provider-web-identity": "3.55.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/credential-provider-env": "3.127.0",
+                "@aws-sdk/credential-provider-imds": "3.127.0",
+                "@aws-sdk/credential-provider-ini": "3.154.0",
+                "@aws-sdk/credential-provider-process": "3.127.0",
+                "@aws-sdk/credential-provider-sso": "3.154.0",
+                "@aws-sdk/credential-provider-web-identity": "3.127.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20382,13 +20334,13 @@
             }
         },
         "@aws-sdk/credential-provider-process": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.75.0.tgz",
-            "integrity": "sha512-G5dvX37AvS+oLGpka2JXv9wS6uViYQnspJ/56RDmXQElE7ChHBRz89GB4lOOowVQMROzpP96LARr8XNJ4iFq/w==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.127.0.tgz",
+            "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
             "requires": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20400,14 +20352,14 @@
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.76.0.tgz",
-            "integrity": "sha512-i2vD1nrq72dNOhfsNI2iRvmI+eaxZeXQCkE5WUqURT8nHCloEkKDPchWWY2obUCVAnL1EPEoSKHyAETl1uSYew==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.154.0.tgz",
+            "integrity": "sha512-w3EZo1IKLyE7rhurq56e8IZuMxr0bc3Qvkq+AJnDwTR4sm5TPp9RNJwo+/A0i7GOdhNufcTlaciZT9Izi3g4+A==",
             "requires": {
-                "@aws-sdk/client-sso": "3.76.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/client-sso": "3.154.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20419,12 +20371,12 @@
             }
         },
         "@aws-sdk/credential-provider-web-identity": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.55.0.tgz",
-            "integrity": "sha512-aKnXfZNGohTuF9rCGYLg4JEIOvWIZ/sb66XMq7bOUrx13KRPDwL/eUQL8quS5jGRLpjXVNvrS17AFf65GbdUBg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
+            "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
             "requires": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20436,14 +20388,14 @@
             }
         },
         "@aws-sdk/fetch-http-handler": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
-            "integrity": "sha512-timF3FjPV5Bd+Kgph83LIKVlPCFObVYzious1a6doeLAT6YFwZpRrWbfP/HzS+DCoYiwUsH69oVJ91BoV66oyA==",
+            "version": "3.131.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+            "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/querystring-builder": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-base64-browser": "3.58.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/querystring-builder": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/util-base64-browser": "3.109.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20455,11 +20407,11 @@
             }
         },
         "@aws-sdk/hash-node": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
-            "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.127.0.tgz",
+            "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "@aws-sdk/util-buffer-from": "3.55.0",
                 "tslib": "^2.3.1"
             },
@@ -20472,11 +20424,11 @@
             }
         },
         "@aws-sdk/invalid-dependency": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.55.0.tgz",
-            "integrity": "sha512-delH0lV+78fdD/8MXIt9kTLS6IwHvdhqq9dw/ow5VjTUw+xBwUlfPfZplaai+3hKTKWh6a2WZCeDasNItBv9aA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.127.0.tgz",
+            "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20503,12 +20455,12 @@
             }
         },
         "@aws-sdk/middleware-content-length": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
-            "integrity": "sha512-h/BypPkhjv2CpCUbXA8Fa2s7V2GPiz9l11XhYK+sKSuQvQ7Lbq6VhaKaLqfeD3gLVZHgJZSLGl2btdHV1qHNNA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.127.0.tgz",
+            "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20520,12 +20472,12 @@
             }
         },
         "@aws-sdk/middleware-host-header": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
-            "integrity": "sha512-q/UKGcanm9e6DBRNN6UKhVqLvpRRdZWbmmPCeDNr4HqhCmgT6i1OvWdhAMOnT++hvCX8DpTsIXzNSlY6zWAxBg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.127.0.tgz",
+            "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20537,11 +20489,28 @@
             }
         },
         "@aws-sdk/middleware-logger": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
-            "integrity": "sha512-PtRbVrxEzDmeV9prBIP4/9or7R5Dj66mjbFSvNRGZ0n+UBfBFfVRfNrhQPNzQpfV9A3KVl9YyWCVXDSW+/rk9Q==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.127.0.tgz",
+            "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+                }
+            }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
+            "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20553,14 +20522,14 @@
             }
         },
         "@aws-sdk/middleware-retry": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.75.0.tgz",
-            "integrity": "sha512-6aQqeasv31d3Iu9t5YyrbbG5m8VKvjTJ+Aeio976ImhZZEEHeh6Hl2i6yX1DvOALIZmFjjMFNHwJkNOVuxXrXg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.127.0.tgz",
+            "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/service-error-classification": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
-                "@aws-sdk/util-middleware": "3.55.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/service-error-classification": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
+                "@aws-sdk/util-middleware": "3.127.0",
                 "tslib": "^2.3.1",
                 "uuid": "^8.3.2"
             },
@@ -20573,31 +20542,18 @@
             }
         },
         "@aws-sdk/middleware-sdk-sts": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.58.0.tgz",
-            "integrity": "sha512-HUz7MhcsSDDTGygOwL61l4voc0pZco06J3z06JjTX19D5XxcQ7hSCtkHHHz0oMb9M1himVSiEon2tjhjsnB99g==",
+            "version": "3.130.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
+            "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
             "requires": {
-                "@aws-sdk/middleware-signing": "3.58.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/signature-v4": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/middleware-signing": "3.130.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/signature-v4": "3.130.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
-                "@aws-sdk/signature-v4": {
-                    "version": "3.58.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-                    "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
-                    "requires": {
-                        "@aws-sdk/is-array-buffer": "3.55.0",
-                        "@aws-sdk/types": "3.55.0",
-                        "@aws-sdk/util-hex-encoding": "3.58.0",
-                        "@aws-sdk/util-middleware": "3.55.0",
-                        "@aws-sdk/util-uri-escape": "3.55.0",
-                        "tslib": "^2.3.1"
-                    }
-                },
                 "tslib": {
                     "version": "2.4.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -20606,11 +20562,11 @@
             }
         },
         "@aws-sdk/middleware-serde": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.55.0.tgz",
-            "integrity": "sha512-NkEbTDrSZcC2NhuvfjXHKJEl0xgI2B5tMAwi/rMOq/TEnARwVUL9qAy+5lgeiPCqebiNllWatARrFgAaYf0VeA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.127.0.tgz",
+            "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20622,30 +20578,17 @@
             }
         },
         "@aws-sdk/middleware-signing": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.58.0.tgz",
-            "integrity": "sha512-4FXubHB66GbhyZUlo6YPQoWpYfED15GNbEmHbJLSONzrVzZR3IkViSPLasDngVm1a050JqKuqNkFYGJBP4No/Q==",
+            "version": "3.130.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.130.0.tgz",
+            "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
             "requires": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/signature-v4": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/signature-v4": "3.130.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
-                "@aws-sdk/signature-v4": {
-                    "version": "3.58.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-                    "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
-                    "requires": {
-                        "@aws-sdk/is-array-buffer": "3.55.0",
-                        "@aws-sdk/types": "3.55.0",
-                        "@aws-sdk/util-hex-encoding": "3.58.0",
-                        "@aws-sdk/util-middleware": "3.55.0",
-                        "@aws-sdk/util-uri-escape": "3.55.0",
-                        "tslib": "^2.3.1"
-                    }
-                },
                 "tslib": {
                     "version": "2.4.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -20654,9 +20597,9 @@
             }
         },
         "@aws-sdk/middleware-stack": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.55.0.tgz",
-            "integrity": "sha512-ouD+wFz8W2R0ZQ8HrbhgN8tg1jyINEg9lPEEXY79w1Q5sf94LJ90XKAMVk02rw3dJalUWjLHf0OQe1/qxZfHyA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+            "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
             "requires": {
                 "tslib": "^2.3.1"
             },
@@ -20669,12 +20612,12 @@
             }
         },
         "@aws-sdk/middleware-user-agent": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.58.0.tgz",
-            "integrity": "sha512-1c69bIWM63JwXijXvb9IWwcwQ/gViKMZ1lhxv52NvdG5VSxWXXsFJ2jETEXZoAypwT97Hmf3xo9SYuaHcKoq+g==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
+            "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20686,13 +20629,13 @@
             }
         },
         "@aws-sdk/node-config-provider": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.75.0.tgz",
-            "integrity": "sha512-eSR0HtqBwRp71d7Cp9fWzC+jtM5sDBcnp4vIQDIBPnHVzvMFwo2YPG0eF5SoYUgboHasHW8VGx9dUsKJ/qTcOg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.127.0.tgz",
+            "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
             "requires": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/shared-ini-file-loader": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/shared-ini-file-loader": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20704,14 +20647,14 @@
             }
         },
         "@aws-sdk/node-http-handler": {
-            "version": "3.76.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.76.0.tgz",
-            "integrity": "sha512-zPWPoaFC5n71efREtpSF1seijZ2E+Wsxz56EK3G55BY7WcSlLgdPXtOS1GXCFtq9Ce6gNALhYvaIryITrbtWsw==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
+            "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
             "requires": {
-                "@aws-sdk/abort-controller": "3.55.0",
-                "@aws-sdk/protocol-http": "3.58.0",
-                "@aws-sdk/querystring-builder": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/abort-controller": "3.127.0",
+                "@aws-sdk/protocol-http": "3.127.0",
+                "@aws-sdk/querystring-builder": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20723,11 +20666,11 @@
             }
         },
         "@aws-sdk/property-provider": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.55.0.tgz",
-            "integrity": "sha512-o7cKFJSHq5WOhwPsspYrzNto35oKKZvESZuWDtLxaZKSI6l7zpA366BI4kDG6Tc9i2+teV553MbxyZ9eya5A8g==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
+            "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20739,11 +20682,11 @@
             }
         },
         "@aws-sdk/protocol-http": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.58.0.tgz",
-            "integrity": "sha512-0yFFRPbR+CCa9eOQBBQ2qtrIDLYqSMN0y7G4iqVM8wQdIw7n3QK1PsTI3RNPGJ3Oi2krFTw5uUKqQQZPZEBuVQ==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+            "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20755,11 +20698,11 @@
             }
         },
         "@aws-sdk/querystring-builder": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.55.0.tgz",
-            "integrity": "sha512-/ZAXNipt9nRR8k+eowwukE/YjXnQ49p5w/MkaQxsBk3IuIf7MAcgVg8glHr0igH84GfUQ7ZVP8v+G2S3tKUG+Q==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+            "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "@aws-sdk/util-uri-escape": "3.55.0",
                 "tslib": "^2.3.1"
             },
@@ -20772,11 +20715,11 @@
             }
         },
         "@aws-sdk/querystring-parser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.55.0.tgz",
-            "integrity": "sha512-e+2FLgo+eDx7oh7ap5HngN9XSVMxredAVztLHxCcSN0lFHHHzMa8b2SpXbaowUxQHh7ziymSqvOrPYFQ71Filg==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
+            "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20788,14 +20731,14 @@
             }
         },
         "@aws-sdk/service-error-classification": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
-            "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ=="
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.127.0.tgz",
+            "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ=="
         },
         "@aws-sdk/shared-ini-file-loader": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.75.0.tgz",
-            "integrity": "sha512-xNeBKoEqBWTdlSNhd0oA0ToA915zvKuAYHppOqJlAHpXQhjZN+Jtz31Rlor/EKZbHSMmZX7YzYMHhYWtY8aeCA==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
+            "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
             "requires": {
                 "tslib": "^2.3.1"
             },
@@ -20820,23 +20763,10 @@
                 "tslib": "^2.3.1"
             },
             "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.127.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
-                    "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
-                },
                 "@aws-sdk/util-hex-encoding": {
                     "version": "3.109.0",
                     "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
                     "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
-                    "requires": {
-                        "tslib": "^2.3.1"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.127.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
-                    "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
                     "requires": {
                         "tslib": "^2.3.1"
                     }
@@ -20849,12 +20779,12 @@
             }
         },
         "@aws-sdk/smithy-client": {
-            "version": "3.72.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.72.0.tgz",
-            "integrity": "sha512-eQ2pEzxtS1Vz1XyNKzG4Z+mtfwRzcAs4FUQP0wrrYVJMsIdI0X4vvro8gYGoBbQtOz65uY3XqQdLuXX/SabTQg==",
+            "version": "3.142.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
+            "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
             "requires": {
-                "@aws-sdk/middleware-stack": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/middleware-stack": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20866,17 +20796,17 @@
             }
         },
         "@aws-sdk/types": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-            "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ=="
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+            "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
         },
         "@aws-sdk/url-parser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.55.0.tgz",
-            "integrity": "sha512-qrTwN5xIgTLreqLnZ+x3cAudjNKfxi6srW1H/px2mk4lb2U9B4fpGjZ6VU+XV8U2kR+YlT8J6Jo5iwuVGfC91A==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.127.0.tgz",
+            "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
             "requires": {
-                "@aws-sdk/querystring-parser": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/querystring-parser": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -20888,9 +20818,9 @@
             }
         },
         "@aws-sdk/util-base64-browser": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
-            "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
+            "version": "3.109.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
+            "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
             "requires": {
                 "tslib": "^2.3.1"
             },
@@ -20919,9 +20849,9 @@
             }
         },
         "@aws-sdk/util-body-length-browser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
-            "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+            "version": "3.154.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.154.0.tgz",
+            "integrity": "sha512-TUuy7paVkBRQrB/XFCsL8iTW6g/ma0S3N8dYOiIMJdeTqTFryeyOGkBpYBgYFQL6zRMZpyu0jOM7GYEffGFOXw==",
             "requires": {
                 "tslib": "^2.3.1"
             },
@@ -20965,9 +20895,9 @@
             }
         },
         "@aws-sdk/util-config-provider": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
-            "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+            "version": "3.109.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
+            "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
             "requires": {
                 "tslib": "^2.3.1"
             },
@@ -20980,12 +20910,12 @@
             }
         },
         "@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.72.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.72.0.tgz",
-            "integrity": "sha512-xeoh4jdq+tpZWDwGeXeoAQI+rZaCBEicjumBcqfzkRFE3DyaeyPHn3hiKGSR13R+P6Uf86aqaRNmWAeZZjeE0w==",
+            "version": "3.142.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.142.0.tgz",
+            "integrity": "sha512-vVB/CrodMmIfv4v54MyBlKO0sQSI/+Mvs4g5gMyVjmT4a+1gnktJQ9R6ZHQ2/ErGewcra6eH9MU5T0r1kYe0+w==",
             "requires": {
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.3.1"
             },
@@ -20998,15 +20928,15 @@
             }
         },
         "@aws-sdk/util-defaults-mode-node": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.75.0.tgz",
-            "integrity": "sha512-zR53YinMCSVcdXumxBMdnZANl5ld0riuEoDwgKIivag/5xOAp/r+PziYvaMDbIvdqtkwwMBXf+WAc9jb0/D7sg==",
+            "version": "3.142.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.142.0.tgz",
+            "integrity": "sha512-13d5RZLO13EDwll3COUq3D4KVsqM63kdf+YjG5mzXR1eXo6GVjghfQfiy0MYM6YbAjTfJxZQkc0nFgWLU8jdyg==",
             "requires": {
-                "@aws-sdk/config-resolver": "3.75.0",
-                "@aws-sdk/credential-provider-imds": "3.75.0",
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/property-provider": "3.55.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/config-resolver": "3.130.0",
+                "@aws-sdk/credential-provider-imds": "3.127.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/property-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -21048,9 +20978,9 @@
             }
         },
         "@aws-sdk/util-middleware": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.55.0.tgz",
-            "integrity": "sha512-82fW2XV+rUalv8lkd4VlhpPp6xnXO5n9sckMp1N+TrQ+p8eqxqT0+o8n1/6s9Qsnkw64Y3m6+EfCdc8/uFOY2g==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+            "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
             "requires": {
                 "tslib": "^2.3.1"
             },
@@ -21078,11 +21008,11 @@
             }
         },
         "@aws-sdk/util-user-agent-browser": {
-            "version": "3.58.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.58.0.tgz",
-            "integrity": "sha512-aJpqCvT09giJRg5xFTBDBRAVF0k0yq3OEf6UTuiOVf5azlL2MGp6PJ/xkJp9Z06PuQQkwBJ/2nIQZemo02a5Sw==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
+            "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
             "requires": {
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/types": "3.127.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.3.1"
             },
@@ -21095,12 +21025,12 @@
             }
         },
         "@aws-sdk/util-user-agent-node": {
-            "version": "3.75.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.75.0.tgz",
-            "integrity": "sha512-tUKI/WIhPjGwIxFZIApWz64/JwJwwzt55Rxp8kv0cP/rYVjfCZafokUKLRwJaOBWi79luvNKV7V6lXY7RjT61A==",
+            "version": "3.127.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
+            "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
             "requires": {
-                "@aws-sdk/node-config-provider": "3.75.0",
-                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.127.0",
+                "@aws-sdk/types": "3.127.0",
                 "tslib": "^2.3.1"
             },
             "dependencies": {
@@ -21112,9 +21042,9 @@
             }
         },
         "@aws-sdk/util-utf8-browser": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
-            "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+            "version": "3.109.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+            "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
             "requires": {
                 "tslib": "^2.3.1"
             },
@@ -21127,9 +21057,9 @@
             }
         },
         "@aws-sdk/util-utf8-node": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
-            "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
+            "version": "3.109.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
+            "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.55.0",
                 "tslib": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4909,7 +4909,7 @@
         "node_modules/add-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-            "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
+            "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
             "dev": true
         },
         "node_modules/agent-base": {
@@ -5119,7 +5119,7 @@
         "node_modules/array-ify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-            "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
             "dev": true
         },
         "node_modules/array-union": {
@@ -6733,9 +6733,9 @@
             }
         },
         "node_modules/conventional-changelog": {
-            "version": "3.1.24",
-            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.24.tgz",
-            "integrity": "sha512-ed6k8PO00UVvhExYohroVPXcOJ/K1N0/drJHx/faTH37OIZthlecuLIRX/T6uOp682CAoVoFpu+sSEaeuH6Asg==",
+            "version": "3.1.25",
+            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+            "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
             "dev": true,
             "dependencies": {
                 "conventional-changelog-angular": "^5.0.12",
@@ -6798,9 +6798,9 @@
             "dev": true
         },
         "node_modules/conventional-changelog-conventionalcommits": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
-            "integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+            "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
             "dev": true,
             "dependencies": {
                 "compare-func": "^2.0.0",
@@ -8625,18 +8625,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/fs-access": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-            "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-            "dev": true,
-            "dependencies": {
-                "null-check": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/fs-minipass": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -8861,7 +8849,7 @@
         "node_modules/git-remote-origin-url": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-            "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+            "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
             "dev": true,
             "dependencies": {
                 "gitconfiglocal": "^1.0.0",
@@ -8869,15 +8857,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/git-remote-origin-url/node_modules/pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/git-semver-tags": {
@@ -8908,7 +8887,7 @@
         "node_modules/gitconfiglocal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-            "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+            "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
             "dev": true,
             "dependencies": {
                 "ini": "^1.3.2"
@@ -14804,15 +14783,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/null-check": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-            "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -15299,6 +15269,15 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -15721,7 +15700,7 @@
         "node_modules/read-pkg-up": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+            "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
             "dev": true,
             "dependencies": {
                 "find-up": "^2.0.0",
@@ -15734,7 +15713,7 @@
         "node_modules/read-pkg-up/node_modules/find-up": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
             "dev": true,
             "dependencies": {
                 "locate-path": "^2.0.0"
@@ -15746,7 +15725,7 @@
         "node_modules/read-pkg-up/node_modules/locate-path": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
             "dev": true,
             "dependencies": {
                 "p-locate": "^2.0.0",
@@ -15771,7 +15750,7 @@
         "node_modules/read-pkg-up/node_modules/p-locate": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
             "dev": true,
             "dependencies": {
                 "p-limit": "^1.1.0"
@@ -15783,7 +15762,7 @@
         "node_modules/read-pkg-up/node_modules/p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
             "dev": true,
             "engines": {
                 "node": ">=4"
@@ -16767,22 +16746,21 @@
             "dev": true
         },
         "node_modules/standard-version": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.3.2.tgz",
-            "integrity": "sha512-u1rfKP4o4ew7Yjbfycv80aNMN2feTiqseAhUhrrx2XtdQGmu7gucpziXe68Z4YfHVqlxVEzo4aUA0Iu3VQOTgQ==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.5.0.tgz",
+            "integrity": "sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q==",
             "dev": true,
             "dependencies": {
                 "chalk": "^2.4.2",
-                "conventional-changelog": "3.1.24",
+                "conventional-changelog": "3.1.25",
                 "conventional-changelog-config-spec": "2.1.0",
-                "conventional-changelog-conventionalcommits": "4.6.1",
+                "conventional-changelog-conventionalcommits": "4.6.3",
                 "conventional-recommended-bump": "6.1.0",
                 "detect-indent": "^6.0.0",
                 "detect-newline": "^3.1.0",
                 "dotgitignore": "^2.1.0",
                 "figures": "^3.1.0",
                 "find-up": "^5.0.0",
-                "fs-access": "^1.0.1",
                 "git-semver-tags": "^4.0.0",
                 "semver": "^7.1.1",
                 "stringify-package": "^1.0.1",
@@ -17552,15 +17530,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/testcafe-browser-tools/node_modules/pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/testcafe-browser-tools/node_modules/universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -17737,15 +17706,6 @@
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
             "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
             "dev": true
-        },
-        "node_modules/testcafe-legacy-api/node_modules/pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/testcafe-legacy-api/node_modules/strip-bom": {
             "version": "2.0.0",
@@ -18090,15 +18050,6 @@
             "dependencies": {
                 "is-extglob": "^1.0.0"
             },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/testcafe/node_modules/pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18706,9 +18657,9 @@
             }
         },
         "node_modules/uglify-js": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-            "integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+            "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -19639,15 +19590,6 @@
                 "which": "^1.1.2"
             }
         },
-        "node_modules/which-promise/node_modules/pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/which-promise/node_modules/pinkie": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
@@ -19711,7 +19653,7 @@
         "node_modules/wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
             "dev": true
         },
         "node_modules/workerpool": {
@@ -23919,7 +23861,7 @@
         "add-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-            "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
+            "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
             "dev": true
         },
         "agent-base": {
@@ -24080,7 +24022,7 @@
         "array-ify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-            "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
             "dev": true
         },
         "array-union": {
@@ -25308,9 +25250,9 @@
             "dev": true
         },
         "conventional-changelog": {
-            "version": "3.1.24",
-            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.24.tgz",
-            "integrity": "sha512-ed6k8PO00UVvhExYohroVPXcOJ/K1N0/drJHx/faTH37OIZthlecuLIRX/T6uOp682CAoVoFpu+sSEaeuH6Asg==",
+            "version": "3.1.25",
+            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+            "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
             "dev": true,
             "requires": {
                 "conventional-changelog-angular": "^5.0.12",
@@ -25361,9 +25303,9 @@
             "dev": true
         },
         "conventional-changelog-conventionalcommits": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
-            "integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+            "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
             "dev": true,
             "requires": {
                 "compare-func": "^2.0.0",
@@ -26820,15 +26762,6 @@
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
             "dev": true
         },
-        "fs-access": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-            "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-            "dev": true,
-            "requires": {
-                "null-check": "^1.0.0"
-            }
-        },
         "fs-minipass": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -26988,19 +26921,11 @@
         "git-remote-origin-url": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-            "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+            "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
             "dev": true,
             "requires": {
                 "gitconfiglocal": "^1.0.0",
                 "pify": "^2.3.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
             }
         },
         "git-semver-tags": {
@@ -27024,7 +26949,7 @@
         "gitconfiglocal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-            "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+            "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
             "dev": true,
             "requires": {
                 "ini": "^1.3.2"
@@ -31509,12 +31434,6 @@
                 "path-key": "^3.0.0"
             }
         },
-        "null-check": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-            "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-            "dev": true
-        },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -31868,6 +31787,12 @@
             "integrity": "sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==",
             "dev": true
         },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true
+        },
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -32218,7 +32143,7 @@
         "read-pkg-up": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+            "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
             "dev": true,
             "requires": {
                 "find-up": "^2.0.0",
@@ -32228,7 +32153,7 @@
                 "find-up": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
                     "dev": true,
                     "requires": {
                         "locate-path": "^2.0.0"
@@ -32237,7 +32162,7 @@
                 "locate-path": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
                     "dev": true,
                     "requires": {
                         "p-locate": "^2.0.0",
@@ -32256,7 +32181,7 @@
                 "p-locate": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
                     "dev": true,
                     "requires": {
                         "p-limit": "^1.1.0"
@@ -32265,7 +32190,7 @@
                 "p-try": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
                     "dev": true
                 }
             }
@@ -33050,22 +32975,21 @@
             "dev": true
         },
         "standard-version": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.3.2.tgz",
-            "integrity": "sha512-u1rfKP4o4ew7Yjbfycv80aNMN2feTiqseAhUhrrx2XtdQGmu7gucpziXe68Z4YfHVqlxVEzo4aUA0Iu3VQOTgQ==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.5.0.tgz",
+            "integrity": "sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2",
-                "conventional-changelog": "3.1.24",
+                "conventional-changelog": "3.1.25",
                 "conventional-changelog-config-spec": "2.1.0",
-                "conventional-changelog-conventionalcommits": "4.6.1",
+                "conventional-changelog-conventionalcommits": "4.6.3",
                 "conventional-recommended-bump": "6.1.0",
                 "detect-indent": "^6.0.0",
                 "detect-newline": "^3.1.0",
                 "dotgitignore": "^2.1.0",
                 "figures": "^3.1.0",
                 "find-up": "^5.0.0",
-                "fs-access": "^1.0.1",
                 "git-semver-tags": "^4.0.0",
                 "semver": "^7.1.1",
                 "stringify-package": "^1.0.1",
@@ -33729,12 +33653,6 @@
                         "is-extglob": "^1.0.0"
                     }
                 },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                },
                 "resolve-cwd": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
@@ -33913,12 +33831,6 @@
                         "aggregate-error": "^3.0.0"
                     }
                 },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                },
                 "universalify": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -34072,12 +33984,6 @@
                     "version": "2.2.3",
                     "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
                     "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
-                    "dev": true
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 },
                 "strip-bom": {
@@ -34541,9 +34447,9 @@
             "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
         },
         "uglify-js": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-            "integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+            "version": "3.16.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+            "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
             "dev": true,
             "optional": true
         },
@@ -35244,12 +35150,6 @@
                 "which": "^1.1.2"
             },
             "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                },
                 "pinkie": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
@@ -35300,7 +35200,7 @@
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
             "dev": true
         },
         "workerpool": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10732,15 +10732,15 @@
             }
         },
         "node_modules/jest-environment-jsdom-global": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom-global/-/jest-environment-jsdom-global-3.0.0.tgz",
-            "integrity": "sha512-+7ZNxuB/35ybGug9vMaBYontqI7T8KhnUU55wtT5OYw6GRfDn2Vzak2YRvBwFjdm0so0Qz7KAL6NtEB0r+3x+g==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom-global/-/jest-environment-jsdom-global-3.1.2.tgz",
+            "integrity": "sha512-Suq/B0c8OVUYrx05j8ynKqKMzNCTNll72SLxzoTeBtjnsbrScM2Az0dBEBPN8EVTuP1lcgWN0tV0M9+hfkvXHQ==",
             "dev": true,
             "engines": {
                 "node": ">= 12"
             },
             "peerDependencies": {
-                "jest-environment-jsdom": "22.x || 23.x || 24.x || 25.x || 26.x || 27.x"
+                "jest-environment-jsdom": "22.x || 23.x || 24.x || 25.x || 26.x || 27.x || 28.x"
             }
         },
         "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
@@ -28424,9 +28424,9 @@
             }
         },
         "jest-environment-jsdom-global": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom-global/-/jest-environment-jsdom-global-3.0.0.tgz",
-            "integrity": "sha512-+7ZNxuB/35ybGug9vMaBYontqI7T8KhnUU55wtT5OYw6GRfDn2Vzak2YRvBwFjdm0so0Qz7KAL6NtEB0r+3x+g==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom-global/-/jest-environment-jsdom-global-3.1.2.tgz",
+            "integrity": "sha512-Suq/B0c8OVUYrx05j8ynKqKMzNCTNll72SLxzoTeBtjnsbrScM2Az0dBEBPN8EVTuP1lcgWN0tV0M9+hfkvXHQ==",
             "dev": true,
             "requires": {}
         },

--- a/src/CommandQueue.ts
+++ b/src/CommandQueue.ts
@@ -38,8 +38,8 @@ export class CommandQueue {
         ): void => {
             this.orchestration.setAwsCredentials(payload);
         },
-        setCustomAttributes: (payload: { [k: string]: any }): void => {
-            this.orchestration.setCustomAttributes(payload);
+        addSessionAttributes: (payload: { [k: string]: any }): void => {
+            this.orchestration.addSessionAttributes(payload);
         },
         recordPageView: (payload: any): void => {
             this.orchestration.recordPageView(payload);

--- a/src/CommandQueue.ts
+++ b/src/CommandQueue.ts
@@ -38,6 +38,9 @@ export class CommandQueue {
         ): void => {
             this.orchestration.setAwsCredentials(payload);
         },
+        setCustomAttributes: (payload: { [k: string]: any }): void => {
+            this.orchestration.setCustomAttributes(payload);
+        },
         recordPageView: (payload: any): void => {
             this.orchestration.recordPageView(payload);
         },

--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -42,6 +42,7 @@ const enable = jest.fn();
 const dispatch = jest.fn();
 const dispatchBeacon = jest.fn();
 const setAwsCredentials = jest.fn();
+const setCustomAttributes = jest.fn();
 const allowCookies = jest.fn();
 const recordPageView = jest.fn();
 const recordError = jest.fn();
@@ -53,6 +54,7 @@ jest.mock('../orchestration/Orchestration', () => ({
         dispatch,
         dispatchBeacon,
         setAwsCredentials,
+        setCustomAttributes,
         allowCookies,
         recordPageView,
         recordError,
@@ -243,6 +245,16 @@ describe('CommandQueue tests', () => {
         });
         expect(Orchestration).toHaveBeenCalled();
         expect(setAwsCredentials).toHaveBeenCalled();
+    });
+
+    test('setCustomAttributes calls Orchestration.setCustomAttributes', async () => {
+        const cq: CommandQueue = getCommandQueue();
+        const result = await cq.push({
+            c: 'setCustomAttributes',
+            p: { customAttribute: 'customAttributeValue' }
+        });
+        expect(Orchestration).toHaveBeenCalled();
+        expect(setCustomAttributes).toHaveBeenCalled();
     });
 
     test('allowCookies calls Orchestration.allowCookies', async () => {

--- a/src/__tests__/CommandQueue.test.ts
+++ b/src/__tests__/CommandQueue.test.ts
@@ -42,7 +42,7 @@ const enable = jest.fn();
 const dispatch = jest.fn();
 const dispatchBeacon = jest.fn();
 const setAwsCredentials = jest.fn();
-const setCustomAttributes = jest.fn();
+const addSessionAttributes = jest.fn();
 const allowCookies = jest.fn();
 const recordPageView = jest.fn();
 const recordError = jest.fn();
@@ -54,7 +54,7 @@ jest.mock('../orchestration/Orchestration', () => ({
         dispatch,
         dispatchBeacon,
         setAwsCredentials,
-        setCustomAttributes,
+        addSessionAttributes,
         allowCookies,
         recordPageView,
         recordError,
@@ -247,14 +247,14 @@ describe('CommandQueue tests', () => {
         expect(setAwsCredentials).toHaveBeenCalled();
     });
 
-    test('setCustomAttributes calls Orchestration.setCustomAttributes', async () => {
+    test('addSessionAttributes calls Orchestration.addSessionAttributes', async () => {
         const cq: CommandQueue = getCommandQueue();
         const result = await cq.push({
-            c: 'setCustomAttributes',
+            c: 'addSessionAttributes',
             p: { customAttribute: 'customAttributeValue' }
         });
         expect(Orchestration).toHaveBeenCalled();
-        expect(setCustomAttributes).toHaveBeenCalled();
+        expect(addSessionAttributes).toHaveBeenCalled();
     });
 
     test('allowCookies calls Orchestration.allowCookies', async () => {

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -155,10 +155,10 @@ export class EventCache {
      * Set custom session attributes to add them to all event metadata.
      * @param payload object containing custom attribute data in the form of key, value pairs
      */
-    public setCustomAttributes(payload: {
+    public addSessionAttributes(sessionAttributes: {
         [k: string]: string | number | boolean;
     }): void {
-        this.sessionManager.setCustomAttributes(payload);
+        this.sessionManager.addSessionAttributes(sessionAttributes);
     }
 
     /**

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -152,6 +152,16 @@ export class EventCache {
     }
 
     /**
+     * Set custom session attributes to add them to all event metadata.
+     * @param payload object containing custom attribute data in the form of key, value pairs
+     */
+    public setCustomAttributes(payload: {
+        [k: string]: string | number | boolean;
+    }): void {
+        this.sessionManager.setCustomAttributes(payload);
+    }
+
+    /**
      * Add a session start event to the cache.
      */
     private recordSessionInitEvent = (

--- a/src/event-cache/__tests__/EventCache.integ.test.ts
+++ b/src/event-cache/__tests__/EventCache.integ.test.ts
@@ -78,7 +78,7 @@ describe('EventCache tests', () => {
             ...{
                 allowCookies: false,
                 sessionLengthSeconds: 0,
-                customAttributesMap: {
+                sessionAttributes: {
                     version: '2.0.0',
                     domain: 'overridden.console.aws.amazon.com',
                     browserLanguage: 'en-UK',

--- a/src/event-cache/__tests__/EventCache.integ.test.ts
+++ b/src/event-cache/__tests__/EventCache.integ.test.ts
@@ -69,4 +69,44 @@ describe('EventCache tests', () => {
             expect(JSON.parse(event.metadata)).toMatchObject(expectedMetaData);
         });
     });
+
+    test('meta data contains attributes with overridden values from custom attributes', async () => {
+        // Init
+        const EVENT1_SCHEMA = 'com.amazon.rum.event1';
+        const config = {
+            ...DEFAULT_CONFIG,
+            ...{
+                allowCookies: false,
+                sessionLengthSeconds: 0,
+                customAttributesMap: {
+                    version: '2.0.0',
+                    domain: 'overridden.console.aws.amazon.com',
+                    browserLanguage: 'en-UK',
+                    browserName: 'Chrome',
+                    deviceType: 'Mac'
+                }
+            }
+        };
+
+        const eventCache: EventCache = Utils.createEventCache(config);
+        const expectedMetaData = {
+            version: '2.0.0',
+            domain: 'overridden.console.aws.amazon.com',
+            browserLanguage: 'en-UK',
+            browserName: 'Chrome',
+            deviceType: 'Mac',
+            platformType: 'web',
+            pageId: '/console/home'
+        };
+
+        // Run
+        eventCache.recordPageView('/console/home');
+        eventCache.recordEvent(EVENT1_SCHEMA, {});
+
+        // Assert
+        const events: RumEvent[] = await eventCache.getEventBatch();
+        events.forEach((event) => {
+            expect(JSON.parse(event.metadata)).toMatchObject(expectedMetaData);
+        });
+    });
 });

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -14,14 +14,14 @@ const getSession = jest.fn(() => ({
 const getUserId = jest.fn(() => 'b');
 const getAttributes = jest.fn();
 const incrementSessionEventCount = jest.fn();
-const setCustomAttributes = jest.fn();
+const addSessionAttributes = jest.fn();
 jest.mock('../../sessions/SessionManager', () => ({
     SessionManager: jest.fn().mockImplementation(() => ({
         getSession,
         getUserId,
         getAttributes,
         incrementSessionEventCount,
-        setCustomAttributes
+        addSessionAttributes
     }))
 }));
 
@@ -290,10 +290,10 @@ describe('EventCache tests', () => {
     /**
      * Test title truncated to meet lint requirements
      * Full title:
-     *  when EventCache.setCustomAttributes() is called
-     *  then SessionManager.setCustomAttributes() is called
+     *  when EventCache.addSessionAttributes() is called
+     *  then SessionManager.addSessionAttributes() is called
      */
-    test('EventCache.setCustomAttributes() calls SessionManager.setCustomAttributes()', async () => {
+    test('EventCache.addSessionAttributes() calls SessionManager.addSessionAttributes()', async () => {
         // Init
         const eventCache: EventCache = Utils.createEventCache({
             ...DEFAULT_CONFIG
@@ -306,14 +306,14 @@ describe('EventCache tests', () => {
         };
 
         // Run
-        eventCache.setCustomAttributes(expected);
+        eventCache.addSessionAttributes(expected);
 
         // Assert
         let actual;
 
         // Assert
-        expect(setCustomAttributes).toHaveBeenCalledTimes(1);
-        actual = setCustomAttributes.mock.calls[0][0];
+        expect(addSessionAttributes).toHaveBeenCalledTimes(1);
+        actual = addSessionAttributes.mock.calls[0][0];
 
         expect(actual).toEqual(expected);
     });

--- a/src/event-schemas/meta-data.json
+++ b/src/event-schemas/meta-data.json
@@ -66,7 +66,7 @@
         "pageTags": { "type": "array", "items": { "type": "string" } }
     },
     "patternProperties": {
-        "^(?!pageTags)[a-zA-Z0-9_]{1,128}$": {
+        "^(?!pageTags).{1,128}$": {
             "maxLength": 256,
             "type": ["string", "boolean", "number"]
         },

--- a/src/event-schemas/meta-data.json
+++ b/src/event-schemas/meta-data.json
@@ -65,6 +65,18 @@
         },
         "pageTags": { "type": "array", "items": { "type": "string" } }
     },
+    "patternProperties": {
+        "^(?!pageTags)[a-zA-Z0-9_]{1,128}$": {
+            "maxLength": 256,
+            "type": ["string", "boolean", "number"]
+        },
+        "pageTags": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
     "additionalProperties": false,
     "required": ["version", "domain"]
 }

--- a/src/loader/loader-standard.js
+++ b/src/loader/loader-standard.js
@@ -4,7 +4,10 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
     allowCookies: true,
     dispatchInterval: 0,
     telemetries: ['performance'],
-    clientBuilder: showRequestClientBuilder
+    clientBuilder: showRequestClientBuilder,
+    customAttributesMap: {
+        customAttributeAtInit: 'customAttributeAtInitValue'
+    }
 });
 window.cwr('setAwsCredentials', {
     accessKeyId: 'a',

--- a/src/loader/loader-standard.js
+++ b/src/loader/loader-standard.js
@@ -5,7 +5,7 @@ loader('cwr', 'abc123', '1.0', 'us-west-2', './rum_javascript_telemetry.js', {
     dispatchInterval: 0,
     telemetries: ['performance'],
     clientBuilder: showRequestClientBuilder,
-    customAttributesMap: {
+    sessionAttributes: {
         customAttributeAtInit: 'customAttributeAtInitValue'
     }
 });

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -63,6 +63,7 @@ export type PartialConfig = {
     batchLimit?: number;
     clientBuilder?: ClientBuilder;
     cookieAttributes?: PartialCookieAttributes;
+    customAttributesMap?: { [k: string]: string | number | boolean };
     disableAutoPageView?: boolean;
     dispatchInterval?: number;
     enableRumClient?: boolean;
@@ -150,6 +151,7 @@ export type Config = {
     batchLimit: number;
     clientBuilder?: ClientBuilder;
     cookieAttributes: CookieAttributes;
+    customAttributesMap?: { [k: string]: string | number | boolean };
     disableAutoPageView: boolean;
     dispatchInterval: number;
     enableRumClient: boolean;
@@ -277,6 +279,14 @@ export class Orchestration {
         credentials: Credentials | CredentialProvider
     ): void {
         this.dispatchManager.setAwsCredentials(credentials);
+    }
+
+    /**
+     * Set custom session attributes to add them to all event metadata.
+     * @param payload object containing custom attribute data in the form of key, value pairs
+     */
+    public setCustomAttributes(payload: { [key: string]: any }): void {
+        this.eventCache.setCustomAttributes(payload);
     }
 
     /**

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -63,7 +63,7 @@ export type PartialConfig = {
     batchLimit?: number;
     clientBuilder?: ClientBuilder;
     cookieAttributes?: PartialCookieAttributes;
-    customAttributesMap?: { [k: string]: string | number | boolean };
+    sessionAttributes?: { [k: string]: string | number | boolean };
     disableAutoPageView?: boolean;
     dispatchInterval?: number;
     enableRumClient?: boolean;
@@ -151,7 +151,7 @@ export type Config = {
     batchLimit: number;
     clientBuilder?: ClientBuilder;
     cookieAttributes: CookieAttributes;
-    customAttributesMap?: { [k: string]: string | number | boolean };
+    sessionAttributes?: { [k: string]: string | number | boolean };
     disableAutoPageView: boolean;
     dispatchInterval: number;
     enableRumClient: boolean;
@@ -285,7 +285,9 @@ export class Orchestration {
      * Set custom session attributes to add them to all event metadata.
      * @param payload object containing custom attribute data in the form of key, value pairs
      */
-    public setCustomAttributes(payload: { [key: string]: any }): void {
+    public setCustomAttributes(payload: {
+        [key: string]: string | boolean | number;
+    }): void {
         this.eventCache.setCustomAttributes(payload);
     }
 

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -114,6 +114,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         allowCookies: false,
         batchLimit: 100,
         cookieAttributes,
+        sessionAttributes: {},
         disableAutoPageView: false,
         dispatchInterval: 5 * 1000,
         enableRumClient: true,
@@ -151,7 +152,7 @@ export type Config = {
     batchLimit: number;
     clientBuilder?: ClientBuilder;
     cookieAttributes: CookieAttributes;
-    sessionAttributes?: { [k: string]: string | number | boolean };
+    sessionAttributes: { [k: string]: string | number | boolean };
     disableAutoPageView: boolean;
     dispatchInterval: number;
     enableRumClient: boolean;
@@ -285,10 +286,10 @@ export class Orchestration {
      * Set custom session attributes to add them to all event metadata.
      * @param payload object containing custom attribute data in the form of key, value pairs
      */
-    public setCustomAttributes(payload: {
+    public addSessionAttributes(sessionAttributes: {
         [key: string]: string | boolean | number;
     }): void {
-        this.eventCache.setCustomAttributes(payload);
+        this.eventCache.addSessionAttributes(sessionAttributes);
     }
 
     /**

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -430,7 +430,7 @@ describe('Orchestration tests', () => {
     test('when custom session attributes are initialized at setup then EventCache.setCustomAttributes() is called', async () => {
         // Init
         const orchestration = new Orchestration('a', 'c', 'us-east-1', {
-            customAttributesMap: {
+            sessionAttributes: {
                 customAttributeString: 'customAttributeValue',
                 customAttributeNumber: 1,
                 customAttributeBoolean: true

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -23,14 +23,14 @@ jest.mock('../../dispatch/Dispatch', () => ({
 const enableEventCache = jest.fn();
 const disableEventCache = jest.fn();
 const recordPageView = jest.fn();
-const setCustomAttributes = jest.fn();
+const addSessionAttributes = jest.fn();
 
 jest.mock('../../event-cache/EventCache', () => ({
     EventCache: jest.fn().mockImplementation(() => ({
         enable: enableEventCache,
         disable: disableEventCache,
         recordPageView,
-        setCustomAttributes
+        addSessionAttributes
     }))
 }));
 
@@ -148,6 +148,7 @@ describe('Orchestration tests', () => {
                 sameSite: 'Strict',
                 secure: true
             },
+            sessionAttributes: {},
             telemetries: [],
             disableAutoPageView: false,
             dispatchInterval: 5000,
@@ -409,7 +410,7 @@ describe('Orchestration tests', () => {
         expect(actual).toEqual(expected);
     });
 
-    test('when Orchestration.setCustomAttributes is called then EventCache.setCustomAttributes() is called', async () => {
+    test('when Orchestration.addSessionAttributes is called then EventCache.addSessionAttributes() is called', async () => {
         // Init
         const orchestration = new Orchestration('a', 'c', 'us-east-1', {});
 
@@ -418,16 +419,16 @@ describe('Orchestration tests', () => {
             customAttributeNumber: 1,
             customAttributeBoolean: true
         };
-        orchestration.setCustomAttributes(expected);
+        orchestration.addSessionAttributes(expected);
 
         // Assert
-        expect(setCustomAttributes).toHaveBeenCalledTimes(1);
-        const actual = setCustomAttributes.mock.calls[0][0];
+        expect(addSessionAttributes).toHaveBeenCalledTimes(1);
+        const actual = addSessionAttributes.mock.calls[0][0];
 
         expect(actual).toEqual(expected);
     });
 
-    test('when custom session attributes are initialized at setup then EventCache.setCustomAttributes() is called', async () => {
+    test('when custom session attributes are initialized at setup then EventCache.addSessionAttributes() is called', async () => {
         // Init
         const orchestration = new Orchestration('a', 'c', 'us-east-1', {
             sessionAttributes: {
@@ -442,11 +443,11 @@ describe('Orchestration tests', () => {
             customAttributeNumber: 1,
             customAttributeBoolean: true
         };
-        orchestration.setCustomAttributes(expected);
+        orchestration.addSessionAttributes(expected);
 
         // Assert
-        expect(setCustomAttributes).toHaveBeenCalledTimes(1);
-        const actual = setCustomAttributes.mock.calls[0][0];
+        expect(addSessionAttributes).toHaveBeenCalledTimes(1);
+        const actual = addSessionAttributes.mock.calls[0][0];
 
         expect(actual).toEqual(expected);
     });

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -20,7 +20,7 @@ export type Attributes = {
     // The value types of custom attributes are restricted to the types: string | number | boolean
     // However, given that pageTags is a string array, we need to include it as a valid type
     // Events will be verified by our service to validate attribute value types where
-    //  1) pageTags attribute values must be of type string[]
+    //  1) pageTags attribute value must be of type string[]
     //  2) any other attribute value must be of the following types:
     //      string | number | boolean
     [k: string]: string | number | boolean | string[];

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -17,11 +17,19 @@ export type Attributes = {
     parentPageId?: string;
     interaction?: number;
     pageTags?: string[];
+    // The value types of custom attributes are restricted to the types: string | number | boolean
+    // However, given that pageTags is a string array, we need to include it as a valid type
+    // Events will be verified by our service to validate attribute value types where
+    //  1) pageTags attribute values must be of type string[]
+    //  2) any other attribute value must be of the following types:
+    //      string | number | boolean
+    [k: string]: string | number | boolean | string[];
 };
 
 export type PageAttributes = {
     pageId: string;
     pageTags?: string[];
+    [k: string]: string | number | boolean | string[];
 };
 
 /**

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -95,7 +95,7 @@ export class SessionManager {
         this.collectAttributes();
 
         // Set custom session attributes
-        this.setCustomAttributes(this.config.sessionAttributes);
+        this.addSessionAttributes(this.config.sessionAttributes);
 
         // Attempt to restore the previous session
         this.getSessionFromCookie();
@@ -134,7 +134,7 @@ export class SessionManager {
      * Adds custom session attributes to the session's attributes
      * @param sessionAttributes object containing custom attribute data in the form of key, value pairs
      */
-    public setCustomAttributes(sessionAttributes: {
+    public addSessionAttributes(sessionAttributes: {
         [k: string]: string | number | boolean;
     }) {
         this.attributes = { ...this.attributes, ...sessionAttributes };

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -45,6 +45,8 @@ export type Attributes = {
     platformType: string;
     // The fully qualified domain name (i.e., host name + domain name)
     domain: string;
+    // Custom attribute value types are restricted to the types: string | number | boolean
+    [k: string]: string | number | boolean;
 };
 
 /**
@@ -92,6 +94,11 @@ export class SessionManager {
         // Collect the user agent and domain
         this.collectAttributes();
 
+        // Set custom session attributes
+        if (this.config.customAttributesMap) {
+            this.setCustomAttributes(this.config.customAttributesMap);
+        }
+
         // Attempt to restore the previous session
         this.getSessionFromCookie();
     }
@@ -123,6 +130,19 @@ export class SessionManager {
 
     public getAttributes(): Attributes {
         return this.attributes;
+    }
+
+    /**
+     * Adds custom session attributes to the session's attributes
+     * @param customAttributesMap object containing custom attribute data in the form of key, value pairs
+     */
+    public setCustomAttributes(customAttributesMap: {
+        [k: string]: string | number | boolean;
+    }) {
+        const attributeKeys = Object.keys(customAttributesMap);
+        for (const attribute of attributeKeys) {
+            this.attributes[attribute] = customAttributesMap[attribute];
+        }
     }
 
     public getUserId(): string {

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -95,9 +95,7 @@ export class SessionManager {
         this.collectAttributes();
 
         // Set custom session attributes
-        if (this.config.customAttributesMap) {
-            this.setCustomAttributes(this.config.customAttributesMap);
-        }
+        this.setCustomAttributes(this.config.sessionAttributes);
 
         // Attempt to restore the previous session
         this.getSessionFromCookie();
@@ -134,15 +132,12 @@ export class SessionManager {
 
     /**
      * Adds custom session attributes to the session's attributes
-     * @param customAttributesMap object containing custom attribute data in the form of key, value pairs
+     * @param sessionAttributes object containing custom attribute data in the form of key, value pairs
      */
-    public setCustomAttributes(customAttributesMap: {
+    public setCustomAttributes(sessionAttributes: {
         [k: string]: string | number | boolean;
     }) {
-        const attributeKeys = Object.keys(customAttributesMap);
-        for (const attribute of attributeKeys) {
-            this.attributes[attribute] = customAttributesMap[attribute];
-        }
+        this.attributes = { ...this.attributes, ...sessionAttributes };
     }
 
     public getUserId(): string {

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -13,7 +13,7 @@ const dispatch: Selector = Selector(`#dispatch`);
 const clear: Selector = Selector(`#clearRequestResponse`);
 const doNotRecordPageView = Selector(`#doNotRecordPageView`);
 
-fixture('PageViewEventPlugin').page('http://localhost:9000/page_event.html');
+fixture('PageViewEventPlugin').page('http://localhost:8080/page_event.html');
 
 const removeUnwantedEvents = (json: any) => {
     for (let i = 0; i < json.RumEvents.length; i++) {

--- a/src/sessions/__integ__/SessionManager.test.ts
+++ b/src/sessions/__integ__/SessionManager.test.ts
@@ -1,3 +1,4 @@
+import { PAGE_VIEW_EVENT_TYPE } from '../../plugins/utils/constant';
 import { Selector } from 'testcafe';
 import {
     STATUS_202,
@@ -29,15 +30,6 @@ const PLATFORM_TYPE = 'platformType';
 const button1: Selector = Selector(`#${BUTTON_ID_1}`);
 
 fixture('Session Handler usage').page('http://localhost:8080/');
-
-const removeUnwantedEvents = (json: any) => {
-    for (let i = 0; i < json.RumEvents.length; i++) {
-        if (/(session_start_event)/.test(json.RumEvents[i].type)) {
-            json.RumEvents.splice(i, 1);
-        }
-    }
-    return json;
-};
 
 test('When cookies are enabled, sessionManager records events using cookies', async (t: TestController) => {
     await t.wait(300);
@@ -130,11 +122,11 @@ test('When custom attribute set at init, custom attribute recorded in event meta
         .pressKey('ctrl+a delete')
         .click(SUBMIT);
 
-    const json = removeUnwantedEvents(
-        JSON.parse(await REQUEST_BODY.textContent)
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) => e.type === SESSION_START_EVENT_TYPE
     );
 
-    const metaData = JSON.parse(json.RumEvents[0].metadata);
+    const metaData = JSON.parse(events[0].metadata);
 
     await t
         .expect(metaData.customAttributeAtInit)
@@ -156,13 +148,11 @@ test('When custom attribute set at runtime, custom attribute recorded in event m
         .pressKey('ctrl+a delete')
         .click(SUBMIT);
 
-    const json = removeUnwantedEvents(
-        JSON.parse(await REQUEST_BODY.textContent)
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) => e.type === PAGE_VIEW_EVENT_TYPE
     );
 
-    const metaData = JSON.parse(
-        json.RumEvents[json.RumEvents.length - 1].metadata
-    );
+    const metaData = JSON.parse(events[events.length - 1].metadata);
 
     await t
         .expect(metaData.customPageAttributeAtRuntimeString)

--- a/src/sessions/__integ__/SessionManager.test.ts
+++ b/src/sessions/__integ__/SessionManager.test.ts
@@ -16,7 +16,7 @@ import { SESSION_START_EVENT_TYPE } from '../SessionManager';
 const randomSessionClickButton: Selector = Selector('#randomSessionClick');
 const disallowCookiesClickButton: Selector = Selector('#disallowCookies');
 
-const setCustomAttributesButton: Selector = Selector(`#setCustomAttributes`);
+const addSessionAttributesButton: Selector = Selector(`#addSessionAttributes`);
 const recordPageViewButton: Selector = Selector(`#recordPageView`);
 
 const BROWSER_LANGUAGE = 'browserLanguage';
@@ -136,7 +136,7 @@ test('When custom attribute set at init, custom attribute recorded in event meta
 test('When custom attribute set at runtime, custom attribute recorded in event metadata', async (t: TestController) => {
     await t.wait(300);
 
-    await t.click(setCustomAttributesButton);
+    await t.click(addSessionAttributesButton);
 
     await t.click(recordPageViewButton);
 

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -238,6 +238,39 @@ describe('PageManager tests', () => {
         );
     });
 
+    test('when the page is manually recorded with custom page attributes then custom page attributes are added to the page attributes', async () => {
+        // Init
+        const pageManager: PageManager = new PageManager(
+            {
+                ...DEFAULT_CONFIG,
+                allowCookies: true
+            },
+            record
+        );
+
+        pageManager.recordPageView({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1'],
+            customPageAttributeString: 'customPageAttributeValue',
+            customPageAttributeNumber: 1,
+            customPageAttributeBoolean: true
+        });
+
+        // Assert
+        expect(record.mock.calls[0][0]).toEqual(PAGE_VIEW_EVENT_TYPE);
+        expect(pageManager.getAttributes()).toMatchObject({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1'],
+            customPageAttributeString: 'customPageAttributeValue',
+            customPageAttributeNumber: 1,
+            customPageAttributeBoolean: true
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
     test('when there is no pageId difference then no pages are created', async () => {
         // Init
         const config: Config = {

--- a/src/sessions/__tests__/SessionManager.test.ts
+++ b/src/sessions/__tests__/SessionManager.test.ts
@@ -703,7 +703,7 @@ describe('SessionManager tests', () => {
             customAttributeBoolean: true
         };
 
-        sessionManager.setCustomAttributes(sessionAttributes);
+        sessionManager.addSessionAttributes(sessionAttributes);
 
         const actualSessionAttributes = sessionManager.getAttributes();
 

--- a/src/sessions/__tests__/SessionManager.test.ts
+++ b/src/sessions/__tests__/SessionManager.test.ts
@@ -667,4 +667,51 @@ describe('SessionManager tests', () => {
             sessionManager.getSession().sessionId
         );
     });
+
+    test('when custom session attributes are set at initialization then custom session attributes are added to the session attributes', async () => {
+        // Init
+        const sessionManager = defaultSessionManager({
+            ...DEFAULT_CONFIG,
+            ...{
+                customAttributesMap: {
+                    customAttributeString: 'customPageAttributeValue',
+                    customAttributeNumber: 1,
+                    customAttributeBoolean: true
+                }
+            }
+        });
+
+        const sessionAttributes = sessionManager.getAttributes();
+
+        // Assert
+        expect(sessionAttributes.customAttributeString).toEqual(
+            'customPageAttributeValue'
+        );
+        expect(sessionAttributes.customAttributeNumber).toEqual(1);
+        expect(sessionAttributes.customAttributeBoolean).toEqual(true);
+    });
+
+    test('when custom session attributes are set at runtime then custom session attributes are added to the session attributes', async () => {
+        // Init
+        const sessionManager = defaultSessionManager({
+            ...DEFAULT_CONFIG
+        });
+
+        const customAttributesMap = {
+            customAttributeString: 'customPageAttributeValue',
+            customAttributeNumber: 1,
+            customAttributeBoolean: true
+        };
+
+        sessionManager.setCustomAttributes(customAttributesMap);
+
+        const sessionAttributes = sessionManager.getAttributes();
+
+        // Assert
+        expect(sessionAttributes.customAttributeString).toEqual(
+            'customPageAttributeValue'
+        );
+        expect(sessionAttributes.customAttributeNumber).toEqual(1);
+        expect(sessionAttributes.customAttributeBoolean).toEqual(true);
+    });
 });

--- a/src/sessions/__tests__/SessionManager.test.ts
+++ b/src/sessions/__tests__/SessionManager.test.ts
@@ -673,7 +673,7 @@ describe('SessionManager tests', () => {
         const sessionManager = defaultSessionManager({
             ...DEFAULT_CONFIG,
             ...{
-                customAttributesMap: {
+                sessionAttributes: {
                     customAttributeString: 'customPageAttributeValue',
                     customAttributeNumber: 1,
                     customAttributeBoolean: true
@@ -697,21 +697,21 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG
         });
 
-        const customAttributesMap = {
+        const sessionAttributes = {
             customAttributeString: 'customPageAttributeValue',
             customAttributeNumber: 1,
             customAttributeBoolean: true
         };
 
-        sessionManager.setCustomAttributes(customAttributesMap);
+        sessionManager.setCustomAttributes(sessionAttributes);
 
-        const sessionAttributes = sessionManager.getAttributes();
+        const actualSessionAttributes = sessionManager.getAttributes();
 
         // Assert
-        expect(sessionAttributes.customAttributeString).toEqual(
+        expect(actualSessionAttributes.customAttributeString).toEqual(
             'customPageAttributeValue'
         );
-        expect(sessionAttributes.customAttributeNumber).toEqual(1);
-        expect(sessionAttributes.customAttributeBoolean).toEqual(true);
+        expect(actualSessionAttributes.customAttributeNumber).toEqual(1);
+        expect(actualSessionAttributes.customAttributeBoolean).toEqual(true);
     });
 });


### PR DESCRIPTION
**Context**:
Currently, RUM Web Client does not provide a mechanism to add custom attributes (data in the form of <key, value> pairs) to RUM events. This is problematic because users want to add attributes in addition to the default attributes provided by the RUM event schemas for better data analysis when querying or using the RUM console.

**Changes**:
This PR addresses the problem by doing the following:
1. Allow the web client to accept session attributes during initialization. 
2. Allow the web client to accept session attributes during runtime through the new `addSessionAttributes` API.
3. Allow the web client to accept page attributes during runtime through the existing `recordPageViews` API.

Invalid custom attributes will be excluded from the event metadata. Custom attributes will be validated to check:
a. Invalid key length
b. Invalid value length
c. Invalid key chars
d. Total number of custom attributes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
