### PR TITLE
fix: Update entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",
     "author": "Amazon CloudWatch RUM Staff <nobody@amazon.com>",
-    "main": "dist/cjs/index.js",
-    "module": "dist/es/index.js",
+    "main": "dist/cjs/src/index.js",
+    "module": "dist/es/src/index.js",
     "files": [
         "dist/",
         "CHANGELOG.md",


### PR DESCRIPTION
Update entry point to new `dist/es/src` directory. Related Issue: https://github.com/aws-observability/aws-rum-web/issues/371

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
