### PR TITLE
feat: allow customization of default attributes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,8 +67,7 @@ custom attributes with the `aws:` prefix, or they may be overwritten by future
 versions of the CloudWatch RUM web client.
 
 The RUM web client also records a set of [default
-attributes](https://github.com/aws-observability/aws-rum-web/blob/main/src/event-schemas/meta-data.json).
-You cannot overwrite default attributes with custom attributes.
+attributes](https://github.com/aws-observability/aws-rum-web/blob/main/src/event-schemas/meta-data.json). Overriding default attributes can have unintended consequences in the Cloudwatch RUM console.
 
 | Field Name | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/src/event-cache/__tests__/EventCache.integ.test.ts
+++ b/src/event-cache/__tests__/EventCache.integ.test.ts
@@ -75,7 +75,7 @@ describe('EventCache tests', () => {
         });
     });
 
-    test('default meta data attributes except platformType can be overriden by custom attributes', async () => {
+    test('default meta data can be overriden by custom attributes', async () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const config = {
@@ -100,16 +100,10 @@ describe('EventCache tests', () => {
             'aws:client': INSTALL_MODULE,
             'aws:clientVersion': WEB_CLIENT_VERSION,
             domain: 'overridden.console.aws.amazon.com',
-<<<<<<< HEAD
-            browserLanguage: 'en-US',
-            browserName: 'WebKit',
-            deviceType: 'desktop',
-=======
             browserLanguage: 'en-UK',
             browserName: 'Chrome',
             deviceType: 'Mac',
->>>>>>> 632bfe3... feat: allow customization of default attributes
-            platformType: 'web',
+            platformType: 'other',
             pageId: '/console/home'
         };
 

--- a/src/event-cache/__tests__/EventCache.integ.test.ts
+++ b/src/event-cache/__tests__/EventCache.integ.test.ts
@@ -75,7 +75,7 @@ describe('EventCache tests', () => {
         });
     });
 
-    test('meta data contains default attributes not overridden from custom attributes', async () => {
+    test('default meta data attributes except platformType can be overriden by custom attributes', async () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const config = {
@@ -88,7 +88,8 @@ describe('EventCache tests', () => {
                     domain: 'overridden.console.aws.amazon.com',
                     browserLanguage: 'en-UK',
                     browserName: 'Chrome',
-                    deviceType: 'Mac'
+                    deviceType: 'Mac',
+                    platformType: 'other'
                 }
             }
         };
@@ -99,9 +100,15 @@ describe('EventCache tests', () => {
             'aws:client': INSTALL_MODULE,
             'aws:clientVersion': WEB_CLIENT_VERSION,
             domain: 'overridden.console.aws.amazon.com',
+<<<<<<< HEAD
             browserLanguage: 'en-US',
             browserName: 'WebKit',
             deviceType: 'desktop',
+=======
+            browserLanguage: 'en-UK',
+            browserName: 'Chrome',
+            deviceType: 'Mac',
+>>>>>>> 632bfe3... feat: allow customization of default attributes
             platformType: 'web',
             pageId: '/console/home'
         };

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -139,9 +139,11 @@ export class SessionManager {
     public addSessionAttributes(sessionAttributes: {
         [k: string]: string | number | boolean;
     }) {
-        this.attributes = { ...sessionAttributes, ...this.attributes };
-        this.attributes.domain =
-            (sessionAttributes.domain as string) || this.attributes.domain;
+        this.attributes = {
+            ...this.attributes,
+            ...sessionAttributes,
+            platformType: this.attributes.platformType
+        };
     }
 
     public getUserId(): string {

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -139,11 +139,7 @@ export class SessionManager {
     public addSessionAttributes(sessionAttributes: {
         [k: string]: string | number | boolean;
     }) {
-        this.attributes = {
-            ...this.attributes,
-            ...sessionAttributes,
-            platformType: this.attributes.platformType
-        };
+        this.attributes = { ...this.attributes, ...sessionAttributes };
     }
 
     public getUserId(): string {

--- a/src/sessions/__tests__/SessionManager.test.ts
+++ b/src/sessions/__tests__/SessionManager.test.ts
@@ -810,16 +810,40 @@ describe('SessionManager tests', () => {
     });
 
     test('when domain is in custom session attributes then domain is overridden', async () => {
+        // Init
         const sessionManager = defaultSessionManager({
             ...DEFAULT_CONFIG
         });
 
-        sessionManager.addSessionAttributes({
-            domain: 'overridden'
-        });
+        const sessionAttributes = {
+            domain: 'preferred.domain'
+        };
+
+        sessionManager.addSessionAttributes(sessionAttributes);
 
         const actualSessionAttributes = sessionManager.getAttributes();
 
-        expect(actualSessionAttributes.domain).toEqual('overridden');
+        // Assert
+        expect(actualSessionAttributes.domain).toEqual(
+            sessionAttributes.domain
+        );
+    });
+
+    test('when custom session attributes have the same key as built in attributies then custom session attributes are used', async () => {
+        // Init
+        const sessionManager = defaultSessionManager({
+            ...DEFAULT_CONFIG
+        });
+
+        const sessionAttributes = {
+            title: 'override'
+        };
+
+        sessionManager.addSessionAttributes(sessionAttributes);
+
+        const actualSessionAttributes = sessionManager.getAttributes();
+
+        // Assert
+        expect(actualSessionAttributes.title).toEqual(sessionAttributes.title);
     });
 });


### PR DESCRIPTION
Allow the customization of default attributes, excluding the `platformType`. 

Primary use case is overriding the domain reported to RUM to facilitate using the same app monitor across different top-level domains which is not natively supported in RUM configuration.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
