### PR TITLE
chore(release): 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.8.2](https://github.com/aws-observability/aws-rum-web/compare/v1.5.0...v1.8.2) (2022-08-18)
+
+
+### Bug Fixes
+* Remove error flag from x-ray trace root. ([#211](https://github.com/aws-observability/aws-rum-web/issues/211)) ([b71aaa9](https://github.com/aws-observability/aws-rum-web/commit/b71aaa9e5d34fc12ac81f0edf2cdc1de375698a0))
+
+
 ### [1.8.1](https://github.com/aws-observability/aws-rum-web/compare/v1.5.1...v1.8.1) (2022-08-04)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aws-rum-web",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-rum-web",
-            "version": "1.8.1",
+            "version": "1.8.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-rum-web",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "sideEffects": false,
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",


### PR DESCRIPTION
Releasing a patch to remove error field from X-ray trace events.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
