### PR TITLE
fix: Add cause to Cognito and STS error messages

### DIFF
--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -125,7 +125,7 @@ export class Authentication {
                     WebIdentityToken: getOpenIdTokenResponse.Token
                 })
             )
-            .then((credentials) => {
+            .then((credentials: Credentials) => {
                 this.credentials = credentials;
                 try {
                     localStorage.setItem(CRED_KEY, JSON.stringify(credentials));

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -81,7 +81,7 @@ export class Authentication {
      */
     private AnonymousStorageCredentialsProvider = async (): Promise<Credentials> => {
         return new Promise<Credentials>((resolve, reject) => {
-            let credentials;
+            let credentials: Credentials;
             try {
                 credentials = JSON.parse(localStorage.getItem(CRED_KEY)!);
             } catch (e) {
@@ -91,8 +91,10 @@ export class Authentication {
             // The expiration property of Credentials has a date type. Because the date was serialized as a string,
             // we need to convert it back into a date, otherwise the AWS SDK signing middleware
             // (@aws-sdk/middleware-signing) will throw an exception and no credentials will be returned.
-            credentials.expiration = new Date(credentials.expiration);
-            this.credentials = credentials;
+            this.credentials = {
+                ...credentials,
+                expiration: new Date(credentials.expiration as Date)
+            };
             if (this.renewCredentials()) {
                 // The credentials have expired.
                 return reject();

--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -52,24 +52,24 @@ export class CognitoIdentityClient {
     }
 
     public getId = async (request: { IdentityPoolId: string }) => {
-        const requestPayload = JSON.stringify(request);
-
-        const idRequest = this.getHttpRequest(GET_ID_TARGET, requestPayload);
-        return this.fetchRequestHandler
-            .handle(idRequest)
-            .then(({ response }) =>
-                response.body
-                    .getReader()
-                    .read()
-                    .then(({ value }: { value: number[] }) =>
-                        JSON.parse(String.fromCharCode.apply(null, value))
-                    )
-            )
-            .catch((e) => {
-                throw new Error(
-                    `CWR: Failed to retrieve Cognito identity: ${e}`
-                );
-            });
+        try {
+            const requestPayload = JSON.stringify(request);
+            const idRequest = this.getHttpRequest(
+                GET_ID_TARGET,
+                requestPayload
+            );
+            const { response } = await this.fetchRequestHandler.handle(
+                idRequest
+            );
+            const { value } = (await response.body.getReader().read()) as {
+                value: number[];
+            };
+            return JSON.parse(String.fromCharCode.apply(null, value)) as {
+                IdentityId: string;
+            };
+        } catch (e) {
+            throw new Error(`CWR: Failed to retrieve Cognito identity: ${e}`);
+        }
     };
 
     public getOpenIdToken = async (request: { IdentityId: string }) => {

--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -24,6 +24,13 @@ interface CognitoProviderParameters {
     client: CognitoIdentityClient;
 }
 
+interface CognitoCredentials {
+    AccessKeyId: string;
+    Expiration: number;
+    SecretAccessKey: string;
+    SessionToken: string;
+}
+
 export const fromCognitoIdentityPool = (
     params: CognitoProviderParameters
 ): (() => Promise<Credentials>) => {
@@ -58,8 +65,10 @@ export class CognitoIdentityClient {
                         JSON.parse(String.fromCharCode.apply(null, value))
                     )
             )
-            .catch(() => {
-                throw new Error('CWR: Failed to retrieve Cognito identity');
+            .catch((e) => {
+                throw new Error(
+                    `CWR: Failed to retrieve Cognito identity: ${e}`
+                );
             });
     };
 
@@ -80,8 +89,10 @@ export class CognitoIdentityClient {
                         JSON.parse(String.fromCharCode.apply(null, value))
                     )
             )
-            .catch(() => {
-                throw new Error('CWR: Failed to retrieve Cognito OpenId token');
+            .catch((e) => {
+                throw new Error(
+                    `CWR: Failed to retrieve Cognito OpenId token: ${e}`
+                );
             });
     };
 
@@ -103,7 +114,10 @@ export class CognitoIdentityClient {
                     .then(({ value }: { value: number[] }) => {
                         const { IdentityId, Credentials } = JSON.parse(
                             String.fromCharCode.apply(null, value)
-                        );
+                        ) as {
+                            IdentityId: string;
+                            Credentials: CognitoCredentials;
+                        };
 
                         const {
                             AccessKeyId,
@@ -119,11 +133,11 @@ export class CognitoIdentityClient {
                             sessionToken: SessionToken as string,
                             expiration: new Date(Expiration * 1000)
                         };
-                    });
+                    }) as Promise<Credentials>;
             })
-            .catch(() => {
+            .catch((e) => {
                 throw new Error(
-                    'CWR: Failed to retrieve credentials for Cognito identity'
+                    `CWR: Failed to retrieve credentials for Cognito identity: ${e}`
                 );
             });
     };

--- a/src/dispatch/StsClient.ts
+++ b/src/dispatch/StsClient.ts
@@ -1,6 +1,7 @@
 import { HttpHandler, HttpRequest } from '@aws-sdk/protocol-http';
 import { CognitoIdentityClientConfig } from './CognitoIdentityClient';
 import { Credentials } from '@aws-sdk/types';
+import { responseToString } from './utils';
 
 const METHOD = 'POST';
 const CONTENT_TYPE = 'application/x-www-form-urlencoded';
@@ -26,61 +27,49 @@ export class StsClient {
     public assumeRoleWithWebIdentity = async (
         request: STSSendRequest
     ): Promise<Credentials> => {
-        const requestObject = {
-            ...request,
-            Action: ACTION,
-            Version: VERSION
-        };
-        const encodedBody = new URLSearchParams(
-            Object.entries(requestObject)
-        ).toString();
-
-        const STSRequest = new HttpRequest({
-            method: METHOD,
-            headers: {
-                'content-type': CONTENT_TYPE,
-                host: this.hostname
-            },
-            protocol: PROTOCOL,
-            hostname: this.hostname,
-            body: encodedBody
-        });
-
-        return this.fetchRequestHandler
-            .handle(STSRequest)
-            .then(
-                ({ response }) =>
-                    response.body
-                        .getReader()
-                        .read()
-                        .then(({ value }: { value: number[] }) => {
-                            const xmlResponse = String.fromCharCode.apply(
-                                null,
-                                value
-                            );
-
-                            return {
-                                accessKeyId: xmlResponse
-                                    .split('<AccessKeyId>')[1]
-                                    .split('</AccessKeyId>')[0],
-                                secretAccessKey: xmlResponse
-                                    .split('<SecretAccessKey>')[1]
-                                    .split('</SecretAccessKey>')[0],
-                                sessionToken: xmlResponse
-                                    .split('<SessionToken>')[1]
-                                    .split('</SessionToken>')[0],
-                                expiration: new Date(
-                                    xmlResponse
-                                        .split('<Expiration>')[1]
-                                        .split('</Expiration>')[0]
-                                )
-                            } as Credentials;
-                        }) as Promise<Credentials>
-            )
-            .catch((e) => {
-                throw new Error(
-                    `CWR: Failed to retrieve credentials from STS: ${e}`
-                );
+        try {
+            const requestObject = {
+                ...request,
+                Action: ACTION,
+                Version: VERSION
+            };
+            const encodedBody = new URLSearchParams(
+                Object.entries(requestObject)
+            ).toString();
+            const STSRequest = new HttpRequest({
+                method: METHOD,
+                headers: {
+                    'content-type': CONTENT_TYPE,
+                    host: this.hostname
+                },
+                protocol: PROTOCOL,
+                hostname: this.hostname,
+                body: encodedBody
             });
+            const { response } = await this.fetchRequestHandler.handle(
+                STSRequest
+            );
+            const xmlResponse = await responseToString(response);
+            return {
+                accessKeyId: xmlResponse
+                    .split('<AccessKeyId>')[1]
+                    .split('</AccessKeyId>')[0],
+                secretAccessKey: xmlResponse
+                    .split('<SecretAccessKey>')[1]
+                    .split('</SecretAccessKey>')[0],
+                sessionToken: xmlResponse
+                    .split('<SessionToken>')[1]
+                    .split('</SessionToken>')[0],
+                expiration: new Date(
+                    xmlResponse
+                        .split('<Expiration>')[1]
+                        .split('</Expiration>')[0]
+                )
+            } as Credentials;
+        } catch (e) {
+            throw new Error(
+                `CWR: Failed to retrieve credentials from STS: ${e}`
+            );
+        }
     };
 }

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -148,9 +148,12 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when getId error, then an error is thrown', async () => {
-        const e: Error = new Error('There are no credentials');
+        const e = new Error('There are no credentials');
+        const expected: Error = new Error(
+            `CWR: Failed to retrieve Cognito identity: ${e}`
+        );
         fetchHandler.mockImplementation(() => {
-            throw new Error('There are no credentials');
+            throw e;
         });
 
         // Init
@@ -164,6 +167,6 @@ describe('CognitoIdentityClient tests', () => {
             client.getId({
                 IdentityPoolId: 'my-fake-identity-pool-id'
             })
-        ).rejects.toEqual(e);
+        ).rejects.toEqual(expected);
     });
 });

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -59,10 +59,13 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when getCredentialsForIdentity error, then an error is thrown', async () => {
-        const e: Error = new Error('There are no credentials');
+        const e: Error = new Error('Something went wrong');
         fetchHandler.mockImplementation(() => {
-            throw new Error('There are no credentials');
+            throw e;
         });
+        const expected: Error = new Error(
+            `CWR: Failed to retrieve credentials for Cognito identity: ${e}`
+        );
 
         // Init
         const client: CognitoIdentityClient = new CognitoIdentityClient({
@@ -73,7 +76,7 @@ describe('CognitoIdentityClient tests', () => {
         // Assert
         return expect(
             client.getCredentialsForIdentity('my-fake-identity-id')
-        ).rejects.toEqual(e);
+        ).rejects.toEqual(expected);
     });
 
     test('when getOpenIdToken is called, then token command is returned', async () => {
@@ -103,10 +106,13 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when getOpenIdToken error, then an error is thrown', async () => {
-        const e: Error = new Error('There are no credentials');
+        const e: Error = new Error('Something went wrong');
         fetchHandler.mockImplementation(() => {
-            throw new Error('There are no credentials');
+            throw e;
         });
+        const expected: Error = new Error(
+            `CWR: Failed to retrieve Cognito OpenId token: ${e}`
+        );
 
         // Init
         const client: CognitoIdentityClient = new CognitoIdentityClient({
@@ -119,7 +125,7 @@ describe('CognitoIdentityClient tests', () => {
             client.getOpenIdToken({
                 IdentityId: 'my-fake-identity-id'
             })
-        ).rejects.toEqual(e);
+        ).rejects.toEqual(expected);
     });
 
     test('when getId is called, then token command is returned', async () => {
@@ -148,13 +154,13 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when getId error, then an error is thrown', async () => {
-        const e = new Error('There are no credentials');
-        const expected: Error = new Error(
-            `CWR: Failed to retrieve Cognito identity: ${e}`
-        );
+        const e = new Error('Something went wrong');
         fetchHandler.mockImplementation(() => {
             throw e;
         });
+        const expected: Error = new Error(
+            `CWR: Failed to retrieve Cognito identity: ${e}`
+        );
 
         // Init
         const client: CognitoIdentityClient = new CognitoIdentityClient({

--- a/src/dispatch/__tests__/StsClient.test.ts
+++ b/src/dispatch/__tests__/StsClient.test.ts
@@ -60,10 +60,13 @@ describe('StsClient tests', () => {
     });
 
     test('when STS fails, error is thrown', async () => {
-        const e: Error = new Error('There are no STS credentials');
+        const e: Error = new Error('Something went wrong');
         fetchHandler.mockImplementation(() => {
             throw e;
         });
+        const expected: Error = new Error(
+            `CWR: Failed to retrieve credentials from STS: ${e}`
+        );
 
         // Init
         const client: StsClient = new StsClient({
@@ -78,6 +81,6 @@ describe('StsClient tests', () => {
                 RoleSessionName: 'mock-session-name',
                 WebIdentityToken: 'mock-web-identity-token'
             })
-        ).rejects.toEqual(e);
+        ).rejects.toEqual(expected);
     });
 });

--- a/src/dispatch/utils.ts
+++ b/src/dispatch/utils.ts
@@ -1,0 +1,19 @@
+import { HttpResponse } from '@aws-sdk/protocol-http';
+
+export const responseToJson = async (
+    response: HttpResponse
+): Promise<object> => {
+    const { value } = (await response.body.getReader().read()) as {
+        value: number[];
+    };
+    return JSON.parse(String.fromCharCode.apply(null, value)) as object;
+};
+
+export const responseToString = async (
+    response: HttpResponse
+): Promise<string> => {
+    const { value } = (await response.body.getReader().read()) as {
+        value: number[];
+    };
+    return String.fromCharCode.apply(null, value);
+};

--- a/src/loader/loader-ingestion.js
+++ b/src/loader/loader-ingestion.js
@@ -10,9 +10,9 @@ loader(
         allowCookies: true,
         clientBuilder: showIntegRequestClientBuilder,
         dispatchInterval: 0,
-        endpoint: 'https://dataplane.rum.us-east-1.amazonaws.com',
+        endpoint: '[endpoint]',
         guestRoleArn: '[guestRoleArn]',
-        identityPoolId: 'a-b-c',
+        identityPoolId: '[identityPoolId]',
         sessionSampleRate: 1,
         telemetries: [
             'performance',

--- a/src/loader/loader-ingestion.js
+++ b/src/loader/loader-ingestion.js
@@ -10,9 +10,9 @@ loader(
         allowCookies: true,
         clientBuilder: showIntegRequestClientBuilder,
         dispatchInterval: 0,
-        endpoint: '[endpoint]',
+        endpoint: 'https://dataplane.rum.us-east-1.amazonaws.com',
         guestRoleArn: '[guestRoleArn]',
-        identityPoolId: '[identityPoolId]',
+        identityPoolId: 'a-b-c',
         sessionSampleRate: 1,
         telemetries: [
             'performance',

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -63,7 +63,6 @@ export type PartialConfig = {
     batchLimit?: number;
     clientBuilder?: ClientBuilder;
     cookieAttributes?: PartialCookieAttributes;
-    sessionAttributes?: { [k: string]: string | number | boolean };
     disableAutoPageView?: boolean;
     dispatchInterval?: number;
     enableRumClient?: boolean;
@@ -79,6 +78,7 @@ export type PartialConfig = {
     recordResourceUrl?: boolean;
     routeChangeComplete?: number;
     routeChangeTimeout?: number;
+    sessionAttributes?: { [k: string]: string | number | boolean };
     sessionEventLimit?: number;
     sessionLengthSeconds?: number;
     sessionSampleRate?: number;
@@ -114,7 +114,6 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         allowCookies: false,
         batchLimit: 100,
         cookieAttributes,
-        sessionAttributes: {},
         disableAutoPageView: false,
         dispatchInterval: 5 * 1000,
         enableRumClient: true,
@@ -130,6 +129,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         retries: 2,
         routeChangeComplete: 100,
         routeChangeTimeout: 10000,
+        sessionAttributes: {},
         sessionEventLimit: 200,
         sessionLengthSeconds: 60 * 30,
         sessionSampleRate: 1,

--- a/src/remote-config/remote-config.ts
+++ b/src/remote-config/remote-config.ts
@@ -24,9 +24,9 @@ const fetchRemoteConfig = async (remoteUrl: string): Promise<FileConfig> => {
                 'Content-Type': 'application/json'
             }
         });
-        return await response.json();
-    } catch (err) {
-        throw new Error(`CWR: Failed to load remote config: ${err}`);
+        return (await response.json()) as FileConfig;
+    } catch (e) {
+        throw new Error(`CWR: Failed to load remote config: ${e}`);
     }
 };
 


### PR DESCRIPTION
Cognito and STS error messages do not currently contain the underlying error.

This change adds the underlying error to the thrown error message.

This change also addresses three other issues in the authentication code:
1. Fix an asynchrony issue where errors weren't being handled by the catch block.
2. Refactor async functions to use async style instead of promise style.
3. Fix linter warnings by adding explicit types to responses.

Resolves #227 and #233.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
