### PR TITLE
Refactored recordPageView to add custom attributes in one param

### DIFF
--- a/app/page_event.html
+++ b/app/page_event.html
@@ -82,9 +82,11 @@
                 cwr('recordPageView', {
                     pageId: '/page_view_two',
                     pageTags: ['pageGroup1'],
-                    customPageAttributeString: 'customPageAttributeValue',
-                    customPageAttributeNumber: 1,
-                    customPageAttributeBoolean: true
+                    pageAttributes: {
+                        customPageAttributeString: 'customPageAttributeValue',
+                        customPageAttributeNumber: 1,
+                        customPageAttributeBoolean: true
+                    }
                 });
             }
 

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -276,9 +276,11 @@ describe('EventCache tests', () => {
         eventCache.recordPageView({
             pageId: '/rum/home',
             pageTags: ['pageGroup1'],
-            customPageAttributeString: 'customPageAttributeValue',
-            customPageAttributeNumber: 1,
-            customPageAttributeBoolean: true
+            pageAttributes: {
+                customPageAttributeString: 'customPageAttributeValue',
+                customPageAttributeNumber: 1,
+                customPageAttributeBoolean: true
+            }
         });
 
         // Assert

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -267,7 +267,7 @@ describe('EventCache tests', () => {
                 timestamp: new Date(),
                 type: EVENT1_SCHEMA,
                 metadata:
-                    '{"version":"1.0.0","title":"","pageId":"/rum/home","pageTags":["pageGroup1"],"customPageAttributeString":"customPageAttributeValue","customPageAttributeNumber":1,"customPageAttributeBoolean":true}',
+                    '{"version":"1.0.0","customPageAttributeString":"customPageAttributeValue","customPageAttributeNumber":1,"customPageAttributeBoolean":true,"title":"","pageId":"/rum/home","pageTags":["pageGroup1"]}',
                 details: '{"version":"1.0.0","pageId":"/rum/home"}'
             }
         ];

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -397,9 +397,11 @@ describe('Orchestration tests', () => {
         const expected: PageAttributes = {
             pageId: '/rum/home',
             pageTags: ['pageGroup1'],
-            customPageAttributeString: 'customPageAttributeValue',
-            customPageAttributeNumber: 1,
-            customPageAttributeBoolean: true
+            pageAttributes: {
+                customPageAttributeString: 'customPageAttributeValue',
+                customPageAttributeNumber: 1,
+                customPageAttributeBoolean: true
+            }
         };
         orchestration.recordPageView(expected);
 

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -3,6 +3,7 @@ import { RecordEvent } from '../plugins/types';
 import { PageViewEvent } from '../events/page-view-event';
 import { VirtualPageLoadTimer } from '../sessions/VirtualPageLoadTimer';
 import { PAGE_VIEW_EVENT_TYPE } from '../plugins/utils/constant';
+import { DEFAULT_PAGE_ATTRIBUTES } from '../utils/constants';
 
 export type Page = {
     pageId: string;
@@ -193,7 +194,7 @@ export class PageManager {
         if (customPageAttributes?.pageAttributes) {
             Object.keys(customPageAttributes.pageAttributes).forEach(
                 (attribute) => {
-                    if (attribute !== 'pageId') {
+                    if (!DEFAULT_PAGE_ATTRIBUTES.includes(attribute)) {
                         this.attributes[attribute] =
                             customPageAttributes.pageAttributes[attribute];
                     }

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -29,7 +29,7 @@ export type Attributes = {
 export type PageAttributes = {
     pageId: string;
     pageTags?: string[];
-    [k: string]: string | number | boolean | string[];
+    pageAttributes?: { [k: string]: string | number | boolean };
 };
 
 /**
@@ -188,9 +188,17 @@ export class PageManager {
         }
 
         if (customPageAttributes) {
-            Object.keys(customPageAttributes).forEach((attribute) => {
-                this.attributes[attribute] = customPageAttributes[attribute];
-            });
+            if (customPageAttributes.pageTags) {
+                this.attributes.pageTags = customPageAttributes.pageTags;
+            }
+            if (customPageAttributes.pageAttributes) {
+                Object.keys(customPageAttributes.pageAttributes).forEach(
+                    (attribute) => {
+                        this.attributes[attribute] =
+                            customPageAttributes.pageAttributes[attribute];
+                    }
+                );
+            }
         }
     }
 

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -187,18 +187,18 @@ export class PageManager {
             }
         }
 
-        if (customPageAttributes) {
-            if (customPageAttributes.pageTags) {
-                this.attributes.pageTags = customPageAttributes.pageTags;
-            }
-            if (customPageAttributes.pageAttributes) {
-                Object.keys(customPageAttributes.pageAttributes).forEach(
-                    (attribute) => {
+        if (customPageAttributes?.pageTags) {
+            this.attributes.pageTags = customPageAttributes.pageTags;
+        }
+        if (customPageAttributes?.pageAttributes) {
+            Object.keys(customPageAttributes.pageAttributes).forEach(
+                (attribute) => {
+                    if (attribute !== 'pageId') {
                         this.attributes[attribute] =
                             customPageAttributes.pageAttributes[attribute];
                     }
-                );
-            }
+                }
+            );
         }
     }
 

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -192,14 +192,10 @@ export class PageManager {
             this.attributes.pageTags = customPageAttributes.pageTags;
         }
         if (customPageAttributes?.pageAttributes) {
-            Object.keys(customPageAttributes.pageAttributes).forEach(
-                (attribute) => {
-                    if (!DEFAULT_PAGE_ATTRIBUTES.includes(attribute)) {
-                        this.attributes[attribute] =
-                            customPageAttributes.pageAttributes[attribute];
-                    }
-                }
-            );
+            this.attributes = {
+                ...customPageAttributes.pageAttributes,
+                ...this.attributes
+            };
         }
     }
 

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -273,6 +273,44 @@ describe('PageManager tests', () => {
             (pageManager as any).popstateListener
         );
     });
+
+    test('when the page is manually recorded with custom page attributes then pageId value at top level takes precendence', async () => {
+        // Init
+        const pageManager: PageManager = new PageManager(
+            {
+                ...DEFAULT_CONFIG,
+                allowCookies: true
+            },
+            record
+        );
+
+        pageManager.recordPageView({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1'],
+            pageAttributes: {
+                pageId: '/rum/home/override',
+                customPageAttributeString: 'customPageAttributeValue',
+                customPageAttributeNumber: 1,
+                customPageAttributeBoolean: true
+            }
+        });
+
+        // Assert
+        expect(record.mock.calls[0][0]).toEqual(PAGE_VIEW_EVENT_TYPE);
+        expect(pageManager.getAttributes()).toMatchObject({
+            pageId: '/rum/home',
+            pageTags: ['pageGroup1'],
+            customPageAttributeString: 'customPageAttributeValue',
+            customPageAttributeNumber: 1,
+            customPageAttributeBoolean: true
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
+
     test('when there is no pageId difference then no pages are created', async () => {
         // Init
         const config: Config = {

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -251,9 +251,11 @@ describe('PageManager tests', () => {
         pageManager.recordPageView({
             pageId: '/rum/home',
             pageTags: ['pageGroup1'],
-            customPageAttributeString: 'customPageAttributeValue',
-            customPageAttributeNumber: 1,
-            customPageAttributeBoolean: true
+            pageAttributes: {
+                customPageAttributeString: 'customPageAttributeValue',
+                customPageAttributeNumber: 1,
+                customPageAttributeBoolean: true
+            }
         });
 
         // Assert

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -289,6 +289,7 @@ describe('PageManager tests', () => {
             pageTags: ['pageGroup1'],
             pageAttributes: {
                 pageId: '/rum/home/override',
+                pageTags: 'testingOverride',
                 customPageAttributeString: 'customPageAttributeValue',
                 customPageAttributeNumber: 1,
                 customPageAttributeBoolean: true

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,3 +2,5 @@ export const CRED_KEY = 'cwr_c';
 export const SESSION_COOKIE_NAME = 'cwr_s';
 export const USER_COOKIE_NAME = 'cwr_u';
 export const CRED_RENEW_MS = 30000;
+
+export const DEFAULT_PAGE_ATTRIBUTES = ['pageId', 'pageTags'];


### PR DESCRIPTION
Previously, users would add custom page attributes to page view events by adding them as individual fields into the object sent in the `recordPageView()` command. However, to keep parity with how users send in custom session attributes, this change will allow users to send the custom page attributes together in a separate field.

For example:

```
//Before
{
  pageId: '/page_view_two',
  pageTags: ['pageGroup1'],
  customPageAttributeString: 'customPageAttributeValue',
  customPageAttributeNumber: 1,
  customPageAttributeBoolean: true
}
```

```
//After
{
  pageId: '/page_view_two',
  pageTags: ['pageGroup1'],
  pageAttributes: {
    customPageAttributeString: 'customPageAttributeValue',
    customPageAttributeNumber: 1,
    customPageAttributeBoolean: true
  } 
}
```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
