### PR TITLE
chore: Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'sunday'
+      labels:
+          - 'npm dependencies'
+      rebase-strategy: 'auto'
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'sunday'
+      labels:
+          - 'actions'


### PR DESCRIPTION
Dependabot is a GitHub utility which helps packages update vulnerable dependencies by automatically creating pull requests.

This change adds a Dependabot configuration which causes Dependabot to be run against the repository on a weekly basis, for both NPM packages and GitHub actions.

Duplicate of #178 but with correct formatting.

[cc @vasireddy99 ]

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
