### PR TITLE
fix: Update deprecated web vitals library methods, refactor dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "prepare": "husky install"
     },
     "devDependencies": {
+        "@aws-sdk/client-rum": "^3.76.0",
         "@babel/plugin-transform-runtime": "^7.16.0",
         "@babel/preset-env": "~7.6.3",
         "@playwright/test": "^1.21.1",
@@ -114,7 +115,6 @@
     },
     "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.2",
-        "@aws-sdk/client-rum": "^3.76.0",
         "@aws-sdk/fetch-http-handler": "^3.36.0",
         "@aws-sdk/protocol-http": "^3.36.0",
         "@aws-sdk/signature-v4": "^3.36.0",

--- a/src/plugins/event-plugins/WebVitalsPlugin.ts
+++ b/src/plugins/event-plugins/WebVitalsPlugin.ts
@@ -2,7 +2,7 @@ import { InternalPlugin } from '../InternalPlugin';
 import { LargestContentfulPaintEvent } from '../../events/largest-contentful-paint-event';
 import { FirstInputDelayEvent } from '../../events/first-input-delay-event';
 import { CumulativeLayoutShiftEvent } from '../../events/cumulative-layout-shift-event';
-import { getCLS, getFID, getLCP, Metric } from 'web-vitals';
+import { Metric, onCLS, onFID, onLCP } from 'web-vitals';
 import {
     LCP_EVENT_TYPE,
     FID_EVENT_TYPE,
@@ -37,8 +37,8 @@ export class WebVitalsPlugin extends InternalPlugin {
     }
 
     protected onload(): void {
-        getLCP((data) => this.getWebVitalData(data, LCP_EVENT_TYPE));
-        getFID((data) => this.getWebVitalData(data, FID_EVENT_TYPE));
-        getCLS((data) => this.getWebVitalData(data, CLS_EVENT_TYPE));
+        onLCP((data) => this.getWebVitalData(data, LCP_EVENT_TYPE));
+        onFID((data) => this.getWebVitalData(data, FID_EVENT_TYPE));
+        onCLS((data) => this.getWebVitalData(data, CLS_EVENT_TYPE));
     }
 }


### PR DESCRIPTION
In a previous update, we've bumped the web vitals library from `1.1.2` to `3.0.2`. The methods `getCLS(), getFID(), getLCP()` have been deprecated in the newest web vitals library. In addition, these deprecated methods do not include the updates to exclude the pages loaded in the background from the web vitals calculation.

This PR updates the WebClient to use the latest methods (`onCLS(), onFID(), onLCP()`) from the latest version of the updated web vitals library. By updating these methods, we will also ensure that web vitals for pages loaded in the background are excluded/not reported in the web vital calculations. 

Related Issue: https://github.com/aws-observability/aws-rum-web/issues/245

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
