### PR TITLE
feat: Add useBeacon config for visibilitychange dispatch behavior.

### DIFF
--- a/src/dispatch/Dispatch.ts
+++ b/src/dispatch/Dispatch.ts
@@ -152,13 +152,22 @@ export class Dispatch {
             // case. However, ad-blockers prevent sendBeacon from functioning.
             // We therefore have two bad options:
             //
-            // (1) Use sendBeacon and accept missing data when ad blockers are
+            // (1) Use sendBeacon. Data will be lost when ad blockers are
             //     used and the page loses visibility
-            // (2) Use fetch and accept missing data when the page is unloaded
+            // (2) Use fetch. Data will be lost when the page is unloaded
             //     before fetch completes
             //
             // A third option is to send both, however this would increase
             // bandwitch and require deduping server side.
+            this.config.useBeacon
+                ? this.dispatchBeaconFailSilent
+                : this.dispatchFetchFailSilent
+        );
+        // Using 'pagehide' is redundant most of the time (visibilitychange is
+        // always fired before pagehide) but older browsers may support
+        // 'pagehide' but not 'visibilitychange'.
+        document.addEventListener(
+            'pagehide',
             this.config.useBeacon
                 ? this.dispatchBeaconFailSilent
                 : this.dispatchFetchFailSilent
@@ -178,6 +187,12 @@ export class Dispatch {
     public stopDispatchTimer() {
         document.removeEventListener(
             'visibilitychange',
+            this.config.useBeacon
+                ? this.dispatchBeaconFailSilent
+                : this.dispatchFetchFailSilent
+        );
+        document.removeEventListener(
+            'pagehide',
             this.config.useBeacon
                 ? this.dispatchBeaconFailSilent
                 : this.dispatchFetchFailSilent

--- a/src/dispatch/__tests__/Dispatch.test.ts
+++ b/src/dispatch/__tests__/Dispatch.test.ts
@@ -281,6 +281,28 @@ describe('Dispatch tests', () => {
         expect(sendBeacon).toHaveBeenCalled();
     });
 
+    test('when useBeacon is false then visibilitychange uses fetch dispatch', async () => {
+        // Init
+        const dispatch = new Dispatch(
+            Utils.AWS_RUM_REGION,
+            Utils.AWS_RUM_ENDPOINT,
+            Utils.createDefaultEventCacheWithEvents(),
+            {
+                ...DEFAULT_CONFIG,
+                ...{ dispatchInterval: 1, useBeacon: false }
+            }
+        );
+        dispatch.setAwsCredentials(Utils.createAwsCredentials());
+        dispatch.startDispatchTimer();
+
+        // Run
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        // Assert
+        expect(sendBeacon).not.toHaveBeenCalled();
+        expect(sendFetch).toHaveBeenCalled();
+    });
+
     test('when plugin is disabled then beacon dispatch does not run', async () => {
         // Init
         const dispatch = new Dispatch(

--- a/src/dispatch/__tests__/Dispatch.test.ts
+++ b/src/dispatch/__tests__/Dispatch.test.ts
@@ -303,6 +303,28 @@ describe('Dispatch tests', () => {
         expect(sendFetch).toHaveBeenCalled();
     });
 
+    test('when useBeacon is false then pagehide uses fetch dispatch', async () => {
+        // Init
+        const dispatch = new Dispatch(
+            Utils.AWS_RUM_REGION,
+            Utils.AWS_RUM_ENDPOINT,
+            Utils.createDefaultEventCacheWithEvents(),
+            {
+                ...DEFAULT_CONFIG,
+                ...{ dispatchInterval: 1, useBeacon: false }
+            }
+        );
+        dispatch.setAwsCredentials(Utils.createAwsCredentials());
+        dispatch.startDispatchTimer();
+
+        // Run
+        document.dispatchEvent(new Event('pagehide'));
+
+        // Assert
+        expect(sendBeacon).not.toHaveBeenCalled();
+        expect(sendFetch).toHaveBeenCalled();
+    });
+
     test('when plugin is disabled then beacon dispatch does not run', async () => {
         // Init
         const dispatch = new Dispatch(

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -94,6 +94,7 @@ export type PartialConfig = {
      * plugins which map to the selected categories.
      */
     telemetries?: Telemetry[];
+    useBeacon?: boolean;
     userIdRetentionDays?: number;
 };
 
@@ -131,6 +132,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         sessionLengthSeconds: 60 * 30,
         sessionSampleRate: 1,
         telemetries: [],
+        useBeacon: true,
         userIdRetentionDays: 30
     };
 };
@@ -178,6 +180,7 @@ export type Config = {
     sessionLengthSeconds: number;
     sessionSampleRate: number;
     telemetries: Telemetry[];
+    useBeacon: boolean;
     userIdRetentionDays: number;
 };
 

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -167,6 +167,7 @@ describe('Orchestration tests', () => {
             sessionSampleRate: 1,
             userIdRetentionDays: 30,
             enableRumClient: true,
+            useBeacon: true,
             fetchFunction: fetch
         });
     });


### PR DESCRIPTION
When the page transitions to a hidden state and fires the `visibilitychange` event, the page [may be in the process of unloading](https://developer.chrome.com/blog/page-lifecycle-api/), so the web client flushes it's event cache. In this scenario, the approach [recommended by MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event) is to use `sendBeacon` so that the request will complete after the page is unloaded. However, ad blockers prevent `sendBeacon` from functioning, so this request may not be sent.

We therefore have two bad options:
1. Use sendBeacon and accept missing data when ad blockers are used and the page loses visibility
2. Use fetch and accept missing data when the page is unloaded before fetch completes
A third option is to send both, however this would increase bandwidch and require deduping server side.

This change adds a config option that controls whether `fetch` or `sendBeacon` is used in this scenario, so that application owners can select the behavior that best fits their application.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
