### PR TITLE
chore(release): 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.12.0](https://github.com/aws-observability/aws-rum-web/compare/v1.11.0...v1.12.0) (2022-11-17)
+
+
+### Features
+
+* Add recordEvent API and expose Plugin to enable recording of custom events ([#188](https://github.com/aws-observability/aws-rum-web/issues/188)) ([3e16093](https://github.com/aws-observability/aws-rum-web/commit/3e16093ec11db86eb404888b83e0e947606a0976))
+
+
+### Bug Fixes
+
+* Populate http method from RequestInfo ([#280](https://github.com/aws-observability/aws-rum-web/issues/280)) ([eb96760](https://github.com/aws-observability/aws-rum-web/commit/eb967602080144094f0b206a3afb48d889480504))
+
 ## [1.11.0](https://github.com/aws-observability/aws-rum-web/compare/v1.10.0...v1.11.0) (2022-10-28)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aws-rum-web",
-    "version": "1.11.0",
+    "version": "1.12.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-rum-web",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-rum-web",
-    "version": "1.11.0",
+    "version": "1.12.0",
     "sideEffects": false,
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",


### PR DESCRIPTION
This PR includes one feature and one fix.

Feature: Add recordEvent API and expose Plugin to enable recording of custom events ([#188](https://github.com/aws-observability/aws-rum-web/issues/188)) ([3e16093](https://github.com/aws-observability/aws-rum-web/commit/3e16093ec11db86eb404888b83e0e947606a0976))

Fix: Populate http method from RequestInfo ([#280](https://github.com/aws-observability/aws-rum-web/issues/280)) ([eb96760](https://github.com/aws-observability/aws-rum-web/commit/eb967602080144094f0b206a3afb48d889480504))

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
