### PR TITLE
feat:referrer

### DIFF
--- a/app/page_event.html
+++ b/app/page_event.html
@@ -71,6 +71,12 @@
                 cwr('recordPageView', '/page_view_two');
             }
 
+            function createReferrer() {
+                Object.defineProperty(document, 'referrer', {
+                    value: 'http://amazon.com/searchresults/1/'
+                });
+            }
+
             function recordPageViewWithPageTagAttribute() {
                 cwr('recordPageView', {
                     pageId: '/page_view_two',
@@ -178,6 +184,9 @@
         </button>
         <button id="doNotRecordPageView" onclick="doNotRecordPageView()">
             Do Not Record Page View
+        </button>
+        <button id="createReferrer" onclick="createReferrer()">
+            Create Referrer
         </button>
         <hr />
         <span id="request"></span>

--- a/src/event-schemas/meta-data.json
+++ b/src/event-schemas/meta-data.json
@@ -45,7 +45,10 @@
         "interaction": {
             "type": "number"
         },
-        "referrerUrl": {
+        "referrer": {
+            "type": "string"
+        },
+        "referrerDomain": {
             "type": "string"
         },
         "pageTitle": {

--- a/src/event-schemas/meta-data.json
+++ b/src/event-schemas/meta-data.json
@@ -45,10 +45,10 @@
         "interaction": {
             "type": "number"
         },
-        "referrer": {
+        "aws:referrer": {
             "type": "string"
         },
-        "referrerDomain": {
+        "aws:referrerDomain": {
             "type": "string"
         },
         "pageTitle": {

--- a/src/event-schemas/meta-data.json
+++ b/src/event-schemas/meta-data.json
@@ -45,10 +45,7 @@
         "interaction": {
             "type": "number"
         },
-        "aws:referrer": {
-            "type": "string"
-        },
-        "aws:referrerDomain": {
+        "referrerUrl": {
             "type": "string"
         },
         "pageTitle": {

--- a/src/event-schemas/page-view-event.json
+++ b/src/event-schemas/page-view-event.json
@@ -12,7 +12,9 @@
         "pageId": { "type": "string" },
         "pageInteractionId": { "type": "string" },
         "interaction": { "type": "number" },
-        "parentPageInteractionId": { "type": "string" }
+        "parentPageInteractionId": { "type": "string" },
+        "referrer": { "type": "string" },
+        "referrerDomain": { "type": "string" }
     },
     "additionalProperties": false,
     "required": ["pageId"]

--- a/src/event-schemas/page-view-event.json
+++ b/src/event-schemas/page-view-event.json
@@ -12,9 +12,7 @@
         "pageId": { "type": "string" },
         "pageInteractionId": { "type": "string" },
         "interaction": { "type": "number" },
-        "parentPageInteractionId": { "type": "string" },
-        "referrer": { "type": "string" },
-        "referrerDomain": { "type": "string" }
+        "parentPageInteractionId": { "type": "string" }
     },
     "additionalProperties": false,
     "required": ["pageId"]

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -8,6 +8,8 @@ export type Page = {
     pageId: string;
     interaction: number;
     parentPageId?: string;
+    referrer?: string | null;
+    referrerDomain?: string | null;
     start: number;
 };
 
@@ -129,6 +131,11 @@ export class PageManager {
             pageId,
             parentPageId: resumed.pageId,
             interaction: resumed.interaction + 1,
+            referrer:
+                document.referrer !== undefined && document.referrer !== ''
+                    ? document.referrer
+                    : null,
+            referrerDomain: this.getDomainFromReferrer(),
             start: Date.now()
         };
         this.resumed = undefined;
@@ -165,6 +172,11 @@ export class PageManager {
             pageId,
             parentPageId: currentPage.pageId,
             interaction: currentPage.interaction + 1,
+            referrer:
+                document.referrer !== undefined && document.referrer !== ''
+                    ? document.referrer
+                    : null,
+            referrerDomain: this.getDomainFromReferrer(),
             start: startTime
         };
     }
@@ -173,6 +185,11 @@ export class PageManager {
         this.page = {
             pageId,
             interaction: 0,
+            referrer:
+                document.referrer !== undefined && document.referrer !== ''
+                    ? document.referrer
+                    : null,
+            referrerDomain: this.getDomainFromReferrer(),
             start: Date.now()
         };
     }
@@ -220,6 +237,14 @@ export class PageManager {
                 pageViewEvent.parentPageInteractionId =
                     page.parentPageId + '-' + (page.interaction - 1);
             }
+
+            if (page.referrer !== null) {
+                pageViewEvent.referrer = page.referrer;
+
+                if (page.referrerDomain !== null) {
+                    pageViewEvent.referrerDomain = page.referrerDomain;
+                }
+            }
         }
 
         return pageViewEvent;
@@ -234,5 +259,22 @@ export class PageManager {
      */
     private useCookies() {
         return navigator.cookieEnabled && this.config.allowCookies;
+    }
+
+    /*
+    Parses the domain from the referrer, if it is available
+    */
+    private getDomainFromReferrer() {
+        if (document.referrer !== undefined || document.referrer !== '') {
+            const domainName = document.referrer.match(
+                '([A-Za-z]+://[^/]+)[/]?'
+            );
+
+            if (domainName) {
+                return domainName[1];
+            }
+        } else {
+            return null;
+        }
     }
 }

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -17,8 +17,8 @@ export type Attributes = {
     parentPageId?: string;
     interaction?: number;
     pageTags?: string[];
-    referrer?: string;
-    referrerDomain?: string;
+    'aws:referrer'?: string;
+    'aws:referrerDomain'?: string;
     // The value types of custom attributes are restricted to the types: string | number | boolean
     // However, given that pageTags is a string array, we need to include it as a valid type
     // Events will be verified by our service to validate attribute value types where
@@ -194,8 +194,10 @@ export class PageManager {
                 this.attributes.parentPageId = page.parentPageId;
             }
             if (document.referrer !== undefined) {
-                this.attributes.referrer = document.referrer;
-                this.attributes.referrerDomain = this.getDomainFromReferrer();
+                this.attributes['aws:referrer'] = document.referrer;
+                this.attributes[
+                    'aws:referrerDomain'
+                ] = this.getDomainFromReferrer();
             }
         }
 

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -131,10 +131,7 @@ export class PageManager {
             pageId,
             parentPageId: resumed.pageId,
             interaction: resumed.interaction + 1,
-            referrer:
-                document.referrer !== undefined && document.referrer !== ''
-                    ? document.referrer
-                    : null,
+            referrer: this.getReferrer(),
             referrerDomain: this.getDomainFromReferrer(),
             start: Date.now()
         };
@@ -172,10 +169,7 @@ export class PageManager {
             pageId,
             parentPageId: currentPage.pageId,
             interaction: currentPage.interaction + 1,
-            referrer:
-                document.referrer !== undefined && document.referrer !== ''
-                    ? document.referrer
-                    : null,
+            referrer: this.getReferrer(),
             referrerDomain: this.getDomainFromReferrer(),
             start: startTime
         };
@@ -185,10 +179,7 @@ export class PageManager {
         this.page = {
             pageId,
             interaction: 0,
-            referrer:
-                document.referrer !== undefined && document.referrer !== ''
-                    ? document.referrer
-                    : null,
+            referrer: this.getReferrer(),
             referrerDomain: this.getDomainFromReferrer(),
             start: Date.now()
         };
@@ -265,7 +256,7 @@ export class PageManager {
     Parses the domain from the referrer, if it is available
     */
     private getDomainFromReferrer() {
-        if (document.referrer !== undefined || document.referrer !== '') {
+        if (document.referrer !== undefined && document.referrer !== '') {
             const domainName = document.referrer.match(
                 '([A-Za-z]+://[^/]+)[/]?'
             );
@@ -273,6 +264,17 @@ export class PageManager {
             if (domainName) {
                 return domainName[1];
             }
+        } else {
+            return null;
+        }
+    }
+
+    /*
+    Get the referrer, if it can be read from the DOM
+    */
+    private getReferrer() {
+        if (document.referrer !== undefined && document.referrer !== '') {
+            return document.referrer;
         } else {
             return null;
         }

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -131,7 +131,7 @@ export class PageManager {
             pageId,
             parentPageId: resumed.pageId,
             interaction: resumed.interaction + 1,
-            referrer: this.getReferrer(),
+            referrer: document.referrer,
             referrerDomain: this.getDomainFromReferrer(),
             start: Date.now()
         };
@@ -169,7 +169,7 @@ export class PageManager {
             pageId,
             parentPageId: currentPage.pageId,
             interaction: currentPage.interaction + 1,
-            referrer: this.getReferrer(),
+            referrer: document.referrer,
             referrerDomain: this.getDomainFromReferrer(),
             start: startTime
         };
@@ -179,7 +179,7 @@ export class PageManager {
         this.page = {
             pageId,
             interaction: 0,
-            referrer: this.getReferrer(),
+            referrer: document.referrer,
             referrerDomain: this.getDomainFromReferrer(),
             start: Date.now()
         };
@@ -256,27 +256,10 @@ export class PageManager {
     Parses the domain from the referrer, if it is available
     */
     private getDomainFromReferrer() {
-        if (document.referrer !== undefined && document.referrer !== '') {
-            const domainName = document.referrer.match(
-                '([A-Za-z]+://[^/]+)[/]?'
-            );
-
-            if (domainName) {
-                return domainName[1];
-            }
-        } else {
-            return null;
-        }
-    }
-
-    /*
-    Get the referrer, if it can be read from the DOM
-    */
-    private getReferrer() {
-        if (document.referrer !== undefined && document.referrer !== '') {
-            return document.referrer;
-        } else {
-            return null;
+        try {
+            return new URL(document.referrer).hostname;
+        } catch (e) {
+            return '';
         }
     }
 }

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -229,13 +229,8 @@ export class PageManager {
                     page.parentPageId + '-' + (page.interaction - 1);
             }
 
-            if (page.referrer !== null) {
-                pageViewEvent.referrer = page.referrer;
-
-                if (page.referrerDomain !== null) {
-                    pageViewEvent.referrerDomain = page.referrerDomain;
-                }
-            }
+            pageViewEvent.referrer = document.referrer;
+            pageViewEvent.referrerDomain = this.getDomainFromReferrer();
         }
 
         return pageViewEvent;
@@ -259,11 +254,7 @@ export class PageManager {
         try {
             return new URL(document.referrer).hostname;
         } catch (e) {
-            if (document.referrer === 'localhost') {
-                // Handle special case for localhost
-                return 'localhost';
-            }
-            return '';
+            return document.referrer === 'localhost' ? document.referrer : '';
         }
     }
 }

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -259,6 +259,10 @@ export class PageManager {
         try {
             return new URL(document.referrer).hostname;
         } catch (e) {
+            if (document.referrer === 'localhost') {
+                // Handle special case for localhost
+                return 'localhost';
+            }
             return '';
         }
     }

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -251,6 +251,10 @@ export class PageManager {
         try {
             return new URL(document.referrer).hostname;
         } catch (e) {
+            if (document.referrer === 'localhost') {
+                // Handle special case for localhost
+                return 'localhost';
+            }
             return '';
         }
     }

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -8,8 +8,6 @@ export type Page = {
     pageId: string;
     interaction: number;
     parentPageId?: string;
-    referrer?: string | null;
-    referrerDomain?: string | null;
     start: number;
 };
 
@@ -19,6 +17,8 @@ export type Attributes = {
     parentPageId?: string;
     interaction?: number;
     pageTags?: string[];
+    referrer?: string;
+    referrerDomain?: string;
     // The value types of custom attributes are restricted to the types: string | number | boolean
     // However, given that pageTags is a string array, we need to include it as a valid type
     // Events will be verified by our service to validate attribute value types where
@@ -131,8 +131,6 @@ export class PageManager {
             pageId,
             parentPageId: resumed.pageId,
             interaction: resumed.interaction + 1,
-            referrer: document.referrer,
-            referrerDomain: this.getDomainFromReferrer(),
             start: Date.now()
         };
         this.resumed = undefined;
@@ -169,8 +167,6 @@ export class PageManager {
             pageId,
             parentPageId: currentPage.pageId,
             interaction: currentPage.interaction + 1,
-            referrer: document.referrer,
-            referrerDomain: this.getDomainFromReferrer(),
             start: startTime
         };
     }
@@ -179,8 +175,6 @@ export class PageManager {
         this.page = {
             pageId,
             interaction: 0,
-            referrer: document.referrer,
-            referrerDomain: this.getDomainFromReferrer(),
             start: Date.now()
         };
     }
@@ -198,6 +192,10 @@ export class PageManager {
             this.attributes.interaction = page.interaction;
             if (page.parentPageId !== undefined) {
                 this.attributes.parentPageId = page.parentPageId;
+            }
+            if (document.referrer !== undefined) {
+                this.attributes.referrer = document.referrer;
+                this.attributes.referrerDomain = this.getDomainFromReferrer();
             }
         }
 
@@ -227,14 +225,6 @@ export class PageManager {
             if (page.parentPageId !== undefined) {
                 pageViewEvent.parentPageInteractionId =
                     page.parentPageId + '-' + (page.interaction - 1);
-            }
-
-            if (page.referrer !== null) {
-                pageViewEvent.referrer = page.referrer;
-
-                if (page.referrerDomain !== null) {
-                    pageViewEvent.referrerDomain = page.referrerDomain;
-                }
             }
         }
 

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -209,7 +209,7 @@ test('when custom page attributes are set when manually recording page view even
         });
 });
 
-test('when referrer exists, then page view event details records it', async (t: TestController) => {
+test('when referrer exists, then metadata records it', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
 
@@ -230,7 +230,7 @@ test('when referrer exists, then page view event details records it', async (t: 
 
     const pages = requestBody.RumEvents.filter(
         (e) => e.type === PAGE_VIEW_EVENT_TYPE
-    ).map((e) => JSON.parse(e.details));
+    ).map((e) => JSON.parse(e.metadata));
 
     await t.expect(pages.length).eql(1).expect(pages[0]).contains({
         referrer: 'http://amazon.com/searchresults/1/',

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -1,6 +1,7 @@
 import { Selector } from 'testcafe';
 import { REQUEST_BODY } from '../../test-utils/integ-test-utils';
 import { PAGE_VIEW_EVENT_TYPE } from '../../plugins/utils/constant';
+import { create } from 'lodash';
 
 const recordPageView: Selector = Selector(`#recordPageView`);
 const recordPageViewWithPageTagAttribute: Selector = Selector(
@@ -208,7 +209,7 @@ test('when custom page attributes are set when manually recording page view even
         });
 });
 
-test('when referrer exists, then metadata records it', async (t: TestController) => {
+test('when referrer exists, then page view event details records it', async (t: TestController) => {
     // If we click too soon, the client/event collector plugin will not be loaded and will not record the click.
     // This could be a symptom of an issue with RUM web client load speed, or prioritization of script execution.
 
@@ -229,10 +230,10 @@ test('when referrer exists, then metadata records it', async (t: TestController)
 
     const pages = requestBody.RumEvents.filter(
         (e) => e.type === PAGE_VIEW_EVENT_TYPE
-    ).map((e) => JSON.parse(e.metadata));
+    ).map((e) => JSON.parse(e.details));
 
     await t.expect(pages.length).eql(1).expect(pages[0]).contains({
-        'aws:referrer': 'http://amazon.com/searchresults/1/',
-        'aws:referrerDomain': 'amazon.com'
+        referrer: 'http://amazon.com/searchresults/1/',
+        referrerDomain: 'amazon.com'
     });
 });

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -1,7 +1,6 @@
 import { Selector } from 'testcafe';
 import { REQUEST_BODY } from '../../test-utils/integ-test-utils';
 import { PAGE_VIEW_EVENT_TYPE } from '../../plugins/utils/constant';
-import { create } from 'lodash';
 
 const recordPageView: Selector = Selector(`#recordPageView`);
 const recordPageViewWithPageTagAttribute: Selector = Selector(

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -234,6 +234,6 @@ test('when referrer exists, then page view event details records it', async (t: 
 
     await t.expect(pages.length).eql(1).expect(pages[0]).contains({
         referrer: 'http://amazon.com/searchresults/1/',
-        referrerDomain: 'http://amazon.com'
+        referrerDomain: 'amazon.com'
     });
 });

--- a/src/sessions/__integ__/PageManager.test.ts
+++ b/src/sessions/__integ__/PageManager.test.ts
@@ -233,7 +233,7 @@ test('when referrer exists, then metadata records it', async (t: TestController)
     ).map((e) => JSON.parse(e.metadata));
 
     await t.expect(pages.length).eql(1).expect(pages[0]).contains({
-        referrer: 'http://amazon.com/searchresults/1/',
-        referrerDomain: 'amazon.com'
+        'aws:referrer': 'http://amazon.com/searchresults/1/',
+        'aws:referrerDomain': 'amazon.com'
     });
 });

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -508,7 +508,7 @@ test('when complete referrer is available from the DOM then is recorded in page 
     // Assert
     expect(pageManager.getPage()).toMatchObject({
         referrer: 'http://abc.com/consoles',
-        referrerDomain: 'http://abc.com',
+        referrerDomain: 'abc.com',
         pageId: '/console/home'
     });
 
@@ -536,7 +536,7 @@ test('when only domain level referrer is available from the DOM then is recorded
     // Assert
     expect(pageManager.getPage()).toMatchObject({
         referrer: 'http://abc.com',
-        referrerDomain: 'http://abc.com',
+        referrerDomain: 'abc.com',
         pageId: '/console/home'
     });
 
@@ -546,7 +546,7 @@ test('when only domain level referrer is available from the DOM then is recorded
     );
 });
 
-test('when referrer from the DOM is not valid then it is not recorded in page view event', async () => {
+test('when referrer from the DOM is empty then it is recorded as empty in the page view event', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -563,7 +563,9 @@ test('when referrer from the DOM is not valid then it is not recorded in page vi
 
     // Assert
     expect(pageManager.getPage()).toMatchObject({
-        pageId: '/console/home'
+        pageId: '/console/home',
+        referrer: '',
+        referrerDomain: ''
     });
 
     window.removeEventListener(

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -489,7 +489,7 @@ describe('PageManager tests', () => {
     });
 });
 
-test('when complete referrer is available from the DOM', async () => {
+test('when complete referrer is available from the DOM then is recorded in page view event', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -518,7 +518,7 @@ test('when complete referrer is available from the DOM', async () => {
     );
 });
 
-test('when only domain level referrer is available from the DOM', async () => {
+test('when only domain level referrer is available from the DOM then is recorded in page view event', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -546,7 +546,7 @@ test('when only domain level referrer is available from the DOM', async () => {
     );
 });
 
-test('when referrer is not available from the DOM', async () => {
+test('when referrer from the DOM is not valid then it is not recorded in page view event', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -489,7 +489,7 @@ describe('PageManager tests', () => {
     });
 });
 
-test('when complete referrer is available from the DOM then is recorded in the metadata', async () => {
+test('when complete referrer is available from the DOM then is recorded in page view event', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -507,12 +507,9 @@ test('when complete referrer is available from the DOM then is recorded in the m
 
     // Assert
     expect(pageManager.getPage()).toMatchObject({
+        referrer: 'http://abc.com/consoles',
+        referrerDomain: 'abc.com',
         pageId: '/console/home'
-    });
-
-    expect(pageManager.getAttributes()).toMatchObject({
-        'aws:referrer': 'http://abc.com/consoles',
-        'aws:referrerDomain': 'abc.com'
     });
 
     window.removeEventListener(
@@ -521,7 +518,7 @@ test('when complete referrer is available from the DOM then is recorded in the m
     );
 });
 
-test('when only domain level referrer is available from the DOM then is recorded in the metadata', async () => {
+test('when only domain level referrer is available from the DOM then is recorded in page view event', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -538,12 +535,9 @@ test('when only domain level referrer is available from the DOM then is recorded
 
     // Assert
     expect(pageManager.getPage()).toMatchObject({
+        referrer: 'http://abc.com',
+        referrerDomain: 'abc.com',
         pageId: '/console/home'
-    });
-
-    expect(pageManager.getAttributes()).toMatchObject({
-        'aws:referrer': 'http://abc.com',
-        'aws:referrerDomain': 'abc.com'
     });
 
     window.removeEventListener(
@@ -552,7 +546,7 @@ test('when only domain level referrer is available from the DOM then is recorded
     );
 });
 
-test('when referrer from the DOM is empty then it is recorded as empty in the metadata', async () => {
+test('when referrer from the DOM is empty then it is recorded as empty in the page view event', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -569,43 +563,9 @@ test('when referrer from the DOM is empty then it is recorded as empty in the me
 
     // Assert
     expect(pageManager.getPage()).toMatchObject({
-        pageId: '/console/home'
-    });
-
-    expect(pageManager.getAttributes()).toMatchObject({
-        'aws:referrer': '',
-        'aws:referrerDomain': ''
-    });
-
-    window.removeEventListener(
-        'popstate',
-        (pageManager as any).popstateListener
-    );
-});
-
-test('when referrer is localhost then it is recorded  in the metadata', async () => {
-    // Init
-    const config: Config = {
-        ...DEFAULT_CONFIG,
-        allowCookies: true
-    };
-    const pageManager: PageManager = new PageManager(config, record);
-
-    Object.defineProperty(document, 'referrer', {
-        value: 'localhost',
-        configurable: true
-    });
-    // Run
-    pageManager.recordPageView('/console/home');
-
-    // Assert
-    expect(pageManager.getPage()).toMatchObject({
-        pageId: '/console/home'
-    });
-
-    expect(pageManager.getAttributes()).toMatchObject({
-        'aws:referrer': 'localhost',
-        'aws:referrerDomain': 'localhost'
+        pageId: '/console/home',
+        referrer: '',
+        referrerDomain: ''
     });
 
     window.removeEventListener(

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -11,7 +11,8 @@ const record = jest.fn();
 declare const jsdom: any;
 
 Object.defineProperty(document, 'referrer', {
-    value: 'https://console.aws.amazon.com'
+    value: 'https://console.aws.amazon.com',
+    configurable: true
 });
 Object.defineProperty(document, 'title', { value: 'Amazon AWS Console' });
 global.fetch = mockFetch;
@@ -486,4 +487,87 @@ describe('PageManager tests', () => {
         expect(startTiming).toBeCalledTimes(1);
         expect(pageManager.getPage().start).toEqual(2500);
     });
+});
+
+test('when complete referrer is available from the DOM', async () => {
+    // Init
+    const config: Config = {
+        ...DEFAULT_CONFIG,
+        allowCookies: true
+    };
+    const pageManager: PageManager = new PageManager(config, record);
+
+    Object.defineProperty(document, 'referrer', {
+        value: 'http://abc.com/consoles',
+        configurable: true
+    });
+
+    // Run
+    pageManager.recordPageView('/console/home');
+
+    // Assert
+    expect(pageManager.getPage()).toMatchObject({
+        referrer: 'http://abc.com/consoles',
+        referrerDomain: 'http://abc.com',
+        pageId: '/console/home'
+    });
+
+    window.removeEventListener(
+        'popstate',
+        (pageManager as any).popstateListener
+    );
+});
+
+test('when only domain level referrer is available from the DOM', async () => {
+    // Init
+    const config: Config = {
+        ...DEFAULT_CONFIG,
+        allowCookies: true
+    };
+    const pageManager: PageManager = new PageManager(config, record);
+
+    Object.defineProperty(document, 'referrer', {
+        value: 'http://abc.com',
+        configurable: true
+    });
+    // Run
+    pageManager.recordPageView('/console/home');
+
+    // Assert
+    expect(pageManager.getPage()).toMatchObject({
+        referrer: 'http://abc.com',
+        referrerDomain: 'http://abc.com',
+        pageId: '/console/home'
+    });
+
+    window.removeEventListener(
+        'popstate',
+        (pageManager as any).popstateListener
+    );
+});
+
+test('when referrer is not available from the DOM', async () => {
+    // Init
+    const config: Config = {
+        ...DEFAULT_CONFIG,
+        allowCookies: true
+    };
+    const pageManager: PageManager = new PageManager(config, record);
+
+    Object.defineProperty(document, 'referrer', {
+        value: '',
+        configurable: true
+    });
+    // Run
+    pageManager.recordPageView('/console/home');
+
+    // Assert
+    expect(pageManager.getPage()).toMatchObject({
+        pageId: '/console/home'
+    });
+
+    window.removeEventListener(
+        'popstate',
+        (pageManager as any).popstateListener
+    );
 });

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -573,3 +573,31 @@ test('when referrer from the DOM is empty then it is recorded as empty in the pa
         (pageManager as any).popstateListener
     );
 });
+
+test('when referrer from the DOM is localhost then referrerDomain is also recorded as localhost', async () => {
+    // Init
+    const config: Config = {
+        ...DEFAULT_CONFIG,
+        allowCookies: true
+    };
+    const pageManager: PageManager = new PageManager(config, record);
+
+    Object.defineProperty(document, 'referrer', {
+        value: 'localhost',
+        configurable: true
+    });
+    // Run
+    pageManager.recordPageView('/console/home');
+
+    // Assert
+    expect(pageManager.getPage()).toMatchObject({
+        pageId: '/console/home',
+        referrer: 'localhost',
+        referrerDomain: 'localhost'
+    });
+
+    window.removeEventListener(
+        'popstate',
+        (pageManager as any).popstateListener
+    );
+});

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -511,8 +511,8 @@ test('when complete referrer is available from the DOM then is recorded in the m
     });
 
     expect(pageManager.getAttributes()).toMatchObject({
-        referrer: 'http://abc.com/consoles',
-        referrerDomain: 'abc.com'
+        'aws:referrer': 'http://abc.com/consoles',
+        'aws:referrerDomain': 'abc.com'
     });
 
     window.removeEventListener(
@@ -542,8 +542,8 @@ test('when only domain level referrer is available from the DOM then is recorded
     });
 
     expect(pageManager.getAttributes()).toMatchObject({
-        referrer: 'http://abc.com',
-        referrerDomain: 'abc.com'
+        'aws:referrer': 'http://abc.com',
+        'aws:referrerDomain': 'abc.com'
     });
 
     window.removeEventListener(
@@ -573,8 +573,8 @@ test('when referrer from the DOM is empty then it is recorded as empty in the me
     });
 
     expect(pageManager.getAttributes()).toMatchObject({
-        referrer: '',
-        referrerDomain: ''
+        'aws:referrer': '',
+        'aws:referrerDomain': ''
     });
 
     window.removeEventListener(

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -489,7 +489,7 @@ describe('PageManager tests', () => {
     });
 });
 
-test('when complete referrer is available from the DOM then is recorded in page view event', async () => {
+test('when complete referrer is available from the DOM then is recorded in the metadata', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -507,9 +507,12 @@ test('when complete referrer is available from the DOM then is recorded in page 
 
     // Assert
     expect(pageManager.getPage()).toMatchObject({
-        referrer: 'http://abc.com/consoles',
-        referrerDomain: 'abc.com',
         pageId: '/console/home'
+    });
+
+    expect(pageManager.getAttributes()).toMatchObject({
+        referrer: 'http://abc.com/consoles',
+        referrerDomain: 'abc.com'
     });
 
     window.removeEventListener(
@@ -518,7 +521,7 @@ test('when complete referrer is available from the DOM then is recorded in page 
     );
 });
 
-test('when only domain level referrer is available from the DOM then is recorded in page view event', async () => {
+test('when only domain level referrer is available from the DOM then is recorded in the metadata', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -535,9 +538,12 @@ test('when only domain level referrer is available from the DOM then is recorded
 
     // Assert
     expect(pageManager.getPage()).toMatchObject({
-        referrer: 'http://abc.com',
-        referrerDomain: 'abc.com',
         pageId: '/console/home'
+    });
+
+    expect(pageManager.getAttributes()).toMatchObject({
+        referrer: 'http://abc.com',
+        referrerDomain: 'abc.com'
     });
 
     window.removeEventListener(
@@ -546,7 +552,7 @@ test('when only domain level referrer is available from the DOM then is recorded
     );
 });
 
-test('when referrer from the DOM is empty then it is recorded as empty in the page view event', async () => {
+test('when referrer from the DOM is empty then it is recorded as empty in the metadata', async () => {
     // Init
     const config: Config = {
         ...DEFAULT_CONFIG,
@@ -563,7 +569,10 @@ test('when referrer from the DOM is empty then it is recorded as empty in the pa
 
     // Assert
     expect(pageManager.getPage()).toMatchObject({
-        pageId: '/console/home',
+        pageId: '/console/home'
+    });
+
+    expect(pageManager.getAttributes()).toMatchObject({
         referrer: '',
         referrerDomain: ''
     });

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -582,3 +582,34 @@ test('when referrer from the DOM is empty then it is recorded as empty in the me
         (pageManager as any).popstateListener
     );
 });
+
+test('when referrer is localhost then it is recorded  in the metadata', async () => {
+    // Init
+    const config: Config = {
+        ...DEFAULT_CONFIG,
+        allowCookies: true
+    };
+    const pageManager: PageManager = new PageManager(config, record);
+
+    Object.defineProperty(document, 'referrer', {
+        value: 'localhost',
+        configurable: true
+    });
+    // Run
+    pageManager.recordPageView('/console/home');
+
+    // Assert
+    expect(pageManager.getPage()).toMatchObject({
+        pageId: '/console/home'
+    });
+
+    expect(pageManager.getAttributes()).toMatchObject({
+        'aws:referrer': 'localhost',
+        'aws:referrerDomain': 'localhost'
+    });
+
+    window.removeEventListener(
+        'popstate',
+        (pageManager as any).popstateListener
+    );
+});


### PR DESCRIPTION
Currently, AWS CloudWatch RUM does not support referrer. Information about the referrer for page views is not presently available. 

This change adds the ability for the RUM web client to record and dispatch referrer information. The referrer will be stored in the `referrer` field in event details of a page view event. The referrer's domain will be stored in the `referrerDomain` field in event details of a page view event.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
