### PR TITLE
fix: Save deserialized credential object to Authentication member

### DIFF
--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -101,7 +101,7 @@ export class Authentication {
                     // The credentials have expired.
                     return reject();
                 }
-                resolve(credentials);
+                resolve(this.credentials);
             });
         };
 

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -53,12 +53,11 @@ export class Authentication {
      *
      * Implements CredentialsProvider = Provider<Credentials>
      */
-    public ChainAnonymousCredentialsProvider =
-        async (): Promise<Credentials> => {
-            return this.AnonymousCredentialsProvider()
-                .catch(this.AnonymousStorageCredentialsProvider)
-                .catch(this.AnonymousCognitoCredentialsProvider);
-        };
+    public ChainAnonymousCredentialsProvider = async (): Promise<Credentials> => {
+        return this.AnonymousCredentialsProvider()
+            .catch(this.AnonymousStorageCredentialsProvider)
+            .catch(this.AnonymousCognitoCredentialsProvider);
+    };
 
     /**
      * Provides credentials for an anonymous (guest) user. These credentials are read from a member variable.
@@ -80,31 +79,29 @@ export class Authentication {
      *
      * Implements CredentialsProvider = Provider<Credentials>
      */
-    private AnonymousStorageCredentialsProvider =
-        async (): Promise<Credentials> => {
-            return new Promise<Credentials>((resolve, reject) => {
-                let credentials: Credentials;
-                try {
-                    credentials = JSON.parse(localStorage.getItem(CRED_KEY)!);
-                } catch (e) {
-                    // Error retrieving, decoding or parsing the cred string -- abort
-                    return reject();
-                }
-                // The expiration property of Credentials has a date type. Because the date was serialized as a string,
-                // we need to convert it back into a date, otherwise the AWS SDK signing middleware
-                // (@aws-sdk/middleware-signing) will throw an exception and no credentials will be returned.
-                this.credentials = {
-                    ...credentials,
-                    expiration: new Date(credentials.expiration as Date)
-                };
-                if (this.renewCredentials()) {
-                    // The credentials have expired.
-                    return reject();
-                }
-                this.credentials = credentials;
-                resolve(credentials);
-            });
-        };
+    private AnonymousStorageCredentialsProvider = async (): Promise<Credentials> => {
+        return new Promise<Credentials>((resolve, reject) => {
+            let credentials: Credentials;
+            try {
+                credentials = JSON.parse(localStorage.getItem(CRED_KEY)!);
+            } catch (e) {
+                // Error retrieving, decoding or parsing the cred string -- abort
+                return reject();
+            }
+            // The expiration property of Credentials has a date type. Because the date was serialized as a string,
+            // we need to convert it back into a date, otherwise the AWS SDK signing middleware
+            // (@aws-sdk/middleware-signing) will throw an exception and no credentials will be returned.
+            this.credentials = {
+                ...credentials,
+                expiration: new Date(credentials.expiration as Date)
+            };
+            if (this.renewCredentials()) {
+                // The credentials have expired.
+                return reject();
+            }
+            resolve(credentials);
+        });
+    };
 
     /**
      * Provides credentials for an anonymous (guest) user. These credentials are retrieved from Cognito's basic
@@ -114,36 +111,32 @@ export class Authentication {
      *
      * Implements CredentialsProvider = Provider<Credentials>
      */
-    private AnonymousCognitoCredentialsProvider =
-        async (): Promise<Credentials> => {
-            return this.cognitoIdentityClient
-                .getId({
-                    IdentityPoolId: this.config.identityPoolId as string
+    private AnonymousCognitoCredentialsProvider = async (): Promise<Credentials> => {
+        return this.cognitoIdentityClient
+            .getId({
+                IdentityPoolId: this.config.identityPoolId as string
+            })
+            .then((getIdResponse) =>
+                this.cognitoIdentityClient.getOpenIdToken(getIdResponse)
+            )
+            .then((getOpenIdTokenResponse) =>
+                this.stsClient.assumeRoleWithWebIdentity({
+                    RoleArn: this.config.guestRoleArn as string,
+                    RoleSessionName: 'cwr',
+                    WebIdentityToken: getOpenIdTokenResponse.Token
                 })
-                .then((getIdResponse) =>
-                    this.cognitoIdentityClient.getOpenIdToken(getIdResponse)
-                )
-                .then((getOpenIdTokenResponse) =>
-                    this.stsClient.assumeRoleWithWebIdentity({
-                        RoleArn: this.config.guestRoleArn as string,
-                        RoleSessionName: 'cwr',
-                        WebIdentityToken: getOpenIdTokenResponse.Token
-                    })
-                )
-                .then((credentials: Credentials) => {
-                    this.credentials = credentials;
-                    try {
-                        localStorage.setItem(
-                            CRED_KEY,
-                            JSON.stringify(credentials)
-                        );
-                    } catch (e) {
-                        // Ignore
-                    }
+            )
+            .then((credentials: Credentials) => {
+                this.credentials = credentials;
+                try {
+                    localStorage.setItem(CRED_KEY, JSON.stringify(credentials));
+                } catch (e) {
+                    // Ignore
+                }
 
-                    return credentials;
-                });
-        };
+                return credentials;
+            });
+    };
 
     private renewCredentials(): boolean {
         if (!this.credentials || !this.credentials.expiration) {

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -77,12 +77,12 @@ export class EnhancedAuthentication {
     private AnonymousStorageCredentialsProvider =
         async (): Promise<Credentials> => {
             return new Promise<Credentials>((resolve, reject) => {
-                let credentials;
+                let credentials: Credentials;
                 try {
                     credentials = JSON.parse(localStorage.getItem(CRED_KEY)!);
                 } catch (e) {
                     // Error decoding or parsing the cookie -- abort
-                    reject();
+                    return reject();
                 }
                 // The expiration property of Credentials has a date type. Because the date was serialized as a string,
                 // we need to convert it back into a date, otherwise the AWS SDK signing middleware
@@ -95,7 +95,7 @@ export class EnhancedAuthentication {
                     // The credentials have expired.
                     return reject();
                 }
-                resolve(credentials);
+                resolve(this.credentials);
             });
         };
 

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -47,11 +47,12 @@ export class EnhancedAuthentication {
      *
      * Implements CredentialsProvider = Provider<Credentials>
      */
-    public ChainAnonymousCredentialsProvider = async (): Promise<Credentials> => {
-        return this.AnonymousCredentialsProvider()
-            .catch(this.AnonymousStorageCredentialsProvider)
-            .catch(this.AnonymousCognitoCredentialsProvider);
-    };
+    public ChainAnonymousCredentialsProvider =
+        async (): Promise<Credentials> => {
+            return this.AnonymousCredentialsProvider()
+                .catch(this.AnonymousStorageCredentialsProvider)
+                .catch(this.AnonymousCognitoCredentialsProvider);
+        };
 
     /**
      * Provides credentials for an anonymous (guest) user. These credentials are read from a member variable.
@@ -73,29 +74,30 @@ export class EnhancedAuthentication {
      *
      * Implements CredentialsProvider = Provider<Credentials>
      */
-    private AnonymousStorageCredentialsProvider = async (): Promise<Credentials> => {
-        return new Promise<Credentials>((resolve, reject) => {
-            let credentials;
-            try {
-                credentials = JSON.parse(localStorage.getItem(CRED_KEY)!);
-            } catch (e) {
-                // Error decoding or parsing the cookie -- abort
-                reject();
-            }
-            // The expiration property of Credentials has a date type. Because the date was serialized as a string,
-            // we need to convert it back into a date, otherwise the AWS SDK signing middleware
-            // (@aws-sdk/middleware-signing) will throw an exception and no credentials will be returned.
-            this.credentials = {
-                ...credentials,
-                expiration: new Date(credentials.expiration as Date)
-            };
-            if (this.renewCredentials()) {
-                // The credentials have expired.
-                return reject();
-            }
-            resolve(credentials);
-        });
-    };
+    private AnonymousStorageCredentialsProvider =
+        async (): Promise<Credentials> => {
+            return new Promise<Credentials>((resolve, reject) => {
+                let credentials;
+                try {
+                    credentials = JSON.parse(localStorage.getItem(CRED_KEY)!);
+                } catch (e) {
+                    // Error decoding or parsing the cookie -- abort
+                    reject();
+                }
+                // The expiration property of Credentials has a date type. Because the date was serialized as a string,
+                // we need to convert it back into a date, otherwise the AWS SDK signing middleware
+                // (@aws-sdk/middleware-signing) will throw an exception and no credentials will be returned.
+                this.credentials = {
+                    ...credentials,
+                    expiration: new Date(credentials.expiration as Date)
+                };
+                if (this.renewCredentials()) {
+                    // The credentials have expired.
+                    return reject();
+                }
+                resolve(credentials);
+            });
+        };
 
     /**
      * Provides credentials for an anonymous (guest) user. These credentials are retrieved from Cognito's enhanced
@@ -105,25 +107,29 @@ export class EnhancedAuthentication {
      *
      * Implements CredentialsProvider = Provider<Credentials>
      */
-    private AnonymousCognitoCredentialsProvider = async (): Promise<Credentials> => {
-        return this.cognitoIdentityClient
-            .getId({ IdentityPoolId: this.config.identityPoolId as string })
-            .then((getIdResponse) =>
-                this.cognitoIdentityClient.getCredentialsForIdentity(
-                    getIdResponse.IdentityId
+    private AnonymousCognitoCredentialsProvider =
+        async (): Promise<Credentials> => {
+            return this.cognitoIdentityClient
+                .getId({ IdentityPoolId: this.config.identityPoolId as string })
+                .then((getIdResponse) =>
+                    this.cognitoIdentityClient.getCredentialsForIdentity(
+                        getIdResponse.IdentityId
+                    )
                 )
-            )
-            .then((credentials: Credentials) => {
-                this.credentials = credentials;
-                try {
-                    localStorage.setItem(CRED_KEY, JSON.stringify(credentials));
-                } catch (e) {
-                    // Ignore
-                }
+                .then((credentials: Credentials) => {
+                    this.credentials = credentials;
+                    try {
+                        localStorage.setItem(
+                            CRED_KEY,
+                            JSON.stringify(credentials)
+                        );
+                    } catch (e) {
+                        // Ignore
+                    }
 
-                return credentials;
-            });
-    };
+                    return credentials;
+                });
+        };
 
     private renewCredentials(): boolean {
         if (!this.credentials || !this.credentials.expiration) {

--- a/src/dispatch/__tests__/Authentication.test.ts
+++ b/src/dispatch/__tests__/Authentication.test.ts
@@ -336,4 +336,69 @@ describe('Authentication tests', () => {
             })
         );
     });
+
+    test('when credentials are read from storage then a new date object is created', async () => {
+        // Init
+        const storageExpiration = new Date(Date.now() + 3600 * 1000);
+
+        localStorage.setItem(
+            CRED_KEY,
+            JSON.stringify({
+                accessKeyId: 'a',
+                secretAccessKey: 'b',
+                sessionToken: 'c',
+                expiration: storageExpiration
+            })
+        );
+
+        const config = {
+            ...DEFAULT_CONFIG,
+            ...{
+                identityPoolId: IDENTITY_POOL_ID,
+                guestRoleArn: GUEST_ROLE_ARN
+            }
+        };
+        const auth = new Authentication(config);
+
+        // Run
+        const credentials = await auth.ChainAnonymousCredentialsProvider();
+
+        // Assert
+        expect(credentials.expiration!.getTime()).toEqual(
+            storageExpiration.getTime()
+        );
+    });
+
+    test('when credentials are read from storage then the member variable stores the expiration as a date object', async () => {
+        // Init
+        const storageExpiration = new Date(Date.now() + 3600 * 1000);
+
+        localStorage.setItem(
+            CRED_KEY,
+            JSON.stringify({
+                accessKeyId: 'a',
+                secretAccessKey: 'b',
+                sessionToken: 'c',
+                expiration: storageExpiration
+            })
+        );
+
+        const config = {
+            ...DEFAULT_CONFIG,
+            ...{
+                identityPoolId: IDENTITY_POOL_ID,
+                guestRoleArn: GUEST_ROLE_ARN
+            }
+        };
+        const auth = new Authentication(config);
+
+        // Run
+        await auth.ChainAnonymousCredentialsProvider();
+        const credentials = await auth.ChainAnonymousCredentialsProvider();
+
+        // Assert
+        expect(credentials.expiration!.getTime()).toEqual(
+            storageExpiration.getTime()
+        );
+    });
 });

--- a/src/dispatch/__tests__/EnhancedAuthentication.test.ts
+++ b/src/dispatch/__tests__/EnhancedAuthentication.test.ts
@@ -305,4 +305,79 @@ describe('EnhancedAuthentication tests', () => {
             })
         );
     });
+
+    test('when credentials are read from storage then a new date object is created', async () => {
+        // Init
+        const fetchExpiration = new Date(0);
+        const storageExpiration = new Date(Date.now() + 3600 * 1000);
+        getCredentials.mockResolvedValue({
+            accessKeyId: 'x',
+            secretAccessKey: 'y',
+            sessionToken: 'z',
+            expiration: fetchExpiration
+        });
+
+        localStorage.setItem(
+            CRED_KEY,
+            JSON.stringify({
+                accessKeyId: 'a',
+                secretAccessKey: 'b',
+                sessionToken: 'c',
+                expiration: storageExpiration
+            })
+        );
+
+        const auth = new EnhancedAuthentication({
+            ...DEFAULT_CONFIG,
+            ...{
+                identityPoolId: IDENTITY_POOL_ID
+            }
+        });
+
+        // Run
+        const credentials = await auth.ChainAnonymousCredentialsProvider();
+
+        // Assert
+        expect(credentials.expiration!.getTime()).toEqual(
+            storageExpiration.getTime()
+        );
+    });
+
+    test('when credentials are read from storage then the member variable stores the expiration as a date object', async () => {
+        // Init
+        const fetchExpiration = new Date(0);
+        const storageExpiration = new Date(Date.now() + 3600 * 1000);
+        getCredentials.mockResolvedValue({
+            accessKeyId: 'x',
+            secretAccessKey: 'y',
+            sessionToken: 'z',
+            expiration: fetchExpiration
+        });
+
+        localStorage.setItem(
+            CRED_KEY,
+            JSON.stringify({
+                accessKeyId: 'a',
+                secretAccessKey: 'b',
+                sessionToken: 'c',
+                expiration: storageExpiration
+            })
+        );
+
+        const auth = new EnhancedAuthentication({
+            ...DEFAULT_CONFIG,
+            ...{
+                identityPoolId: IDENTITY_POOL_ID
+            }
+        });
+
+        // Run
+        await auth.ChainAnonymousCredentialsProvider();
+        const credentials = await auth.ChainAnonymousCredentialsProvider();
+
+        // Assert
+        expect(credentials.expiration!.getTime()).toEqual(
+            storageExpiration.getTime()
+        );
+    });
 });


### PR DESCRIPTION
## Details
Currently in our Authentication and EnhancedAuthentication, we save credential object as serialized string values. Then, as we read the serialized string from Storage, we parse the string into a Credential object.

However, in AnonymousStorageCredentialsProvider, we overwrite the local member variable credential with the serialized string instead of the parsed object. As a result, any situation that requires reading of the credential from storage leads to: `TypeError: this.credentials.expiration.getTime is not a function.`

This PR removes the unnecessary step to overwrite the local member `this.credential` with the serialized string.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
