### PR TITLE
fix: Add getId to enhanced authflow

### DIFF
--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -29,6 +29,7 @@ interface CognitoCredentials {
     AccessKeyId: string;
     Expiration: number;
     SecretAccessKey: string;
+    SecretKey: string;
     SessionToken: string;
 }
 
@@ -45,12 +46,6 @@ interface CredentialsResponse {
 interface GetIdResponse {
     IdentityId: string;
 }
-
-export const fromCognitoIdentityPool = (
-    params: CognitoProviderParameters
-): (() => Promise<Credentials>) => {
-    return () => params.client.getCredentialsForIdentity(params.identityPoolId);
-};
 
 export declare type CognitoIdentityClientConfig = {
     fetchRequestHandler: HttpHandler;
@@ -115,11 +110,11 @@ export class CognitoIdentityClient {
             const { Credentials } = (await responseToJson(
                 response
             )) as CredentialsResponse;
-            const { AccessKeyId, Expiration, SecretAccessKey, SessionToken } =
+            const { AccessKeyId, Expiration, SecretKey, SessionToken } =
                 Credentials;
             return {
                 accessKeyId: AccessKeyId as string,
-                secretAccessKey: SecretAccessKey as string,
+                secretAccessKey: SecretKey as string,
                 sessionToken: SessionToken as string,
                 expiration: new Date(Expiration * 1000)
             };

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -6,7 +6,7 @@ import { Credentials } from '@aws-sdk/types';
 import { getReadableStream } from '../../test-utils/test-utils';
 
 const mockCredentials =
-    '{ "IdentityId": "a", "Credentials": { "AccessKeyId": "x", "SecretAccessKey": "y", "SessionToken": "z" } }';
+    '{ "IdentityId": "a", "Credentials": { "AccessKeyId": "x", "SecretKey": "y", "SessionToken": "z" } }';
 const mockToken = '{"IdentityId": "mockId", "Token": "mockToken"}';
 const mockIdCommand = '{"IdentityId": "mockId"}';
 


### PR DESCRIPTION
Cognito recently onboarded CloudWatch RUM to its enhanced authflow. However, the enhanced authflow implemented in the web client is currently broken because it uses the identity pool Id, instead of the identity Id, as the argument for `getCredentialsForIdentity`.

This change modifies the enhanced authflow to fetch the identity Id before calling `getCredentialsForIdentity`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
