### PR TITLE
fix: Default attributes not overwritten by custom attributes

### DIFF
--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -207,9 +207,9 @@ export class EventCache {
         // objects with their own attribute sets. Instead, we store session
         // attributes and page attributes together as 'meta data'.
         const metaData: MetaData = {
-            version: '1.0.0',
             ...this.sessionManager.getAttributes(),
-            ...this.pageManager.getAttributes()
+            ...this.pageManager.getAttributes(),
+            version: '1.0.0'
         };
 
         this.events.push({

--- a/src/event-cache/__tests__/EventCache.integ.test.ts
+++ b/src/event-cache/__tests__/EventCache.integ.test.ts
@@ -70,7 +70,7 @@ describe('EventCache tests', () => {
         });
     });
 
-    test('meta data contains attributes with overridden values from custom attributes', async () => {
+    test('meta data contains default attributes not overridden from custom attributes', async () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const config = {
@@ -90,11 +90,11 @@ describe('EventCache tests', () => {
 
         const eventCache: EventCache = Utils.createEventCache(config);
         const expectedMetaData = {
-            version: '2.0.0',
-            domain: 'overridden.console.aws.amazon.com',
-            browserLanguage: 'en-UK',
-            browserName: 'Chrome',
-            deviceType: 'Mac',
+            version: '1.0.0',
+            domain: 'us-east-1.console.aws.amazon.com',
+            browserLanguage: 'en-US',
+            browserName: 'WebKit',
+            deviceType: 'desktop',
             platformType: 'web',
             pageId: '/console/home'
         };

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -238,7 +238,7 @@ describe('EventCache tests', () => {
                 timestamp: new Date(),
                 type: EVENT1_SCHEMA,
                 metadata:
-                    '{"version":"1.0.0","title":"","pageId":"/rum/home","pageTags":["pageGroup1"]}',
+                    '{"title":"","pageId":"/rum/home","pageTags":["pageGroup1"],"version":"1.0.0"}',
                 details: '{"version":"1.0.0","pageId":"/rum/home"}'
             }
         ];
@@ -267,7 +267,7 @@ describe('EventCache tests', () => {
                 timestamp: new Date(),
                 type: EVENT1_SCHEMA,
                 metadata:
-                    '{"version":"1.0.0","customPageAttributeString":"customPageAttributeValue","customPageAttributeNumber":1,"customPageAttributeBoolean":true,"title":"","pageId":"/rum/home","pageTags":["pageGroup1"]}',
+                    '{"customPageAttributeString":"customPageAttributeValue","customPageAttributeNumber":1,"customPageAttributeBoolean":true,"title":"","pageId":"/rum/home","pageTags":["pageGroup1"],"version":"1.0.0"}',
                 details: '{"version":"1.0.0","pageId":"/rum/home"}'
             }
         ];

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -137,7 +137,7 @@ export class SessionManager {
     public addSessionAttributes(sessionAttributes: {
         [k: string]: string | number | boolean;
     }) {
-        this.attributes = { ...this.attributes, ...sessionAttributes };
+        this.attributes = { ...sessionAttributes, ...this.attributes };
     }
 
     public getUserId(): string {


### PR DESCRIPTION
Previously, users could overwrite built-in default attributes. However, this may lead to unexpected behavior in the CW RUM console and poor user experience. This change will ensure that built-int attributes will overwrite any custom attributes if the attribute key is the same.

Changes passed integ tests: https://github.com/limhjgrace/aws-rum-web/pull/1

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
