### PR TITLE
fix: Fix MonkeyPatch type arg.

### DIFF
--- a/src/plugins/event-plugins/XhrPlugin.ts
+++ b/src/plugins/event-plugins/XhrPlugin.ts
@@ -118,7 +118,7 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
                 nodule: XMLHttpRequest.prototype,
                 name: 'open' as const,
                 wrapper: this.openWrapper
-            } as MonkeyPatch<XMLHttpRequest, 'open'>
+            } as MonkeyPatch<XMLHttpRequest, 'send' | 'open'>
         ];
     }
 


### PR DESCRIPTION
An incorrect type argument is causing some builds to fail because of a TypeScript error.

This change fixes the TypeScript error and resolves #218 

Note that enabling TypeScript strict mode (i.e., `"strict": true` in `tsconfig.js`) made the error visible. I don't know why this error isn't visible without strict mode. I did try bumping the TypeScript version.

Issues like this could be prevented by #12.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
