### PR TITLE
feat: Increase stack trace length

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ telemetries: [
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| stackTraceLength | Number | `200` | The number of characters to record from a JavaScript error's stack trace (if available). |
+| stackTraceLength | Number | `1000` | The number of characters to record from a JavaScript error's stack trace (if available). |
 | ignore | Function | `() => false` | A function which accepts an [`ErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent) or a [`PromiseRejectionEvent`](https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent) and returns a value that coerces to true when the error should be ignored. By default, no errors are ignored. |
 
 For example, the following telemetry config array causes the web client to ignore all errors whose message begins with "Warning:".
@@ -130,7 +130,7 @@ telemetries: [
 | --- | --- | --- | --- |
 | urlsToInclude | RegExp[] | `[/.*/]` | A list of HTTP request (`XMLHttpRequest` or `fetch`) URLs. These requests will be recorded, unless explicitly excluded by `urlsToExclude`. |
 | urlsToExclude | RegExp[] | `[]` | A list of HTTP request (`XMLHttpRequest` or `fetch`) URLs. These requests will not be recorded. |
-| stackTraceLength | Number | `200 ` | The number of characters to record from a JavaScript error's stack trace (if available). |
+| stackTraceLength | Number | `1000 ` | The number of characters to record from a JavaScript error's stack trace (if available). |
 | recordAllRequests | boolean | `false` | By default, only HTTP failed requests (i.e., those with network errors or status codes which are not 2xx) are recorded. When this field is `true`, the http telemetry will record all requests, including those with successful 2xx status codes. <br/><br/>This field does **does not apply** to X-Ray traces, where all requests are recorded. |
 | addXRayTraceIdHeader | boolean | `false` | By default, the `X-Amzn-Trace-Id` header will not be added to the HTTP request. This means that the client-side trace and server-side trace will **not be linked** in X-Ray or the ServiceLens graph.<br/><br/> When this field is `true`, the `X-Amzn-Trace-Id` header will be added to HTTP requests (`XMLHttpRequest` or `fetch`). **Adding the header is dangerous and you must test your application before setting this field to `true` in a production environment.** The header could cause CORS to fail or invalidate the request's signature if the request is signed with sigv4.
 

--- a/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -15,7 +15,7 @@ export type JsErrorPluginConfig = {
 };
 
 const defaultConfig: JsErrorPluginConfig = {
-    stackTraceLength: 200,
+    stackTraceLength: 1000,
     ignore: () => false
 };
 

--- a/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
+++ b/src/plugins/event-plugins/__integ__/JsErrorPlugin.test.ts
@@ -43,11 +43,11 @@ test('when a TypeError is thrown then name and message are recorded', async (t: 
         .expect(REQUEST_BODY.textContent)
         .contains('BatchId');
 
-    const json = removeUnwantedEvents(
-        JSON.parse(await REQUEST_BODY.textContent)
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) => e.type === JS_ERROR_EVENT_TYPE
     );
-    const eventType = json.RumEvents[0].type;
-    const eventDetails = JSON.parse(json.RumEvents[0].details);
+    const eventType = events[0].type;
+    const eventDetails = JSON.parse(events[0].details);
 
     await t
         .expect(eventType)
@@ -99,11 +99,11 @@ test('stack trace is recorded by default', async (t: TestController) => {
         .expect(REQUEST_BODY.textContent)
         .contains('BatchId');
 
-    const json = removeUnwantedEvents(
-        JSON.parse(await REQUEST_BODY.textContent)
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) => e.type === JS_ERROR_EVENT_TYPE
     );
-    const eventType = json.RumEvents[0].type;
-    const eventDetails = JSON.parse(json.RumEvents[0].details);
+    const eventType = events[0].type;
+    const eventDetails = JSON.parse(events[0].details);
 
     await t
         .expect(eventType)
@@ -198,9 +198,9 @@ test('when error invoked with record method then the plugin records the error', 
         .expect(REQUEST_BODY.textContent)
         .contains('BatchId');
 
-    const json = removeUnwantedEvents(
-        JSON.parse(await REQUEST_BODY.textContent)
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) => e.type === JS_ERROR_EVENT_TYPE
     );
 
-    await t.expect(json.RumEvents.length).eql(1);
+    await t.expect(events.length).eql(1);
 });


### PR DESCRIPTION
Presently, the default stack trace length is too short, leading to important stack trace information being truncated. A longer stack trace is crucial for allowing better insight into errors.

This changes increases the default stack trace length for Javascript errors from 200 to 1000. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
