### PR TITLE
fix: Remove error flag from x-ray trace root.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: AWS RUM Web Client Continuous Build
 
 on:
     push:
-        branches: [main]
+        branches: [main, release-*.*.*]
     pull_request:
-        branches: [main]
+        branches: [main, release-*.*.*]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/src/plugins/event-plugins/FetchPlugin.ts
+++ b/src/plugins/event-plugins/FetchPlugin.ts
@@ -151,7 +151,6 @@ export class FetchPlugin extends MonkeyPatched<Window, 'fetch'> {
                     xRayTraceEvent.throttle = true;
                 } else if (is4xx(response.status)) {
                     xRayTraceEvent.subsegments[0].error = true;
-                    xRayTraceEvent.error = true;
                 } else if (is5xx(response.status)) {
                     xRayTraceEvent.subsegments[0].fault = true;
                     xRayTraceEvent.fault = true;

--- a/src/plugins/event-plugins/XhrPlugin.ts
+++ b/src/plugins/event-plugins/XhrPlugin.ts
@@ -150,7 +150,6 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
                 xhrDetails.trace.throttle = true;
             } else if (is4xx(xhr.status)) {
                 xhrDetails.trace.subsegments[0].error = true;
-                xhrDetails.trace.error = true;
             } else if (is5xx(xhr.status)) {
                 xhrDetails.trace.subsegments[0].fault = true;
                 xhrDetails.trace.fault = true;

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -290,7 +290,6 @@ describe('FetchPlugin tests', () => {
 
         // Assert
         expect(record.mock.calls[0][1]).toMatchObject({
-            error: true,
             subsegments: [
                 {
                     error: true,


### PR DESCRIPTION
When recording a trace for an http 400, the X-Ray error flag is set on both the root span and the subsegment.

This change removes the error flag from the root span.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
