### PR TITLE
Run CI and CD on node 18.x LTS

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
+                  node-version: '18.x'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Fetch AWS Credentials for Deployment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
+                  node-version: '18.x'
 
             - name: Cache NPM modules
               uses: actions/cache@v3
@@ -61,7 +61,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
+                  node-version: '18.x'
 
             - name: Cache NPM modules
               uses: actions/cache@v3


### PR DESCRIPTION
Node 18 is current LTS

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
