### PR TITLE
chore: Remove internet explorer from CI workflow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,4 +82,3 @@ jobs:
               if: matrix.os == 'windows-latest'
               run: |
                   npm run integ:browser
-                  npm run integ:browser:ie

--- a/app/unsupported_browser.html
+++ b/app/unsupported_browser.html
@@ -2,6 +2,9 @@
 <html>
     <head>
         <title>RUM Integ Test</title>
+        <script>
+            window.navigator.sendBeacon = undefined;
+        </script>
         <script src="./loader_js_error_event.js"></script>
         <link
             rel="icon"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "preinteg": "npm run build:dev",
         "integ": "testcafe --app \"http-server ./build/dev -s\"",
         "integ:browser": "npm run integ -- --config-file=./.testcafe.browser.js",
-        "integ:browser:ie": "npm run integ -- ie src/__integ__/unsupportedBrowser.test.ts",
         "integ:headless": "npm run integ -- --config-file=./.testcafe.headless.js",
         "preinteg:local:nightwatch": "http-server ./build/dev -s &",
         "integ:local:nightwatch": "nightwatch",

--- a/src/__integ__/unsupportedBrowser.test.ts
+++ b/src/__integ__/unsupportedBrowser.test.ts
@@ -10,11 +10,9 @@ fixture('Unsupported Browsers').page(
 );
 
 test('when a browser is not supported then the command function is a no-op', async (t: TestController) => {
-    if (t.browser.name === 'Internet Explorer') {
-        await t
-            .wait(300)
-            .click(viewCommandQueueFunction)
-            .expect(cwrFunction.textContent)
-            .contains('function(){}');
-    }
+    await t
+        .wait(300)
+        .click(viewCommandQueueFunction)
+        .expect(cwrFunction.textContent)
+        .contains('function(){}');
 });


### PR DESCRIPTION
The unsupported browser tests, which run on Internet Explorer, are failing in the CI workflow. This is blocking dependency version bumps. I have been unable to reproduce the issue locally.

The intent of this test is to check that the web client does not load when certain APIs (fetch and sendBeacon) are unsupported. This change (1) reproduces this scenario using the test application so that it can be run on any browser, and (2) removes Internet Explorer from the CI workflow.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
