### PR TITLE
fix: Only ignore PutRumEvents requests on proxy endpoints.

### DIFF
--- a/src/plugins/event-plugins/ResourcePlugin.ts
+++ b/src/plugins/event-plugins/ResourcePlugin.ts
@@ -118,11 +118,15 @@ export class ResourcePlugin extends InternalPlugin {
     };
 
     recordResourceEvent = (entryData: PerformanceResourceTiming): void => {
-        // Ignore monitoring beacons.
+        const pathRegex = /.*\/application\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/events/;
+        const entryUrl = new URL(entryData.name);
         if (
-            new URL(entryData.name).host ===
-            this.context.config.endpointUrl.host
+            entryUrl.host === this.context.config.endpointUrl.host &&
+            pathRegex.test(entryUrl.pathname)
         ) {
+            // Ignore calls to PutRumEvents (i.e., the CloudWatch RUM data
+            // plane), otherwise we end up in an infinite loop of recording
+            // PutRumEvents.
             return;
         }
 

--- a/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
@@ -3,8 +3,9 @@ import {
     performanceEvent,
     performanceEventNotLoaded,
     mockPerformanceObserver,
-    mockPerformanceObject,
-    MockPerformanceTiming
+    MockPerformanceTiming,
+    mockPerformanceObjectWith,
+    putRumEventsDocument
 } from '../../../test-utils/mock-data';
 import { NavigationPlugin } from '../NavigationPlugin';
 import { context, record } from '../../../test-utils/test-utils';
@@ -46,7 +47,7 @@ describe('NavigationPlugin tests', () => {
 
     test('When navigation timing level 2 API is not present then navigation timing level 1 API is recorded', async () => {
         jest.useFakeTimers();
-        mockPerformanceObject();
+        mockPerformanceObjectWith([putRumEventsDocument], [], []);
         mockPerformanceObserver();
 
         const plugin: NavigationPlugin = buildNavigationPlugin();

--- a/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
@@ -4,9 +4,12 @@ import {
     cssResourceEvent,
     performanceEvent,
     mockPerformanceObserver,
-    mockPerformanceObject,
     mockPerformanceObjectWithResources,
-    resourceEvent
+    resourceEvent,
+    mockPerformanceObjectWith,
+    putRumEventsDocument,
+    putRumEventsGammaDocument,
+    dataPlaneDocument
 } from '../../../test-utils/mock-data';
 import { PartialResourcePluginConfig, ResourcePlugin } from '../ResourcePlugin';
 import { mockRandom } from 'jest-mock-random';
@@ -90,9 +93,9 @@ describe('ResourcePlugin tests', () => {
         ).toBeUndefined();
     });
 
-    test('when resource is from data plane endpoint then resource event is not recorded', async () => {
+    test('when resource is a PutRumEvents request then resource event is not recorded', async () => {
         // Setup
-        mockPerformanceObject();
+        mockPerformanceObjectWith([putRumEventsDocument], [], []);
         mockPerformanceObserver();
 
         const plugin: ResourcePlugin = buildResourcePlugin();
@@ -104,6 +107,38 @@ describe('ResourcePlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
+    });
+
+    test('when resource is a PutRumEvents request with a path prefix then resource event is not recorded', async () => {
+        // Setup
+        mockPerformanceObjectWith([putRumEventsGammaDocument], [], []);
+        mockPerformanceObserver();
+
+        const plugin: ResourcePlugin = buildResourcePlugin();
+
+        // Run
+        plugin.load(context);
+        window.dispatchEvent(new Event('load'));
+        plugin.disable();
+
+        // Assert
+        expect(record).not.toHaveBeenCalled();
+    });
+
+    test('when resource is not a PutRumEvents request but has the same host then the resource event is recorded', async () => {
+        // Setup
+        mockPerformanceObjectWith([dataPlaneDocument], [], []);
+        mockPerformanceObserver();
+
+        const plugin: ResourcePlugin = buildResourcePlugin();
+
+        // Run
+        plugin.load(context);
+        window.dispatchEvent(new Event('load'));
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalled();
     });
 
     test('when enabled then events are recorded', async () => {

--- a/src/test-utils/mock-data.ts
+++ b/src/test-utils/mock-data.ts
@@ -140,32 +140,43 @@ export const resourceEvent2 = {
     fileType: 'image'
 };
 
-export const dataPlaneResourceEvent = {
-    connectEnd: 0,
-    connectStart: 0,
-    decodedBodySize: 0,
-    domainLookupEnd: 0,
-    domainLookupStart: 0,
-    duration: 438.39999999909196,
-    encodedBodySize: 0,
-    entryType: 'resource',
-    fetchStart: 357.59500000131084,
-    initiatorType: 'link',
-    name:
-        'https://dataplane.rum.us-west-2.amazonaws.com/application/aa17a42c-e737-48f7-adaf-2e0905f48073/events',
-    nextHopProtocol: 'h2',
-    redirectEnd: 0,
-    redirectStart: 0,
-    requestStart: 0,
-    responseEnd: 795.9950000004028,
-    responseStart: 0,
-    secureConnectionStart: 0,
-    serverTiming: [],
-    startTime: 357.59500000131084,
-    transferSize: 0,
-    workerStart: 0,
-    fileType: 'document'
+export const createDocumentResource = (url: string) => {
+    return {
+        connectEnd: 0,
+        connectStart: 0,
+        decodedBodySize: 0,
+        domainLookupEnd: 0,
+        domainLookupStart: 0,
+        duration: 438.39999999909196,
+        encodedBodySize: 0,
+        entryType: 'resource',
+        fetchStart: 357.59500000131084,
+        initiatorType: 'link',
+        name: url,
+        nextHopProtocol: 'h2',
+        redirectEnd: 0,
+        redirectStart: 0,
+        requestStart: 0,
+        responseEnd: 795.9950000004028,
+        responseStart: 0,
+        secureConnectionStart: 0,
+        serverTiming: [],
+        startTime: 357.59500000131084,
+        transferSize: 0,
+        workerStart: 0,
+        fileType: 'document'
+    };
 };
+
+export const putRumEventsDocument = createDocumentResource(
+    'https://dataplane.rum.us-west-2.amazonaws.com/application/aa17a42c-e737-48f7-adaf-2e0905f48073/events'
+);
+export const putRumEventsGammaDocument = createDocumentResource(
+    'https://dataplane.rum.us-west-2.amazonaws.com/gamma/application/aa17a42c-e737-48f7-adaf-2e0905f48073/events'
+);
+export const dataPlaneDocument = createDocumentResource(
+    'https://dataplane.rum.us-west-2.amazonaws.com/user'
+);
 
 export const scriptResourceEvent = {
     connectEnd: 386.37999998172745,
@@ -368,15 +379,22 @@ export const performanceEventNotLoaded = {
     PerformanceObserver: MockPerformanceObserver
 };
 
-export const mockPerformanceObject = () => {
+export const mockPerformanceObjectWith = (
+    resource: any[],
+    paint: any[],
+    navigation: any[]
+) => {
     delete (window as any).performance;
     const performanceObject = {
         getEntriesByType: (entryType: string) => {
             if (entryType === 'resource') {
-                return [dataPlaneResourceEvent];
+                return resource;
             }
             if (entryType === 'paint') {
-                return [];
+                return paint;
+            }
+            if (entryType === 'navigation') {
+                return navigation;
             }
             return [];
         },
@@ -391,63 +409,22 @@ export const mockPerformanceObject = () => {
         value: performanceObject,
         writable: true
     });
+};
+
+export const mockPerformanceObjectWithDataPlaneResource = () => {
+    mockPerformanceObjectWith([putRumEventsDocument], [], []);
 };
 
 export const mockPerformanceObjectWithResources = () => {
-    delete (window as any).performance;
-    const performanceObject = {
-        getEntriesByType: (entryType: string) => {
-            if (entryType === 'resource') {
-                return [
-                    scriptResourceEvent,
-                    imageResourceEvent,
-                    cssResourceEvent
-                ];
-            }
-            if (entryType === 'paint') {
-                return [];
-            }
-            return [];
-        },
-        now: () => {
-            return Date.now();
-        },
-        timing: MockPerformanceTiming
-    };
-    Object.defineProperty(window, 'performance', {
-        configurable: true,
-        enumerable: true,
-        value: performanceObject,
-        writable: true
-    });
+    mockPerformanceObjectWith(
+        [scriptResourceEvent, imageResourceEvent, cssResourceEvent],
+        [],
+        []
+    );
 };
 
 export const mockPaintPerformanceObject = () => {
-    delete (window as any).performance;
-    const performanceObject = {
-        getEntriesByType: (entryType: string) => {
-            if (entryType === 'resource') {
-                return [resourceEvent];
-            }
-            if (entryType === 'paint') {
-                return [];
-            }
-            if (entryType === 'navigation') {
-                return [navigationEvent];
-            }
-            return [];
-        },
-        now: () => {
-            return Date.now();
-        },
-        timing: MockPerformanceTiming
-    };
-    Object.defineProperty(window, 'performance', {
-        configurable: true,
-        enumerable: true,
-        value: performanceObject,
-        writable: true
-    });
+    mockPerformanceObjectWith([resourceEvent], [], [navigationEvent]);
 };
 
 export class MockPaintPerformanceObserver {


### PR DESCRIPTION
The web client currently ignores resource timings where the resource has the same host name as the RUM data plane endpoint. While this prevents an infinite loop of recording PutRumEvents requests, it is problematic when PutRumEvents requests are proxied through the same endpoint as the application server.

For example, I may have an endpoint which routes the following paths:
1. `https://myapp.amazonaws.com/user`
2. `https://myapp.amazonaws.com/gamma/application/aa17a42c-e737-48f7-adaf-2e0905f48073/events`

In case (1), the request is related to the application logic, and the web client should record the request.

In case (2), the request is related to RUM, and the web client should not record the request.

This change solves the problem by checking the path fragment of the resource URL **in addition to** the host name of the resource URL. This allows the web client to disambiguate application requests from PutRumEvents proxy requests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
