### PR TITLE
chore: Add GitHub issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug Report
+description: Report a bug/issue
+title: '[Bug]: '
+labels: ['bug-report']
+
+body:
+    - type: checkboxes
+      attributes:
+          label: Is there an existing issue for this?
+          description: Please search to see if an issue already exists for the bug you encountered, and that it hasn't been fixed in a recent build/commit.
+          options:
+              - label: I have searched the existing issues and checked the recent builds/commits
+                required: true
+    - type: markdown
+      attributes:
+          value: |
+              *Please fill out this form with as much information as possible*
+    - type: textarea
+      id: version
+      attributes:
+          label: Which web client version did you detect this bug?
+          value: |
+              v1.13.3
+      validations:
+          required: true
+    - type: textarea
+      id: build
+      attributes:
+          label: What build system and module are you using?
+          value: |
+              Next.js 13 framework with CommonJS (CJS) on the server and ECMASript (ES) in the browser
+      validations:
+          required: true
+    - type: textarea
+      id: config
+      attributes:
+          label: Please provide your web client configurations
+          value: |
+              {
+                allowCookies: true,
+                endpoint: "https://dataplane.rum.us-west-2.amazonaws.com",
+                guestRoleArn: "arn:aws:iam::000000000000:role/RUM-Monitor-us-west-2-000000000000-00xx-Unauth",
+                identityPoolId: "us-west-2:00000000-0000-0000-0000-000000000000",
+                sessionSampleRate: 1,
+                telemetries: ['errors', 'performance', 'http']
+              }
+      validations:
+          required: true
+    - type: textarea
+      id: what-did
+      attributes:
+          label: What happened?
+          description: Tell us what happened in a very clear and simple way
+      validations:
+          required: true
+    - type: textarea
+      id: steps
+      attributes:
+          label: Steps to reproduce the problem
+          description: Please provide us with precise step by step information on how to reproduce the bug
+          value: |
+              1. Go to ....
+              2. Click ....
+              3. ...
+      validations:
+          required: true
+    - type: textarea
+      id: what-should
+      attributes:
+          label: What should have happened?
+          description: Tell what you think the normal behavior should be
+      validations:
+          required: true
+    - type: textarea
+      id: misc
+      attributes:
+          label: Additional information
+          description: Please provide us with any additional relevant info or context.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,7 +34,7 @@ body:
     - type: dropdown
       id: web-app-pages
       attributes:
-          label: Is your web application a single page application (SPA) or multi page application (MPA?
+          label: Is your web application a single page application (SPA) or multi page application (MPA)?
           multiple: false
           options:
               - SPA

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,7 @@ body:
       attributes:
           label: What environment (build systems, module system, and framework) did you detect this bug with?
           value: |
-              Next.js 13 framework with CommonJS (CJS) on the server and ECMASript (ES) in the browser
+              TypeScript v5.0.2, Webpack v4.46.0, ECMAScript modules (ESM) and React v18.2.0
       validations:
           required: true
     - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,7 +42,7 @@ body:
                 telemetries: ['errors', 'performance', 'http']
               }
       validations:
-          required: true
+          required: false
     - type: textarea
       id: bug-details
       attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     - type: textarea
       id: version
       attributes:
-          label: Which web client version did you detect this bug?
+          label: Which web client version did you detect this bug with?
           value: |
               v1.13.3
       validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,17 +4,6 @@ title: '[Bug]: '
 labels: ['bug-report']
 
 body:
-    - type: checkboxes
-      attributes:
-          label: Is there an existing issue for this?
-          description: Please search to see if an issue already exists for the bug you encountered, and that it hasn't been fixed in a recent build/commit.
-          options:
-              - label: I have searched the existing issues and checked the recent builds/commits
-                required: true
-    - type: markdown
-      attributes:
-          value: |
-              *Please fill out this form with as much information as possible*
     - type: textarea
       id: version
       attributes:
@@ -55,32 +44,9 @@ body:
       validations:
           required: true
     - type: textarea
-      id: what-did
+      id: bug-details
       attributes:
-          label: What happened?
-          description: Tell us what happened in a very clear and simple way
+          label: Please describe the issue/bug
+          description: Please provide as much detail as possible. Include details on how we can reproduce the bug.
       validations:
           required: true
-    - type: textarea
-      id: steps
-      attributes:
-          label: Steps to reproduce the problem
-          description: Please provide us with precise step by step information on how to reproduce the bug
-          value: |
-              1. Go to ....
-              2. Click ....
-              3. ...
-      validations:
-          required: true
-    - type: textarea
-      id: what-should
-      attributes:
-          label: What should have happened?
-          description: Tell what you think the normal behavior should be
-      validations:
-          required: true
-    - type: textarea
-      id: misc
-      attributes:
-          label: Additional information
-          description: Please provide us with any additional relevant info or context.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
     - type: textarea
       id: build
       attributes:
-          label: What build system and module are you using?
+          label: What environment (build systems, module system, and framework) did you detect this bug with?
           value: |
               Next.js 13 framework with CommonJS (CJS) on the server and ECMASript (ES) in the browser
       validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,7 @@ body:
     - type: textarea
       id: bug-details
       attributes:
