### PR TITLE
fix: Set appropriate error codes in X-Ray segments

### DIFF
--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -208,11 +208,13 @@ describe('XhrPlugin tests', () => {
             start_time: 0,
             trace_id: '1-0-000000000000000000000000',
             end_time: 0,
+            fault: true,
             subsegments: [
                 {
                     id: '0000000000000000',
                     start_time: 0,
                     end_time: 0,
+                    fault: true,
                     http: {
                         request: {
                             method: 'GET',

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -53,6 +53,18 @@ export const defaultConfig: HttpPluginConfig = {
     addXRayTraceIdHeader: false
 };
 
+export const is4xx = (status: number) => {
+    return Math.floor(status / 100) === 4;
+};
+
+export const is5xx = (status: number) => {
+    return Math.floor(status / 100) === 5;
+};
+
+export const is429 = (status: number) => {
+    return status === 429;
+};
+
 export const isUrlAllowed = (url: string, config: HttpPluginConfig) => {
     const include = config.urlsToInclude.some((urlPattern) =>
         urlPattern.test(url)

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -165,7 +165,29 @@ export const mockFetchWith500 = jest.fn(
         Promise.resolve({
             status: 500,
             statusText: 'InternalError',
-            headers: {},
+            headers: new Headers({ 'Content-Length': '125' }),
+            body: '',
+            ok: false
+        } as any)
+);
+
+export const mockFetchWith400 = jest.fn(
+    (input: RequestInfo, init?: RequestInit): Promise<Response> =>
+        Promise.resolve({
+            status: 404,
+            statusText: 'Not Found',
+            headers: new Headers({ 'Content-Length': '125' }),
+            body: '',
+            ok: false
+        } as any)
+);
+
+export const mockFetchWith429 = jest.fn(
+    (input: RequestInfo, init?: RequestInit): Promise<Response> =>
+        Promise.resolve({
+            status: 429,
+            statusText: 'Too Many Requests',
+            headers: new Headers({ 'Content-Length': '125' }),
             body: '',
             ok: false
         } as any)


### PR DESCRIPTION
When an error, fault or throttle event occurs, the web client does not currently set the appropriate status flag in the X-Ray segment or subsegment. When viewing the trace in X-Ray, this causes the request to look like it succeeded when it failed.

According to the [X-Ray segment documentation](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-errors):
> Record errors in segments when your application returns an error to the user, and in subsegments when a downstream call returns an error.

This change sets the appropriate `error`, `fault` or `throttle` flag when (1) a 4xx or 5xx status code is returned, or (2) the http request fails.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
