### PR TITLE
chore: Run smoke tests in pre-prod before publishing

### DIFF
--- a/.github/scripts/update_smoke_test.sh
+++ b/.github/scripts/update_smoke_test.sh
@@ -1,4 +1,4 @@
-# App monitor details 
+# App monitor details
 MONITOR_ID=$1
 REGION=$2
 GUEST_ARN=$3
@@ -7,17 +7,15 @@ ENDPOINT=$5
 CDN=$6
 VERSION=$(npm pkg get version | sed 's/"//g')/cwr.js
 CDN+=${VERSION}
-INSTALL_METHOD=$7
 
-if [ "$INSTALL_METHOD" = "CDN" ]; then
+# CDN
 awk '{sub(/\$MONITOR_ID/,MONITOR_ID);sub(/\$REGION/,REGION);sub(/\$CDN/,CDN);sub(/\$GUEST_ARN/,GUEST_ARN);sub(/\$IDENTITY_POOL/,IDENTITY_POOL);sub(/\$ENDPOINT/,ENDPOINT);}1' \
- MONITOR_ID="'$MONITOR_ID'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN="'$GUEST_ARN'" IDENTITY_POOL="'$IDENTITY_POOL'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-CDN/smoke.html
-elif [ "$INSTALL_METHOD" = "NPM_ES" ]; then
+ MONITOR_ID="'$MONITOR_ID'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN="'$GUEST_ARN'" IDENTITY_POOL="'$IDENTITY_POOL'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-CDN/smoke.html > processed_smoke.html
+
+# Module ES
 awk '{sub(/\$MONITOR_ID/,MONITOR_ID);sub(/\$REGION/,REGION);sub(/\$CDN/,CDN);sub(/\$GUEST_ARN/,GUEST_ARN);sub(/\$IDENTITY_POOL/,IDENTITY_POOL);sub(/\$ENDPOINT/,ENDPOINT);}1' \
- MONITOR_ID="'$MONITOR_ID'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN="'$GUEST_ARN'" IDENTITY_POOL="'$IDENTITY_POOL'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
- elif [ "$INSTALL_METHOD" = "NPM_CJS" ]; then
+ MONITOR_ID="'$MONITOR_ID'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN="'$GUEST_ARN'" IDENTITY_POOL="'$IDENTITY_POOL'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts > smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-tmp.ts
+
+# Module CJS
 awk '{sub(/\$MONITOR_ID/,MONITOR_ID);sub(/\$REGION/,REGION);sub(/\$CDN/,CDN);sub(/\$GUEST_ARN/,GUEST_ARN);sub(/\$IDENTITY_POOL/,IDENTITY_POOL);sub(/\$ENDPOINT/,ENDPOINT);}1' \
- MONITOR_ID="'$MONITOR_ID'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN="'$GUEST_ARN'" IDENTITY_POOL="'$IDENTITY_POOL'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
-else
-    echo "No valid installation method input"
-fi
+ MONITOR_ID="'$MONITOR_ID'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN="'$GUEST_ARN'" IDENTITY_POOL="'$IDENTITY_POOL'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts > smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-tmp.ts

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,18 +19,6 @@ jobs:
                   node-version: '16.x'
                   registry-url: 'https://registry.npmjs.org'
 
-            - name: Fetch AWS Credentials for Deployment
-              run: |
-                  export AWS_ROLE_ARN=${{ secrets.ROLE }}
-                  export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-                  export AWS_DEFAULT_REGION=us-east-1
-
-                  echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-                  echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-                  echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
-
-                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-
             - name: Cache NPM modules
               uses: actions/cache@v3
               with:
@@ -44,18 +32,33 @@ jobs:
                   npm ci
                   npm run release
 
-            - name: Publish to CloudWatch RUM CDN
-              id: publish-cdn
+            - name: Install PlayWright
+              run: npx playwright install --with-deps chromium
+
+            - name: Fetch AWS Credentials for Gamma Deployment
+              run: |
+                  export AWS_ROLE_ARN=${{ secrets.ROLE_GAMMA }}
+                  export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
+                  export AWS_DEFAULT_REGION=us-east-1
+
+                  echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
+                  echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
+                  echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
+
+                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+
+            - name: Publish to CloudWatch RUM Gamma CDN
+              id: publish-cdn-gamma
               run: |
                   chmod u+x .github/scripts/deploy.sh
-                  .github/scripts/deploy.sh ${{ secrets.BUCKET }}
+                  .github/scripts/deploy.sh ${{ secrets.BUCKET_GAMMA }}
 
-            - name: Validate versions.csv file
+            - name: Validate Gamma versions.csv file
               run: |
                   chmod u+x .github/scripts/validate_versions.sh
-                  .github/scripts/validate_versions.sh ${{ secrets.BUCKET }}
+                  .github/scripts/validate_versions.sh ${{ secrets.BUCKET_GAMMA }}
 
-            - name: Fetch AWS Credentials for Smoke Test
+            - name: Fetch AWS Credentials for Gamma Smoke Test
               run: |
                   export AWS_ROLE_ARN=${{ secrets.SMOKE_TEST_ROLE }}
                   export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
@@ -67,23 +70,11 @@ jobs:
 
                   curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
 
-            - name: Update Smoke Test Application - CDN
-              id: update-smoke-test-cdn
+            - name: Update Gamma Smoke Test Application
+              id: update-smoke-test-gamma-cdn
               run: |
                   chmod u+x .github/scripts/update_smoke_test.sh
