### PR TITLE
feat: Omit request signature when in proxy mode.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6373,9 +6373,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001418",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
-            "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
+            "version": "1.0.30001425",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz",
+            "integrity": "sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw==",
             "dev": true,
             "funding": [
                 {
@@ -26180,9 +26180,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001418",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
-            "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
+            "version": "1.0.30001425",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz",
+            "integrity": "sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw==",
             "dev": true
         },
         "case-sensitive-paths-webpack-plugin": {

--- a/src/dispatch/DataPlaneClient.ts
+++ b/src/dispatch/DataPlaneClient.ts
@@ -43,6 +43,7 @@ export declare type DataPlaneClientConfig = {
     endpoint: URL;
     region: string;
     credentials: CredentialProvider | Credentials;
+    proxy: boolean;
 };
 
 export class DataPlaneClient {
@@ -64,60 +65,69 @@ export class DataPlaneClient {
     public sendFetch = async (
         putRumEventsRequest: PutRumEventsRequest
     ): Promise<{ response: HttpResponse }> => {
-        const serializedRequest: string = JSON.stringify(
-            serializeRequest(putRumEventsRequest)
+        const options = await this.getHttpRequestOptions(
+            putRumEventsRequest,
+            CONTENT_TYPE_JSON
         );
-        const path = this.config.endpoint.pathname.replace(/\/$/, '');
-        const request = new HttpRequest({
-            method: METHOD,
-            headers: {
-                'content-type': CONTENT_TYPE_JSON,
-                'X-Amz-Content-Sha256': await hashAndEncode(serializedRequest),
-                host: this.config.endpoint.host
-            },
-            protocol: this.config.endpoint.protocol,
-            hostname: this.config.endpoint.hostname,
-            path: `${path}/appmonitors/${putRumEventsRequest.AppMonitorDetails.id}/`,
-            body: serializedRequest
-        });
-
-        const signedRequest: HttpRequest = (await this.awsSigV4.sign(
-            request
-        )) as any;
+        let request: HttpRequest = new HttpRequest(options);
+        if (!this.config.proxy) {
+            request = (await this.awsSigV4.sign(request)) as HttpRequest;
+        }
         const httpResponse: Promise<{
             response: HttpResponse;
-        }> = this.config.fetchRequestHandler.handle(signedRequest);
+        }> = this.config.fetchRequestHandler.handle(request);
         return httpResponse;
     };
 
     public sendBeacon = async (
         putRumEventsRequest: PutRumEventsRequest
     ): Promise<{ response: HttpResponse }> => {
+        const options = await this.getHttpRequestOptions(
+            putRumEventsRequest,
+            CONTENT_TYPE_TEXT
+        );
+        let request: HttpRequest = new HttpRequest(options);
+        if (!this.config.proxy) {
+            request = (await this.awsSigV4.presign(
+                request,
+                REQUEST_PRESIGN_ARGS
+            )) as HttpRequest;
+        }
+        const httpResponse: Promise<{
+            response: HttpResponse;
+        }> = this.config.beaconRequestHandler.handle(request);
+        return httpResponse;
+    };
+
+    private getHttpRequestOptions = async (
+        putRumEventsRequest: PutRumEventsRequest,
+        contentType: string
+    ) => {
         const serializedRequest: string = JSON.stringify(
             serializeRequest(putRumEventsRequest)
         );
         const path = this.config.endpoint.pathname.replace(/\/$/, '');
-        const request = new HttpRequest({
+        const options = {
             method: METHOD,
+            protocol: this.config.endpoint.protocol,
             headers: {
-                'content-type': CONTENT_TYPE_TEXT,
-                'X-Amz-Content-Sha256': await hashAndEncode(serializedRequest),
+                'content-type': contentType,
                 host: this.config.endpoint.host
             },
-            protocol: this.config.endpoint.protocol,
             hostname: this.config.endpoint.hostname,
             path: `${path}/appmonitors/${putRumEventsRequest.AppMonitorDetails.id}`,
             body: serializedRequest
-        });
-
-        const preSignedRequest: HttpRequest = (await this.awsSigV4.presign(
-            request,
-            REQUEST_PRESIGN_ARGS
-        )) as any;
-        const httpResponse: Promise<{
-            response: HttpResponse;
-        }> = this.config.beaconRequestHandler.handle(preSignedRequest);
-        return httpResponse;
+        };
+        if (this.config.proxy) {
+            return options;
+        }
+        return {
+            ...options,
+            headers: {
+                ...options.headers,
+                'X-Amz-Content-Sha256': await hashAndEncode(serializedRequest)
+            }
+        };
     };
 }
 

--- a/src/dispatch/Dispatch.ts
+++ b/src/dispatch/Dispatch.ts
@@ -48,9 +48,7 @@ export class Dispatch {
         this.buildClient = config.clientBuilder || this.defaultClientBuilder;
         this.config = config;
         this.startDispatchTimer();
-        if (config.proxy) {
-            this.rum = this.buildClient(this.endpoint, this.region, undefined);
-        } else {
+        if (config.signing) {
             this.rum = {
                 sendFetch: (): Promise<{ response: HttpResponse }> => {
                     return Promise.reject(new Error(NO_CRED_MSG));
@@ -59,6 +57,8 @@ export class Dispatch {
                     return Promise.reject(new Error(NO_CRED_MSG));
                 }
             };
+        } else {
+            this.rum = this.buildClient(this.endpoint, this.region, undefined);
         }
     }
 

--- a/src/dispatch/Dispatch.ts
+++ b/src/dispatch/Dispatch.ts
@@ -22,7 +22,8 @@ const NO_CRED_MSG = 'CWR: Cannot dispatch; no AWS credentials.';
 export type ClientBuilder = (
     endpoint: URL,
     region: string,
-    credentials: CredentialProvider | Credentials
+    credentials: CredentialProvider | Credentials,
+    proxy: boolean
 ) => DataPlaneClient;
 
 export class Dispatch {
@@ -86,7 +87,8 @@ export class Dispatch {
         this.rum = this.buildClient(
             this.endpoint,
             this.region,
-            credentialProvider
+            credentialProvider,
+            this.config.proxy
         );
         if (typeof credentialProvider === 'function') {
             // In case a beacon in the first dispatch, we must pre-fetch credentials into a cookie so there is no delay
@@ -239,7 +241,8 @@ export class Dispatch {
     private defaultClientBuilder: ClientBuilder = (
         endpoint,
         region,
-        credentials
+        credentials,
+        proxy
     ) => {
         return new DataPlaneClient({
             fetchRequestHandler: new RetryHttpHandler(
@@ -251,7 +254,8 @@ export class Dispatch {
             beaconRequestHandler: new BeaconHttpHandler(),
             endpoint,
             region,
-            credentials
+            credentials,
+            proxy
         });
     };
 }

--- a/src/dispatch/__tests__/BeaconHttpHandler.test.ts
+++ b/src/dispatch/__tests__/BeaconHttpHandler.test.ts
@@ -68,7 +68,7 @@ describe('BeaconHttpHandler tests', () => {
         );
     });
 
-    test('when proxy is tue then sendBeacon omits the signature', async () => {
+    test('when proxy is true then sendBeacon omits the signature', async () => {
         // Init
         const client: DataPlaneClient = createDataPlaneClient({ proxy: true });
 

--- a/src/dispatch/__tests__/BeaconHttpHandler.test.ts
+++ b/src/dispatch/__tests__/BeaconHttpHandler.test.ts
@@ -7,7 +7,7 @@ import { advanceTo } from 'jest-date-mock';
 const sendBeacon = jest.fn(() => true);
 
 const createDataPlaneClient = (
-    config: { proxy: boolean } = { proxy: false }
+    config: { signing: boolean } = { signing: true }
 ): DataPlaneClient => {
     const beaconHandler = new BeaconHttpHandler();
     return new DataPlaneClient({
@@ -15,7 +15,7 @@ const createDataPlaneClient = (
         beaconRequestHandler: beaconHandler,
         endpoint: Utils.AWS_RUM_ENDPOINT,
         region: Utils.AWS_RUM_REGION,
-        credentials: config.proxy ? undefined : Utils.createAwsCredentials()
+        credentials: config.signing ? Utils.createAwsCredentials() : undefined
     });
 };
 
@@ -68,9 +68,11 @@ describe('BeaconHttpHandler tests', () => {
         );
     });
 
-    test('when proxy is true then sendBeacon omits the signature', async () => {
+    test('when signing is false then sendBeacon omits the signature', async () => {
         // Init
-        const client: DataPlaneClient = createDataPlaneClient({ proxy: true });
+        const client: DataPlaneClient = createDataPlaneClient({
+            signing: false
+        });
 
         // Run
         const response: HttpResponse = (

--- a/src/dispatch/__tests__/BeaconHttpHandler.test.ts
+++ b/src/dispatch/__tests__/BeaconHttpHandler.test.ts
@@ -15,8 +15,7 @@ const createDataPlaneClient = (
         beaconRequestHandler: beaconHandler,
         endpoint: Utils.AWS_RUM_ENDPOINT,
         region: Utils.AWS_RUM_REGION,
-        credentials: Utils.createAwsCredentials(),
-        proxy: config.proxy
+        credentials: config.proxy ? undefined : Utils.createAwsCredentials()
     });
 };
 

--- a/src/dispatch/__tests__/BeaconHttpHandler.test.ts
+++ b/src/dispatch/__tests__/BeaconHttpHandler.test.ts
@@ -1,10 +1,24 @@
 import * as Utils from '../../test-utils/test-utils';
 import { BeaconHttpHandler } from '../BeaconHttpHandler';
 import { DataPlaneClient } from '../DataPlaneClient';
-import { HttpResponse } from '@aws-sdk/protocol-http';
+import { HttpHandler, HttpResponse } from '@aws-sdk/protocol-http';
 import { advanceTo } from 'jest-date-mock';
 
 const sendBeacon = jest.fn(() => true);
+
+const createDataPlaneClient = (
+    config: { proxy: boolean } = { proxy: false }
+): DataPlaneClient => {
+    const beaconHandler = new BeaconHttpHandler();
+    return new DataPlaneClient({
+        fetchRequestHandler: {} as HttpHandler,
+        beaconRequestHandler: beaconHandler,
+        endpoint: Utils.AWS_RUM_ENDPOINT,
+        region: Utils.AWS_RUM_REGION,
+        credentials: Utils.createAwsCredentials(),
+        proxy: config.proxy
+    });
+};
 
 describe('BeaconHttpHandler tests', () => {
     beforeEach(() => {
@@ -15,14 +29,7 @@ describe('BeaconHttpHandler tests', () => {
 
     test('when sendBeacon succeeds then HttpResponse status is 200', async () => {
         // Init
-        const beaconHandler = new BeaconHttpHandler();
-        const client: DataPlaneClient = new DataPlaneClient({
-            fetchRequestHandler: undefined,
-            beaconRequestHandler: beaconHandler,
-            endpoint: Utils.AWS_RUM_ENDPOINT,
-            region: Utils.AWS_RUM_REGION,
-            credentials: Utils.createAwsCredentials()
-        });
+        const client: DataPlaneClient = createDataPlaneClient();
 
         // Run
         const response: HttpResponse = (
@@ -36,14 +43,7 @@ describe('BeaconHttpHandler tests', () => {
     test('when sendBeacon fails then promise is rejected', async () => {
         // Init
         global.navigator.sendBeacon = jest.fn(() => false);
-        const beaconHandler = new BeaconHttpHandler();
-        const client: DataPlaneClient = new DataPlaneClient({
-            fetchRequestHandler: undefined,
-            beaconRequestHandler: beaconHandler,
-            endpoint: Utils.AWS_RUM_ENDPOINT,
-            region: Utils.AWS_RUM_REGION,
-            credentials: Utils.createAwsCredentials()
-        });
+        const client: DataPlaneClient = createDataPlaneClient();
 
         // Run
         const response: Promise<{ response: HttpResponse }> = client.sendBeacon(
@@ -55,14 +55,7 @@ describe('BeaconHttpHandler tests', () => {
 
     test('sendBeacon builds correct url', async () => {
         // Init
-        const beaconHandler = new BeaconHttpHandler();
-        const client: DataPlaneClient = new DataPlaneClient({
-            fetchRequestHandler: undefined,
-            beaconRequestHandler: beaconHandler,
-            endpoint: Utils.AWS_RUM_ENDPOINT,
-            region: Utils.AWS_RUM_REGION,
-            credentials: Utils.createAwsCredentials()
-        });
+        const client: DataPlaneClient = createDataPlaneClient();
 
         // Run
         const response: HttpResponse = (
@@ -73,6 +66,22 @@ describe('BeaconHttpHandler tests', () => {
         const url: string = (sendBeacon.mock.calls[0] as any)[0];
         expect(url).toContain(
             'https://rumservicelambda.us-west-2.amazonaws.com/appmonitors/application123?X-Amz-Algorithm=AWS4-HMAC-SHA256'
+        );
+    });
+
+    test('when proxy is tue then sendBeacon omits the signature', async () => {
+        // Init
+        const client: DataPlaneClient = createDataPlaneClient({ proxy: true });
+
+        // Run
+        const response: HttpResponse = (
+            await client.sendBeacon(Utils.PUT_RUM_EVENTS_REQUEST)
+        ).response;
+
+        // Assert
+        const url: string = (sendBeacon.mock.calls[0] as any)[0];
+        expect(url).toEqual(
+            'https://rumservicelambda.us-west-2.amazonaws.com/appmonitors/application123'
         );
     });
 });

--- a/src/dispatch/__tests__/DataPlaneClient.test.ts
+++ b/src/dispatch/__tests__/DataPlaneClient.test.ts
@@ -33,8 +33,7 @@ const createDataPlaneClient = (
         beaconRequestHandler: new BeaconHttpHandler(),
         endpoint: config.endpoint,
         region: Utils.AWS_RUM_REGION,
-        credentials: Utils.createAwsCredentials(),
-        proxy: config.proxy
+        credentials: config.proxy ? undefined : Utils.createAwsCredentials()
     });
 };
 

--- a/src/dispatch/__tests__/DataPlaneClient.test.ts
+++ b/src/dispatch/__tests__/DataPlaneClient.test.ts
@@ -19,11 +19,11 @@ jest.mock('@aws-sdk/fetch-http-handler', () => ({
 }));
 
 interface Config {
-    proxy: boolean;
+    signing: boolean;
     endpoint: URL;
 }
 
-const defaultConfig = { proxy: false, endpoint: Utils.AWS_RUM_ENDPOINT };
+const defaultConfig = { signing: true, endpoint: Utils.AWS_RUM_ENDPOINT };
 
 const createDataPlaneClient = (
     config: Config = defaultConfig
@@ -33,7 +33,7 @@ const createDataPlaneClient = (
         beaconRequestHandler: new BeaconHttpHandler(),
         endpoint: config.endpoint,
         region: Utils.AWS_RUM_REGION,
-        credentials: config.proxy ? undefined : Utils.createAwsCredentials()
+        credentials: config.signing ? Utils.createAwsCredentials() : undefined
     });
 };
 
@@ -208,11 +208,11 @@ describe('DataPlaneClient tests', () => {
         );
     });
 
-    test('when proxy is enabled then sendFetch does not sign the request', async () => {
+    test('when signing is disabled then sendFetch does not sign the request', async () => {
         // Init
         const client: DataPlaneClient = createDataPlaneClient({
             ...defaultConfig,
-            proxy: true
+            signing: false
         });
 
         // Run
@@ -228,11 +228,11 @@ describe('DataPlaneClient tests', () => {
         expect(signedRequest.headers.authorization).toEqual(undefined);
     });
 
-    test('when proxy is enabled then sendBeacon does not sign the request', async () => {
+    test('when signing is disabled then sendBeacon does not sign the request', async () => {
         // Init
         const client: DataPlaneClient = createDataPlaneClient({
             ...defaultConfig,
-            proxy: true
+            signing: false
         });
 
         // Run

--- a/src/dispatch/__tests__/Dispatch.test.ts
+++ b/src/dispatch/__tests__/Dispatch.test.ts
@@ -355,7 +355,7 @@ describe('Dispatch tests', () => {
             Utils.createDefaultEventCacheWithEvents(),
             {
                 ...DEFAULT_CONFIG,
-                ...{ dispatchInterval: 0, proxy: false }
+                ...{ dispatchInterval: 0, signing: true }
             }
         );
 
@@ -450,7 +450,7 @@ describe('Dispatch tests', () => {
         await expect(dispatch.dispatchFetch()).resolves.toEqual(undefined);
     });
 
-    test('when proxy is used then credentials are not needed for dispatch', async () => {
+    test('when signing is disabled then credentials are not needed for dispatch', async () => {
         // Init
         const dispatch = new Dispatch(
             Utils.AWS_RUM_REGION,
@@ -458,7 +458,7 @@ describe('Dispatch tests', () => {
             Utils.createDefaultEventCacheWithEvents(),
             {
                 ...DEFAULT_CONFIG,
-                ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF, proxy: true }
+                ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF, signing: false }
             }
         );
 

--- a/src/dispatch/__tests__/Dispatch.test.ts
+++ b/src/dispatch/__tests__/Dispatch.test.ts
@@ -355,7 +355,7 @@ describe('Dispatch tests', () => {
             Utils.createDefaultEventCacheWithEvents(),
             {
                 ...DEFAULT_CONFIG,
-                ...{ dispatchInterval: 0 }
+                ...{ dispatchInterval: 0, proxy: false }
             }
         );
 
@@ -448,5 +448,25 @@ describe('Dispatch tests', () => {
 
         // Assert
         await expect(dispatch.dispatchFetch()).resolves.toEqual(undefined);
+    });
+
+    test('when proxy is used then credentials are not needed for dispatch', async () => {
+        // Init
+        const dispatch = new Dispatch(
+            Utils.AWS_RUM_REGION,
+            Utils.AWS_RUM_ENDPOINT,
+            Utils.createDefaultEventCacheWithEvents(),
+            {
+                ...DEFAULT_CONFIG,
+                ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF, proxy: true }
+            }
+        );
+
+        // Run
+        await expect(dispatch.dispatchFetch()).resolves.toBe(undefined);
+
+        // Assert
+        expect(DataPlaneClient).toHaveBeenCalled();
+        expect(sendFetch).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -76,7 +76,7 @@ export type PartialConfig = {
     pageIdFormat?: PageIdFormat;
     pagesToExclude?: RegExp[];
     pagesToInclude?: RegExp[];
-    proxy?: boolean;
+    signing?: boolean;
     recordResourceUrl?: boolean;
     routeChangeComplete?: number;
     routeChangeTimeout?: number;
@@ -127,7 +127,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         pageIdFormat: PageIdFormatEnum.Path,
         pagesToExclude: [],
         pagesToInclude: [/.*/],
-        proxy: false,
+        signing: true,
         recordResourceUrl: true,
         retries: 2,
         routeChangeComplete: 100,
@@ -177,7 +177,7 @@ export type Config = {
     pageIdFormat: PageIdFormat;
     pagesToExclude: RegExp[];
     pagesToInclude: RegExp[];
-    proxy: boolean;
+    signing: boolean;
     recordResourceUrl: boolean;
     retries: number;
     routeChangeComplete: number;

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -76,6 +76,7 @@ export type PartialConfig = {
     pageIdFormat?: PageIdFormat;
     pagesToExclude?: RegExp[];
     pagesToInclude?: RegExp[];
+    proxy?: boolean;
     recordResourceUrl?: boolean;
     routeChangeComplete?: number;
     routeChangeTimeout?: number;
@@ -126,6 +127,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         pageIdFormat: PageIdFormatEnum.Path,
         pagesToExclude: [],
         pagesToInclude: [/.*/],
+        proxy: false,
         recordResourceUrl: true,
         retries: 2,
         routeChangeComplete: 100,
@@ -175,6 +177,7 @@ export type Config = {
     pageIdFormat: PageIdFormat;
     pagesToExclude: RegExp[];
     pagesToInclude: RegExp[];
+    proxy: boolean;
     recordResourceUrl: boolean;
     retries: number;
     routeChangeComplete: number;

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -161,6 +161,7 @@ describe('Orchestration tests', () => {
             pageIdFormat: PageIdFormatEnum.Path,
             pagesToExclude: [],
             pagesToInclude: [/.*/],
+            proxy: false,
             recordResourceUrl: true,
             retries: 2,
             routeChangeComplete: 100,

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -161,7 +161,7 @@ describe('Orchestration tests', () => {
             pageIdFormat: PageIdFormatEnum.Path,
             pagesToExclude: [],
             pagesToInclude: [/.*/],
-            proxy: false,
+            signing: true,
             recordResourceUrl: true,
             retries: 2,
             routeChangeComplete: 100,


### PR DESCRIPTION
When using a proxy, requests need not be signed by SigV4, however, the web client still requires credentials to dispatch requests. A workaround to this has been to add dummy credentials. 

This change adds a `proxy` config option. When `proxy = true`, the web client will dispatch data without waiting for credentials, and without signing requests.

While we could have simply added dummy credentials as a solution, omitting the SigV4 step entirely will allow us to remove this part of the AWS SDK in the future, reducing the size of the web client.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
