### PR TITLE
feat: Add config to disable route change timing.

### DIFF
--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -67,6 +67,7 @@ export type PartialConfig = {
     cookieAttributes?: PartialCookieAttributes;
     disableAutoPageView?: boolean;
     dispatchInterval?: number;
+    enableRouteChangeTiming?: boolean;
     enableRumClient?: boolean;
     enableXRay?: boolean;
     endpoint?: string;
@@ -120,6 +121,7 @@ export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
         cookieAttributes,
         disableAutoPageView: false,
         dispatchInterval: 5 * 1000,
+        enableRouteChangeTiming: true,
         enableRumClient: true,
         enableXRay: false,
         endpoint: DEFAULT_ENDPOINT,
@@ -161,6 +163,7 @@ export type Config = {
     sessionAttributes: { [k: string]: string | number | boolean };
     disableAutoPageView: boolean;
     dispatchInterval: number;
+    enableRouteChangeTiming: boolean;
     enableRumClient: boolean;
     enableXRay: boolean;
     endpoint: string;

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -155,6 +155,7 @@ describe('Orchestration tests', () => {
             telemetries: [],
             disableAutoPageView: false,
             dispatchInterval: 5000,
+            enableRouteChangeTiming: true,
             enableXRay: false,
             endpoint: 'https://dataplane.rum.us-west-2.amazonaws.com',
             endpointUrl: new URL(

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -681,118 +681,169 @@ describe('PageManager tests', () => {
         // Assert
         expect(record.mock.calls[1][0]).toEqual(PAGE_VIEW_EVENT_TYPE);
         expect(record.mock.calls[1][1].timeOnParentPage).toBeUndefined();
-    });
-});
 
-test('when complete referrer is available from the DOM then is recorded in page view event', async () => {
-    // Init
-    const config: Config = {
-        ...DEFAULT_CONFIG,
-        allowCookies: true
-    };
-    const pageManager: PageManager = new PageManager(config, record);
-
-    Object.defineProperty(document, 'referrer', {
-        value: 'http://abc.com/consoles',
-        configurable: true
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
     });
 
-    // Run
-    pageManager.recordPageView('/console/home');
+    test('when complete referrer is available from the DOM then is recorded in page view event', async () => {
+        // Init
+        const config: Config = {
+            ...DEFAULT_CONFIG,
+            allowCookies: true
+        };
+        const pageManager: PageManager = new PageManager(config, record);
 
-    // Assert
-    expect(pageManager.getPage()).toMatchObject({
-        referrer: 'http://abc.com/consoles',
-        referrerDomain: 'abc.com',
-        pageId: '/console/home'
+        Object.defineProperty(document, 'referrer', {
+            value: 'http://abc.com/consoles',
+            configurable: true
+        });
+
+        // Run
+        pageManager.recordPageView('/console/home');
+
+        // Assert
+        expect(pageManager.getPage()).toMatchObject({
+            referrer: 'http://abc.com/consoles',
+            referrerDomain: 'abc.com',
+            pageId: '/console/home'
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
     });
 
-    window.removeEventListener(
-        'popstate',
-        (pageManager as any).popstateListener
-    );
-});
+    test('when only domain level referrer is available from the DOM then is recorded in page view event', async () => {
+        // Init
+        const config: Config = {
+            ...DEFAULT_CONFIG,
+            allowCookies: true
+        };
+        const pageManager: PageManager = new PageManager(config, record);
 
-test('when only domain level referrer is available from the DOM then is recorded in page view event', async () => {
-    // Init
-    const config: Config = {
-        ...DEFAULT_CONFIG,
-        allowCookies: true
-    };
-    const pageManager: PageManager = new PageManager(config, record);
+        Object.defineProperty(document, 'referrer', {
+            value: 'http://abc.com',
+            configurable: true
+        });
+        // Run
+        pageManager.recordPageView('/console/home');
 
-    Object.defineProperty(document, 'referrer', {
-        value: 'http://abc.com',
-        configurable: true
-    });
-    // Run
-    pageManager.recordPageView('/console/home');
+        // Assert
+        expect(pageManager.getPage()).toMatchObject({
+            referrer: 'http://abc.com',
+            referrerDomain: 'abc.com',
+            pageId: '/console/home'
+        });
 
-    // Assert
-    expect(pageManager.getPage()).toMatchObject({
-        referrer: 'http://abc.com',
-        referrerDomain: 'abc.com',
-        pageId: '/console/home'
-    });
-
-    window.removeEventListener(
-        'popstate',
-        (pageManager as any).popstateListener
-    );
-});
-
-test('when referrer from the DOM is empty then it is recorded as empty in the page view event', async () => {
-    // Init
-    const config: Config = {
-        ...DEFAULT_CONFIG,
-        allowCookies: true
-    };
-    const pageManager: PageManager = new PageManager(config, record);
-
-    Object.defineProperty(document, 'referrer', {
-        value: '',
-        configurable: true
-    });
-    // Run
-    pageManager.recordPageView('/console/home');
-
-    // Assert
-    expect(pageManager.getPage()).toMatchObject({
-        pageId: '/console/home',
-        referrer: '',
-        referrerDomain: ''
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
     });
 
-    window.removeEventListener(
-        'popstate',
-        (pageManager as any).popstateListener
-    );
-});
+    test('when referrer from the DOM is empty then it is recorded as empty in the page view event', async () => {
+        // Init
+        const config: Config = {
+            ...DEFAULT_CONFIG,
+            allowCookies: true
+        };
+        const pageManager: PageManager = new PageManager(config, record);
 
-test('when referrer from the DOM is localhost then referrerDomain is also recorded as localhost', async () => {
-    // Init
-    const config: Config = {
-        ...DEFAULT_CONFIG,
-        allowCookies: true
-    };
-    const pageManager: PageManager = new PageManager(config, record);
+        Object.defineProperty(document, 'referrer', {
+            value: '',
+            configurable: true
+        });
+        // Run
+        pageManager.recordPageView('/console/home');
 
-    Object.defineProperty(document, 'referrer', {
-        value: 'localhost',
-        configurable: true
+        // Assert
+        expect(pageManager.getPage()).toMatchObject({
+            pageId: '/console/home',
+            referrer: '',
+            referrerDomain: ''
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
     });
-    // Run
-    pageManager.recordPageView('/console/home');
 
-    // Assert
-    expect(pageManager.getPage()).toMatchObject({
-        pageId: '/console/home',
-        referrer: 'localhost',
-        referrerDomain: 'localhost'
+    test('when referrer from the DOM is localhost then referrerDomain is also recorded as localhost', async () => {
+        // Init
+        const config: Config = {
+            ...DEFAULT_CONFIG,
+            allowCookies: true
+        };
+        const pageManager: PageManager = new PageManager(config, record);
+
+        Object.defineProperty(document, 'referrer', {
+            value: 'localhost',
+            configurable: true
+        });
+        // Run
+        pageManager.recordPageView('/console/home');
+
+        // Assert
+        expect(pageManager.getPage()).toMatchObject({
+            pageId: '/console/home',
+            referrer: 'localhost',
+            referrerDomain: 'localhost'
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
     });
 
-    window.removeEventListener(
-        'popstate',
-        (pageManager as any).popstateListener
-    );
+    test('when enableRouteChangeTiming is false then VirtualPageLoadTimer is not initialized', async () => {
+        // Init
+        const config: Config = {
+            ...DEFAULT_CONFIG,
+            enableRouteChangeTiming: false
+        };
+        const pageManager: PageManager = new PageManager(config, record);
+        const helper = pageManager['virtualPageLoadTimer'];
+
+        // Assert
+        expect(helper).toBeUndefined();
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
+
+    test('when VirtualPageLoadTimer is not initialized then recordPageView records a page view event.', async () => {
+        // Init
+        const pageManager: PageManager = new PageManager(
+            {
+                ...DEFAULT_CONFIG,
+                allowCookies: true,
+                enableRouteChangeTiming: false
+            },
+            record
+        );
+
+        // Run
+        pageManager.recordPageView('/console/home');
+        pageManager.recordPageView('/console/about');
+
+        // Assert
+        expect(record.mock.calls[1][0]).toEqual(PAGE_VIEW_EVENT_TYPE);
+        expect(record.mock.calls[1][1]).toMatchObject({
+            pageId: '/console/about',
+            interaction: 1
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
 });


### PR DESCRIPTION
Automated route change timing requires the web client to monkey patch the HTTP APIs (i.e., fetch and XHR). If other libraries are also patching the HTTP APIs, this could interfere with application behavior.

To fix this problem, this change adds a configuration option to enable/disable route change timing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