-                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }} "CDN" >> processed_smoke.html
-
-            - name: Update Smoke Test Application - NPM/ES
-              id: update-smoke-test-npm-es
-              run: |
-                  chmod u+x .github/scripts/update_smoke_test.sh
-                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }} "NPM_ES" >> smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-tmp.ts
-
-            - name: Update Smoke Test Application - NPM/CJS
-              id: update-smoke-test-npm-cjs
-              run: |
-                  chmod u+x .github/scripts/update_smoke_test.sh
-                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }} "NPM_CJS" >> smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-tmp.ts
+                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN_GAMMA }}
 
             - name: Build Smoke Test Application - NPM/ES
               id: build-npm-es-application-pre-release
@@ -97,14 +88,11 @@ jobs:
                   chmod u+x .github/scripts/build_npm_applications.sh
                   .github/scripts/build_npm_applications.sh "PRE" "NPM-CJS"
 
-            - name: Upload Smoke Tests to CloudFront
-              id: upload-smoke-test
+            - name: Upload Gamma Smoke Tests to CloudFront
+              id: upload-smoke-test-gamma
               run: |
                   chmod u+x .github/scripts/upload_smoke_test.sh
                   .github/scripts/upload_smoke_test.sh ${{ secrets.SMOKE_BUCKET }}
-
-            - name: Install PlayWright
-              run: npx playwright install --with-deps chromium
 
             - name: Run Smoke Test (NPM ES)
               env:
@@ -116,18 +104,6 @@ jobs:
               run: npm run smoke:headless
               timeout-minutes: 10
 
-            - name: Fetch AWS Credentials for Smoke Test
-              run: |
-                  export AWS_ROLE_ARN=${{ secrets.SMOKE_TEST_ROLE }}
-                  export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-                  export AWS_DEFAULT_REGION=us-east-1
-
-                  echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-                  echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-                  echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
-
-                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
-
             - name: Run Smoke Test (NPM CJS)
               env:
                   URL: ${{ secrets.SMOKE_URL }}
@@ -138,7 +114,39 @@ jobs:
               run: npm run smoke:headless
               timeout-minutes: 10
 
-            - name: Fetch AWS Credentials for Smoke Test
+            - name: Run Gamma Smoke Test (CDN GAMMA)
+              env:
+                  URL: ${{ secrets.SMOKE_URL }}
+                  MONITOR: ${{ secrets.SMOKE_MONITOR }}
+                  ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
+                  NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
+                  INSTALL_METHOD: 'CDN'
+              run: npm run smoke:headless
+
+            - name: Fetch AWS Credentials for Prod Deployment
+              run: |
+                  export AWS_ROLE_ARN=${{ secrets.ROLE }}
+                  export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
+                  export AWS_DEFAULT_REGION=us-east-1
+
+                  echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
+                  echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
+                  echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
+
+                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+
+            - name: Publish to CloudWatch RUM Prod CDN
+              id: publish-cdn-prod
+              run: |
+                  chmod u+x .github/scripts/deploy.sh
+                  .github/scripts/deploy.sh ${{ secrets.BUCKET }}
+
+            - name: Validate Prod versions.csv file
+              run: |
+                  chmod u+x .github/scripts/validate_versions.sh
+                  .github/scripts/validate_versions.sh ${{ secrets.BUCKET }}
+
+            - name: Fetch AWS Credentials for Prod Smoke Test
               run: |
                   export AWS_ROLE_ARN=${{ secrets.SMOKE_TEST_ROLE }}
                   export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
@@ -150,7 +158,19 @@ jobs:
 
                   curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
 
-            - name: Run Smoke Test (CDN)
+            - name: Update Prod Smoke Test Application
+              id: update-smoke-test-prod-cdn
+              run: |
+                  chmod u+x .github/scripts/update_smoke_test.sh
+                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }}
+
+            - name: Upload Prod Smoke Tests to CloudFront
+              id: upload-smoke-test-prod
+              run: |
+                  chmod u+x .github/scripts/upload_smoke_test.sh
+                  .github/scripts/upload_smoke_test.sh ${{ secrets.SMOKE_BUCKET }}
+
+            - name: Run Prod Smoke Test (CDN)
               env:
                   URL: ${{ secrets.SMOKE_URL }}
                   MONITOR: ${{ secrets.SMOKE_MONITOR }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -101,7 +101,9 @@ jobs:
                   ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
                   NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
                   INSTALL_METHOD: 'NPM-ES'
-              run: npm run smoke:headless
+              run: |
+                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+                  npm run smoke:headless
               timeout-minutes: 10
 
             - name: Run Smoke Test (NPM CJS)
@@ -111,7 +113,9 @@ jobs:
                   ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
                   NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
                   INSTALL_METHOD: 'NPM-CJS'
-              run: npm run smoke:headless
+              run: |
+                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+                  npm run smoke:headless
               timeout-minutes: 10
 
             - name: Run Gamma Smoke Test (CDN GAMMA)
@@ -121,7 +125,9 @@ jobs:
                   ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
                   NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
                   INSTALL_METHOD: 'CDN'
-              run: npm run smoke:headless
+              run: |
+                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+                  npm run smoke:headless
 
             - name: Fetch AWS Credentials for Prod Deployment
               run: |


### PR DESCRIPTION
The release workflow does not currently test the release in a pre-prod environment before executing the release. This means that (1) the release technician must manually test the release in a pre-prod environment before executing a release, and (2) there is an increased risk of a regression.

This change adds steps to the release workflow to test the release in a pre-prod environment before running the release.

This change adds the following three secrets secrets to the release environment.
1. `ROLE_GAMMA`
2. `BUCKET_GAMMA`
3. `CDN_GAMMA`

I've verified the new release workflow succeeds in pre-prod up to the NPM publishing step, which is unchanged. See https://github.com/qhanam/aws-rum-web/actions/runs/5226500122/jobs/9437220189

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
