### PR TITLE
fix: Populate method from Request Info

### DIFF
--- a/src/plugins/event-plugins/FetchPlugin.ts
+++ b/src/plugins/event-plugins/FetchPlugin.ts
@@ -216,11 +216,16 @@ export class FetchPlugin extends MonkeyPatched<Window, 'fetch'> {
         input: RequestInfo | URL | string,
         init?: RequestInit
     ): HttpEvent => {
+        const request = input as Request;
         return {
             version: '1.0.0',
             request: {
                 url: resourceToUrlString(input),
-                method: init?.method ? init.method : 'GET'
+                method: init?.method
+                    ? init.method
+                    : request.method
+                    ? request.method
+                    : 'GET'
             }
         };
     };

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -105,6 +105,41 @@ describe('FetchPlugin tests', () => {
         });
     });
 
+    test('when fetch is called with a Request/RequestInfo then the plugin records the http request/response', async () => {
+        // Init
+        const config: PartialHttpPluginConfig = {
+            urlsToInclude: [/aws\.amazon\.com/],
+            recordAllRequests: true
+        };
+
+        const plugin: FetchPlugin = new FetchPlugin(config);
+        plugin.load(xRayOffContext);
+
+        const request: RequestInfo = {
+            url: URL,
+            method: 'POST'
+        } as RequestInfo;
+
+        // Run
+        await fetch(request);
+        plugin.disable();
+
+        // Assert
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(HTTP_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject({
+            request: {
+                method: 'POST',
+                url: URL
+            },
+            response: {
+                status: 200,
+                statusText: 'OK'
+            }
+        });
+    });
+
     test('when fetch throws an error then the plugin adds the error to the http event', async () => {
         // Init
         global.fetch = mockFetchWithError;


### PR DESCRIPTION
- When in createHttpEvent, if there is no method on the RequestInit, then try to get the method from the RequestInfo

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
