### PR TITLE
fix: Handle missing PageId in metadata when page is resumed

### DIFF
--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -107,14 +107,14 @@ export class PageManager {
             this.createLandingPage(pageId);
         } else if (this.page.pageId !== pageId) {
             this.createNextPage(this.page, pageId);
+        } else if (this.resumed) {
+            // Update attributes state in PageManager for event metadata
+            this.collectAttributes(
+                this.page as Page,
+                typeof payload === 'object' ? payload : undefined
+            );
+            return;
         } else {
-            // If its a resumed or reloaded page, update attributes state in PageManager for event metadata
-            if (this.resumed) {
-                this.collectAttributes(
-                    this.page as Page,
-                    typeof payload === 'object' ? payload : undefined
-                );
-            }
             // The view has not changed.
             return;
         }

--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -108,6 +108,13 @@ export class PageManager {
         } else if (this.page.pageId !== pageId) {
             this.createNextPage(this.page, pageId);
         } else {
+            // If its a resumed or reloaded page, update attributes state in PageManager for event metadata
+            if (this.resumed) {
+                this.collectAttributes(
+                    this.page as Page,
+                    typeof payload === 'object' ? payload : undefined
+                );
+            }
             // The view has not changed.
             return;
         }

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -233,6 +233,54 @@ describe('PageManager tests', () => {
         // Assert
         expect(pageManager.getPage()?.interaction).toEqual(1);
 
+        // Assert
+        expect(pageManager.getAttributes()).toMatchObject({
+            pageId: '/console/home',
+            interaction: 1
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
+
+    test('when session resumes and page is manually recorded with custom page attributes then custom page attributes are restored', async () => {
+        // Init
+        const pageManager: PageManager = new PageManager(
+            {
+                ...DEFAULT_CONFIG,
+                allowCookies: true
+            },
+            record
+        );
+
+        pageManager.resumeSession({
+            pageId: '/console/home',
+            interaction: 1,
+            start: Date.now()
+        });
+
+        pageManager.recordPageView({
+            pageId: '/console/home',
+            pageTags: ['pageGroup1'],
+            pageAttributes: {
+                customPageAttributeString: 'customPageAttributeValue',
+                customPageAttributeNumber: 1,
+                customPageAttributeBoolean: true
+            }
+        });
+
+        // Assert
+        expect(record.mock.calls).toHaveLength(0); // No event emitted, but attributes restored in PageManager state
+        expect(pageManager.getAttributes()).toMatchObject({
+            pageId: '/console/home',
+            pageTags: ['pageGroup1'],
+            customPageAttributeString: 'customPageAttributeValue',
+            customPageAttributeNumber: 1,
+            customPageAttributeBoolean: true
+        });
+
         window.removeEventListener(
             'popstate',
             (pageManager as any).popstateListener


### PR DESCRIPTION
This change contains a patch based on customer reported issue, wherein, pageId was missing from the metadata of certain events. 

In a previous [change](https://github.com/aws-observability/aws-rum-web/pull/341) we changed the behavior of when a Page View event is recorded. In cases where  page views resume (this includes resumed sessions and page being reloaded) but page ID is same were changed from being recorded as a separate page view event for each reload/resume to only creating a new page view event only when there was a change in the pageId. However, the change failed to address the following: 

1) In the case when the PageManager's state is restored after being resumed (using the page object stored in cookie), the cookie does not contain PageManager managed attributes which are added as metadata to all events. This means, the PageManager's attributes are not updated from what they were previously and remain null. Therefore, after a page is restored or reloaded, subsequent events don't contain the pageId in the metadata (since pageId is obtained from the PageManager). The pageId is restored in metadata only after a new page view event is generated as that forces the PageManager to update the metadata attributes. 


This change addresses this by: 
1) Updating the PageManager's attributes when a page is resumed as well. 
2) Adding Unit tests to capture this behavior

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
