### PR TITLE
fix: Remove trailing slash in TARGET_URL

### DIFF
--- a/src/__smoke-test__/ingestion-integ.spec.ts
+++ b/src/__smoke-test__/ingestion-integ.spec.ts
@@ -27,7 +27,7 @@ const MONITOR_ID = process.env.MONITOR;
 const TEST_URL = getUrl(process.env.URL, process.env.VERSION);
 const MONITOR_NAME = process.env.NAME;
 const REGION = ENDPOINT.split('.')[2];
-const TARGET_URL = ENDPOINT + MONITOR_ID + '/';
+const TARGET_URL = ENDPOINT + MONITOR_ID;
 
 // Parse region from endpoint
 const rumClient = new RUMClient({ region: REGION });


### PR DESCRIPTION
## Details
This PR removes the trailing slash in `TARGET_URL` variable used for all smoke test cases. 
The trailing slash caused the smoke test cases to hang as the request URL never matched with the `TARGET_URL`

##Verification
Successful Smoke Test on v1.11.0 - https://github.com/adebayor123/aws-rum-web/actions/runs/3365000004/jobs/5579997365

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
