### PR TITLE
fix: Export PageAttributes type.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
     TelemetryEnum
 } from './orchestration/Orchestration';
 export { ClientBuilder } from './dispatch/Dispatch';
+export { PageAttributes } from './sessions/PageManager';
 export { Plugin } from './plugins/Plugin';
 export { PluginContext } from './plugins/types';
 export * from './plugins/event-plugins/DomEventPlugin';


### PR DESCRIPTION
The `recordPageView` function accepts an argument of type `PageAttributes`, but this type is not exported.

This change exports the `PageAttributes` type.

Resolves #330 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
