### PR TITLE
chore: Pin Ubuntu CI image to 20.04.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
     unit-test:
         name: Check Format and Run Unit Tests
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions: read-all
         steps:
             - name: Checkout AWS RUM Web Client Repository
@@ -52,7 +52,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-20.04, windows-latest]
 
         steps:
             - name: Checkout AWS RUM Web Client Repository
@@ -73,8 +73,8 @@ jobs:
 
             - run: npm ci
 
-            - name: Run Integ Tests on ubuntu-latest
-              if: matrix.os == 'ubuntu-latest'
+            - name: Run Integ Tests on ubuntu-20.04
+              if: matrix.os == 'ubuntu-20.04'
               run: |
                   npm run integ:headless
 


### PR DESCRIPTION
The web client CI is breaking because GitHub's Ubuntu 22 image [does not have](https://github.com/actions/runner-images/issues/6399#issuecomment-1302149048) Firefox installed.

GitHub is [planning to add Firefox](https://github.com/actions/runner-images/pull/6528) to its Ubuntu 22 image. In the meantime, this change pins Ubuntu to 20.04 for the web client CI.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
