### PR TITLE
chore(release): 1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+
+### [1.13.2](https://github.com/aws-observability/aws-rum-web/compare/v1.13.1...v1.13.2) (2022-02-25)
+
+### Bug Fixes
+
+* Transpile @aws-sdk to ES5 to gracefully close browsers at end of life ([#363](https://github.com/aws-observability/aws-rum-web/pull/363)) ([f63150d](https://github.com/aws-observability/aws-rum-web/commit/f63150df6ed6a9d8a877ccfe8e160c5a8d9873ec))
+
 ### [1.13.1](https://github.com/aws-observability/aws-rum-web/compare/v1.13.0...v1.13.1) (2022-02-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aws-rum-web",
-    "version": "1.12.0",
+    "version": "1.13.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-rum-web",
-            "version": "1.12.0",
+            "version": "1.13.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aws-rum-web",
-    "version": "1.13.1",
+    "version": "1.12.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-rum-web",
-            "version": "1.13.1",
+            "version": "1.12.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^2.0.2",
@@ -22,6 +22,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/client-rum": "^3.76.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.21.2",
                 "@babel/plugin-transform-runtime": "^7.16.0",
                 "@babel/preset-env": "~7.20.2",
                 "@playwright/test": "^1.21.1",
@@ -1665,13 +1666,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.20.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-            "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+            "version": "7.21.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
+            "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.20.2",
+                "@babel/types": "^7.21.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -1815,13 +1817,13 @@
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-            "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+            "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.18.10",
-                "@babel/types": "^7.19.0"
+                "@babel/template": "^7.20.7",
+                "@babel/types": "^7.21.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1864,9 +1866,9 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+            "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
@@ -1874,9 +1876,9 @@
                 "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
                 "@babel/helper-validator-identifier": "^7.19.1",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.20.1",
-                "@babel/types": "^7.20.2"
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.21.2",
+                "@babel/types": "^7.21.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2044,9 +2046,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.20.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-            "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
+            "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -2886,14 +2888,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.19.6.tgz",
-            "integrity": "sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.2.tgz",
+            "integrity": "sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.19.6",
-                "@babel/helper-plugin-utils": "^7.19.0",
-                "@babel/helper-simple-access": "^7.19.4"
+                "@babel/helper-module-transforms": "^7.21.2",
+                "@babel/helper-plugin-utils": "^7.20.2",
+                "@babel/helper-simple-access": "^7.20.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3408,33 +3410,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+            "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
+            "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.20.1",
+                "@babel/generator": "^7.21.1",
                 "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
+                "@babel/helper-function-name": "^7.21.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.20.1",
-                "@babel/types": "^7.20.0",
+                "@babel/parser": "^7.21.2",
+                "@babel/types": "^7.21.2",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -3443,9 +3445,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
+            "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -22992,13 +22994,14 @@
             }
         },
         "@babel/generator": {
-            "version": "7.20.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-            "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+            "version": "7.21.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
+            "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.20.2",
+                "@babel/types": "^7.21.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
+                "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
             }
         },
@@ -23104,13 +23107,13 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-            "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+            "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.18.10",
-                "@babel/types": "^7.19.0"
+                "@babel/template": "^7.20.7",
+                "@babel/types": "^7.21.0"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -23141,9 +23144,9 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+            "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
@@ -23151,9 +23154,9 @@
                 "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
                 "@babel/helper-validator-identifier": "^7.19.1",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.20.1",
-                "@babel/types": "^7.20.2"
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.21.2",
+                "@babel/types": "^7.21.2"
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -23276,9 +23279,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.20.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-            "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
+            "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
             "dev": true
         },
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -23821,14 +23824,14 @@
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.19.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.19.6.tgz",
-            "integrity": "sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.2.tgz",
+            "integrity": "sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.19.6",
-                "@babel/helper-plugin-utils": "^7.19.0",
-                "@babel/helper-simple-access": "^7.19.4"
+                "@babel/helper-module-transforms": "^7.21.2",
+                "@babel/helper-plugin-utils": "^7.20.2",
+                "@babel/helper-simple-access": "^7.20.2"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
@@ -24185,38 +24188,38 @@
             }
         },
         "@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+            "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7"
             }
         },
         "@babel/traverse": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
+            "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.20.1",
+                "@babel/generator": "^7.21.1",
                 "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-function-name": "^7.19.0",
+                "@babel/helper-function-name": "^7.21.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.20.1",
-                "@babel/types": "^7.20.0",
+                "@babel/parser": "^7.21.2",
+                "@babel/types": "^7.21.2",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+            "version": "7.21.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
+            "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
             "dev": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.19.4",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     },
     "devDependencies": {
         "@aws-sdk/client-rum": "^3.76.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
         "@babel/plugin-transform-runtime": "^7.16.0",
         "@babel/preset-env": "~7.20.2",
         "@playwright/test": "^1.21.1",
@@ -83,8 +84,8 @@
         "eslint-plugin-jsdoc": "^39.3.6",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-react": "^7.31.8",
-        "http-server": "^14.1.1",
         "generate-json-webpack-plugin": "^2.0.0",
+        "http-server": "^14.1.1",
         "husky": "^8.0.1",
         "jest": "^29.3.1",
         "jest-date-mock": "^1.0.8",
@@ -145,6 +146,7 @@
         ]
     },
     "browserslist": [
-        "defaults"
+        "defaults",
+        "ie 11"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-rum-web",
-    "version": "1.13.1",
+    "version": "1.13.2",
     "sideEffects": false,
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -3,6 +3,7 @@ const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const babelLoaderOptions = {
     presets: [['@babel/preset-env', {}]],
     plugins: [
+        '@babel/plugin-transform-modules-commonjs',
         [
             '@babel/plugin-transform-runtime',
             {
@@ -26,7 +27,7 @@ module.exports = {
         rules: [
             {
                 test: [/\.js$/],
-                exclude: /node_modules/,
+                exclude: /node_modules\/(?!@aws-sdk)/,
                 use: {
                     loader: 'babel-loader',
                     options: babelLoaderOptions
@@ -34,7 +35,7 @@ module.exports = {
             },
             {
                 test: [/\.ts$/],
-                exclude: /node_modules/,
+                exclude: /node_modules\/(?!@aws-sdk)/,
                 use: [
                     {
                         loader: 'babel-loader',


### PR DESCRIPTION

This PR adds the following fix and bumps the patch version from 1 to 2 (1.13.1 to 1.13.2)

* Transpile @aws-sdk to ES5 to gracefully close browsers at end of life (https://github.com/aws-observability/aws-rum-web/pull/363) ([f63150d](https://github.com/aws-observability/aws-rum-web/commit/f63150df6ed6a9d8a877ccfe8e160c5a8d9873ec))

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
