### PR TITLE
fix: Update false-negative test case in Authentication.test

### DIFF
--- a/src/dispatch/__tests__/Authentication.test.ts
+++ b/src/dispatch/__tests__/Authentication.test.ts
@@ -372,6 +372,12 @@ describe('Authentication tests', () => {
     test('when credentials are read from storage then the member variable stores the expiration as a date object', async () => {
         // Init
         const storageExpiration = new Date(Date.now() + 3600 * 1000);
+        assumeRole.mockResolvedValue({
+            accessKeyId: 'x',
+            secretAccessKey: 'y',
+            sessionToken: 'z',
+            expiration: new Date(0)
+        });
 
         localStorage.setItem(
             CRED_KEY,


### PR DESCRIPTION
##  Details
Addresses the concern from https://github.com/aws-observability/aws-rum-web/pull/436.

> nit: This test will pass under certain conditions when it should fail (i.e., false negative).

> Specifically, when this.credentials.expiration is undefined, and the expiration property of the value returned by AnonymousStorageCredentialsProvider is a Date object. When this happens, control flow will reach AnonymousCognitoCredentialsProvider, and the test needs a way to distinguish the value returned here from the expected value.

> You can fix this by mocking the response of getCredentials, like was done in [EnhancedAuthentication.test.ts here](https://github.com/aws-observability/aws-rum-web/pull/436/files#diff-94a33512cc69b461d93e786b0cfc32e12f8767a11831604e38300860eb1ffba7R348-R355).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
