### PR TITLE
chore: Add versioning related metadata attributes to smoke test utilities

### DIFF
--- a/src/test-utils/smoke-test-utils.ts
+++ b/src/test-utils/smoke-test-utils.ts
@@ -25,7 +25,9 @@ const builtInAttributes = [
     'countryCode',
     'subdivisionCode',
     'domain',
-    'pageTags'
+    'pageTags',
+    'aws:client',
+    'aws:clientVersion'
 ];
 
 /** Returns filtered events by type */


### PR DESCRIPTION


Added the following metadata attributes in the list of built in attributes that smoke test checks against. 

```aws:client```
```aws:clientVersion```

These metadata attributes will be added to every event and therefore need to be included in the list of built in attributes that smoke test verify events against. For more details on why these attributes are added to every event's metadata, refer to [PR](https://github.com/aws-observability/aws-rum-web/pull/321). 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
