### PR TITLE
fix: Add @aws-sdk/querystring-builder as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
         "@aws-crypto/sha256-js": "^2.0.2",
         "@aws-sdk/fetch-http-handler": "^3.36.0",
         "@aws-sdk/protocol-http": "^3.36.0",
+        "@aws-sdk/querystring-builder": "^3.36.0",
         "@aws-sdk/signature-v4": "^3.36.0",
         "@aws-sdk/util-hex-encoding": "^3.36.0",
         "@babel/runtime": "^7.16.0",


### PR DESCRIPTION
There is a missing dependency on `@aws-sdk/querystring-builder`, which can break builds.

This change adds that dependency to package.json.

Resolves #328 .

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
