### PR TITLE
ci: use codeql-action v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-20.04, windows-latest]
 
         steps:
             - name: Checkout AWS RUM Web Client Repository
@@ -74,7 +74,7 @@ jobs:
             - run: npm ci
 
             - name: Run Integ Tests on ubuntu-latest
-              if: matrix.os == 'ubuntu-latest'
+              if: matrix.os == 'ubuntu-20.04'
               run: |
                   npm run integ:headless
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ jobs:
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v1
+              uses: github/codeql-action/init@v2
               with:
                   languages: ${{ matrix.language }}
                   # If you wish to specify custom queries, you can do so here or in a config file.
@@ -29,4 +29,4 @@ jobs:
                   # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v1
+              uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL Action v1 will be deprecated on December 7th, 2022.

https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