-          label: Please describe the issue/bug
+          label: Please describe the bug/issue
           description: Please provide as much detail as possible. Include details on how we can reproduce the bug.
       validations:
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,6 +47,6 @@ body:
       id: bug-details
       attributes:
           label: Please describe the bug/issue
-          description: Please provide as much detail as possible. Include details on how we can reproduce the bug.
+          description: Provide as much detail as possible. Include details on how to reproduce the bug.
       validations:
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     - type: textarea
       id: config
       attributes:
-          label: Please provide your web client configurations
+          label: Please provide your web client configuration
           value: |
               {
                 allowCookies: true,

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,6 +31,14 @@ body:
               Next.js 13 framework with CommonJS (CJS) on the server and ECMASript (ES) in the browser
       validations:
           required: true
+    - type: dropdown
+      id: web-app-pages
+      attributes:
+          label: Is your web application a single page application (SPA) or multi page application (MPA?
+          multiple: false
+          options:
+              - SPA
+              - MPA
     - type: textarea
       id: config
       attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest an idea for this project
+title: '[Feature Request]: '
+labels: ['enhancement']
+
+body:
+    - type: checkboxes
+      attributes:
+          label: Is there an existing issue for this?
+          description: Please search to see if an issue already exists for the feature you want, and that it's not implemented in a recent build/commit.
+          options:
+              - label: I have searched the existing issues and checked the recent builds/commits
+                required: true
+    - type: markdown
+      attributes:
+          value: |
+              *Please fill out this form with as much information as possible, provide screenshots and/or illustrations of the feature if possible*
+    - type: textarea
+      id: feature
+      attributes:
+          label: What would your feature do?
+          description: Tell us about your feature in a very clear and simple way, and what problem it would solve
+      validations:
+          required: true
+    - type: textarea
+      id: workflow
+      attributes:
+          label: Proposed workflow
+          description: Please provide us with step by step information on how you'd like the feature to be accessed and used
+          value: |
+              1. Go to ....
+              2. Click ....
+              3. ...
+      validations:
+          required: true
+    - type: textarea
+      id: misc
+      attributes:
+          label: Additional information
+          description: Add any additional context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,37 +4,10 @@ title: '[Feature Request]: '
 labels: ['enhancement']
 
 body:
-    - type: checkboxes
-      attributes:
-          label: Is there an existing issue for this?
-          description: Please search to see if an issue already exists for the feature you want, and that it's not implemented in a recent build/commit.
-          options:
-              - label: I have searched the existing issues and checked the recent builds/commits
-                required: true
-    - type: markdown
-      attributes:
-          value: |
-              *Please fill out this form with as much information as possible, provide screenshots and/or illustrations of the feature if possible*
     - type: textarea
       id: feature
       attributes:
-          label: What would your feature do?
-          description: Tell us about your feature in a very clear and simple way, and what problem it would solve
+          label: Please provide your feature request
+          description: What problem are you trying to solve? How would this feature be used?
       validations:
           required: true
-    - type: textarea
-      id: workflow
-      attributes:
-          label: Proposed workflow
-          description: Please provide us with step by step information on how you'd like the feature to be accessed and used
-          value: |
-              1. Go to ....
-              2. Click ....
-              3. ...
-      validations:
-          required: true
-    - type: textarea
-      id: misc
-      attributes:
-          label: Additional information
-          description: Add any additional context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an idea for this project
+description: Suggest new features or enhancements
 title: '[Feature Request]: '
 labels: ['enhancement']
 

--- a/.github/ISSUE_TEMPLATE/general_inquiries.yml
+++ b/.github/ISSUE_TEMPLATE/general_inquiries.yml
@@ -1,0 +1,19 @@
+name: General inquiry
+description: Start a discussion not related to a bug or feature request
+title: '[General Inquiry]: '
+labels: ['question']
+
+body:
+    - type: checkboxes
+      attributes:
+          label: Is this regarding a bug or a feature request?
+          options:
+              - label: This is not regarding a bug or a feature request
+                required: true
+    - type: textarea
+      id: general-inquiry
+      attributes:
+          label: What is your general inquiry?
+          description: Please fill out this form with as much information as possible
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/general_inquiries.yml
+++ b/.github/ISSUE_TEMPLATE/general_inquiries.yml
@@ -4,16 +4,10 @@ title: '[General Inquiry]: '
 labels: ['question']
 
 body:
-    - type: checkboxes
-      attributes:
-          label: Is this regarding a bug or a feature request?
-          options:
-              - label: This is not regarding a bug or a feature request
-                required: true
     - type: textarea
       id: general-inquiry
       attributes:
           label: What is your general inquiry?
-          description: Please fill out this form with as much information as possible
+          description: Please provide as much detail as possible
       validations:
           required: true

--- a/.github/ISSUE_TEMPLATE/general_inquiries.yml
+++ b/.github/ISSUE_TEMPLATE/general_inquiries.yml
@@ -8,6 +8,6 @@ body:
       id: general-inquiry
       attributes:
           label: What is your general inquiry?
-          description: Please provide as much detail as possible
+          description: Please provide as much detail as possible.
       validations:
           required: true


### PR DESCRIPTION
To better categorize our GitHub issues, we will add the following templates:
1. Bug Report
2. Feature Request
3. General Inquiries

We will disable the option to create a blank issue so all issues must use one of the three templates mentioned above. Tested each template by pushing changes to separate branch in forked repo and verifying the generated form. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
