### PR TITLE
fix: Remove trailing slash in dataplane-integ.spec.ts

### DIFF
--- a/src/__smoke-test__/dataplane-integ.spec.ts
+++ b/src/__smoke-test__/dataplane-integ.spec.ts
@@ -15,7 +15,7 @@ import {
 const ENDPOINT = process.env.ENDPOINT;
 const MONITOR_ID = process.env.MONITOR;
 const TEST_URL = getUrl(process.env.URL, process.env.VERSION);
-const TARGET_URL = ENDPOINT + MONITOR_ID + '/';
+const TARGET_URL = ENDPOINT + MONITOR_ID;
 
 test('when web client calls PutRumEvents then the response code is 200', async ({
     page


### PR DESCRIPTION
## Details

This PR removes the trailing slash in TARGET_URL variable in dataplane-integ.spec.ts file to fix hanging smoke tests.
Verification: https://github.com/adebayor123/aws-rum-web/actions/runs/3372478141/jobs/5595952388

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
