### PR TITLE
Update the usage of set-output command in GH actions

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -3,7 +3,7 @@
 version=$(npm pkg get version | sed 's/"//g')
 bucket=$1
 
-echo ::set-output name=current-version::$version
+echo "current-version=$version" >> $GITHUB_OUTPUT
 
 aws s3api put-object --bucket $bucket --key "content/$version/cwr.js" --body build/assets/cwr.js --cache-control max-age=604800 --content-type "text/javascript"
 aws s3api put-object --bucket $bucket --key "content/$version/cwr.js.map" --body build/assets/cwr.js.map --cache-control max-age=604800


### PR DESCRIPTION

Description:

This PR updates the usage of set-output command in GH actions.

Reference : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
