### PR TITLE
feat: Re-use Cognito identity id

### DIFF
--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -175,4 +175,30 @@ describe('CognitoIdentityClient tests', () => {
             })
         ).rejects.toEqual(expected);
     });
+
+    test('when identity Id is retrieved from Cognito then next identity Id is retrieved from localStorage', async () => {
+        fetchHandler.mockResolvedValueOnce({
+            response: {
+                body: getReadableStream(mockIdCommand)
+            }
+        });
+
+        // Init
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION
+        });
+
+        // Run
+        await client.getId({ IdentityPoolId: 'my-fake-identity-pool-id' });
+        const idCommand = await client.getId({
+            IdentityPoolId: 'my-fake-identity-pool-id'
+        });
+
+        // Assert
+        expect(fetchHandler).toHaveBeenCalledTimes(1);
+        expect(idCommand).toMatchObject({
+            IdentityId: 'mockId'
+        });
+    });
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,5 @@
 export const CRED_KEY = 'cwr_c';
+export const IDENTITY_KEY = 'cwr_i';
 export const SESSION_COOKIE_NAME = 'cwr_s';
 export const USER_COOKIE_NAME = 'cwr_u';
 export const CRED_RENEW_MS = 30000;


### PR DESCRIPTION
Cognito identity Ids, which are used to allow unauthenticated users to send RUM data, can be re-used and do not expire.

This change stores identity Ids in localStorage in a similar way to how credentials are stored. Along with using the enhanced authflow, this means in most cases there will be one auth-related request instead of three.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
