### PR TITLE
feat:Time Spent on Page

### DIFF
--- a/src/__integ__/cookiesEnabled.test.ts
+++ b/src/__integ__/cookiesEnabled.test.ts
@@ -27,18 +27,8 @@ test('when page is re-loaded with cookies enabled, session start is not dispatch
         .click(clear)
         .eval(() => location.reload());
 
-    await t
-        .wait(300)
-        .click(dispatch)
-        .expect(REQUEST_BODY.textContent)
-        .contains('BatchId');
-
-    const jsonB = JSON.parse(await REQUEST_BODY.textContent);
-    const sessionStartEventsB = jsonB.RumEvents.filter(
-        (e) => e.type === SESSION_START_EVENT_TYPE
-    );
-
-    await t.expect(sessionStartEventsB.length).eql(0);
+    // No new events should be recorded, thus no request body
+    await t.wait(300).click(dispatch).expect(REQUEST_BODY.textContent).eql('');
 });
 
 test('when page is loaded with cookies enabled, session start includes meta data', async (t: TestController) => {

--- a/src/event-schemas/page-view-event.json
+++ b/src/event-schemas/page-view-event.json
@@ -13,6 +13,7 @@
         "pageInteractionId": { "type": "string" },
         "interaction": { "type": "number" },
         "parentPageInteractionId": { "type": "string" },
+        "timeOnParentPage": { "type": "number" },
         "referrer": { "type": "string" },
         "referrerDomain": { "type": "string" }
     },

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -196,11 +196,8 @@ export class SessionManager {
 
             if (cookie && atob) {
                 try {
-                    this.session = JSON.parse(atob(cookie));
-                    this.pageManager.resumeSession(
-                        this.session.page!.pageId,
-                        this.session.page!.interaction
-                    );
+                    this.session = JSON.parse(atob(cookie)) as Session;
+                    this.pageManager.resumeSession(this.session.page);
                 } catch (e) {
                     // Error decoding or parsing the cookie -- ignore
                 }


### PR DESCRIPTION
Currently, AWS CloudWatch RUM does not record the time spent on a certain page. This change records the time spent on a page as part of the `parentTimeSpentOnPage` field in the page view event details. This field records the time spent on the parent page to the page view event it is recorded in.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
