### PR TITLE
chore: dispatch all events to EventBus

### DIFF
--- a/src/event-bus/EventBus.ts
+++ b/src/event-bus/EventBus.ts
@@ -1,8 +1,4 @@
-export type Subscriber = (message: Message) => void;
-export interface Message {
-    key?: any;
-    payload: any;
-}
+export type Subscriber = (message: any) => void;
 export enum Topic {
     EVENT = 'event'
 }
@@ -33,7 +29,7 @@ export default class EventBus<T = Topic> {
         return false;
     }
 
-    dispatch(topic: T, message: Message): void {
+    dispatch(topic: T, message: any): void {
         const list = this.subscribers.get(topic);
         if (list) {
             for (const subscriber of list) {

--- a/src/event-bus/__tests__/EventBus.test.ts
+++ b/src/event-bus/__tests__/EventBus.test.ts
@@ -1,4 +1,4 @@
-import EventBus, { Topic } from '../EventBus';
+import EventBus from '../EventBus';
 
 export enum MockTopics {
     FOOD = 'food',
@@ -18,11 +18,11 @@ describe('EventBus tests', () => {
         eventBus.subscribe(MockTopics.FOOD, l2);
 
         // run
-        eventBus.dispatch(MockTopics.FOOD, { payload: 'burger' });
+        eventBus.dispatch(MockTopics.FOOD, 'burger');
 
         // assert
-        expect(l1).toHaveBeenCalledWith({ payload: 'burger' });
-        expect(l2).toHaveBeenCalledWith({ payload: 'burger' });
+        expect(l1).toHaveBeenCalledWith('burger');
+        expect(l2).toHaveBeenCalledWith('burger');
     });
 
     test('when subscriber is removed then it is not called', async () => {
@@ -32,10 +32,10 @@ describe('EventBus tests', () => {
         const removed = eventBus.unsubscribe(MockTopics.FOOD, l2);
 
         // run
-        eventBus.dispatch(MockTopics.FOOD, { payload: 'burger' });
+        eventBus.dispatch(MockTopics.FOOD, 'burger');
 
         // assert
-        expect(l1).toHaveBeenCalledWith({ payload: 'burger' });
+        expect(l1).toHaveBeenCalledWith('burger');
         expect(removed).toBe(true);
         expect(l2).not.toHaveBeenCalled();
     });
@@ -45,7 +45,7 @@ describe('EventBus tests', () => {
         eventBus.subscribe(MockTopics.BOOKS, l2);
 
         // run
-        eventBus.dispatch(MockTopics.FOOD, { payload: 'burger' });
+        eventBus.dispatch(MockTopics.FOOD, 'burger');
 
         // assert
         expect(l2).not.toHaveBeenCalled();

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -88,7 +88,7 @@ export class EventCache {
      *
      * @param type The event schema.
      */
-    public recordEvent = (type: string, eventData: object, key?: any) => {
+    public recordEvent = (type: string, eventData: object) => {
         if (!this.enabled) {
             return;
         }
@@ -98,7 +98,7 @@ export class EventCache {
             this.sessionManager.incrementSessionEventCount();
 
             if (this.canRecord(session)) {
-                this.addRecordToCache(type, eventData, key);
+                this.addRecordToCache(type, eventData);
             }
         }
     };
@@ -231,7 +231,6 @@ export class EventCache {
             type
         };
         this.eventBus.dispatch(Topic.EVENT, {
-            ...(key && { key }),
             payload: {
                 ...partialEvent,
                 details: eventData,

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -203,7 +203,7 @@ export class EventCache {
      *
      * @param type The event schema.
      */
-    private addRecordToCache = (type: string, eventData: object, key?: any) => {
+    private addRecordToCache = (type: string, eventData: object) => {
         if (!this.enabled) {
             return;
         }
@@ -231,11 +231,9 @@ export class EventCache {
             type
         };
         this.eventBus.dispatch(Topic.EVENT, {
-            payload: {
-                ...partialEvent,
-                details: eventData,
-                metadata: metaData
-            }
+            ...partialEvent,
+            details: eventData,
+            metadata: metaData
         });
         this.events.push({
             ...partialEvent,

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -519,17 +519,15 @@ describe('EventCache tests', () => {
         expect(bus.dispatch).toHaveBeenCalledWith(
             Topic.EVENT,
             expect.objectContaining({
-                payload: expect.objectContaining({
-                    id: expect.stringMatching(/[0-9a-f\-]+/),
-                    timestamp: new Date(),
-                    type: EVENT1_SCHEMA,
-                    metadata: expect.objectContaining({
-                        version: '1.0.0',
-                        'aws:client': INSTALL_MODULE,
-                        'aws:clientVersion': WEB_CLIENT_VERSION
-                    }),
-                    details: expect.objectContaining({})
-                })
+                id: expect.stringMatching(/[0-9a-f\-]+/),
+                timestamp: new Date(),
+                type: EVENT1_SCHEMA,
+                metadata: expect.objectContaining({
+                    version: '1.0.0',
+                    'aws:client': INSTALL_MODULE,
+                    'aws:clientVersion': WEB_CLIENT_VERSION
+                }),
+                details: expect.objectContaining({})
             })
         );
     });

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -494,7 +494,7 @@ describe('EventCache tests', () => {
         expect(eventCache.getEventBatch().length).toEqual(1);
     });
 
-    test('when event is recorded then events subscribers are notified with raw event', async () => {
+    test('when event is recorded then events subscribers are notified with parsed rum event', async () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const bus = new EventBus();
@@ -531,41 +531,6 @@ describe('EventCache tests', () => {
                     details: expect.objectContaining({})
                 })
             })
-        );
-    });
-
-    test('when event is recorded with key then the key is dispatched', async () => {
-        const EVENT1_SCHEMA = 'com.amazon.rum.event1';
-        const bus = new EventBus();
-        const eventCache: EventCache = Utils.createEventCache(
-            DEFAULT_CONFIG,
-            bus
-        );
-
-        // run
-        eventCache.recordEvent(EVENT1_SCHEMA, {}, 'key');
-
-        // eslint-disable-next-line
-        expect(bus.dispatch).toHaveBeenCalledWith(
-            Topic.EVENT,
-            expect.objectContaining({ key: 'key' })
-        );
-    });
-
-    test('when event is recorded without key then dispatched message does not contain key', async () => {
-        const EVENT1_SCHEMA = 'com.amazon.rum.event1';
-        const bus = new EventBus();
-        const eventCache: EventCache = Utils.createEventCache(
-            DEFAULT_CONFIG,
-            bus
-        );
-
-        // run
-        eventCache.recordEvent(EVENT1_SCHEMA, {});
-        // eslint-disable-next-line
-        expect(bus.dispatch).not.toHaveBeenCalledWith(
-            expect.anything(),
-            expect.objectContaining({ key: 'key' })
         );
     });
 

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -207,7 +207,7 @@ export class Orchestration {
     private eventCache: EventCache;
     private dispatchManager: Dispatch;
     private config: Config;
-    private eventBus = new EventBus();
+    private eventBus = new EventBus<Topic>();
 
     /**
      * Instantiate the CloudWatch RUM web client and begin monitoring the

--- a/src/plugins/event-plugins/NavigationPlugin.ts
+++ b/src/plugins/event-plugins/NavigationPlugin.ts
@@ -265,8 +265,7 @@ export class NavigationPlugin extends InternalPlugin {
         if (this.context?.record) {
             this.context.record(
                 PERFORMANCE_NAVIGATION_EVENT_TYPE,
-                eventDataNavigationTimingLevel2,
-                entryData
+                eventDataNavigationTimingLevel2
             );
         }
     };

--- a/src/plugins/event-plugins/ResourcePlugin.ts
+++ b/src/plugins/event-plugins/ResourcePlugin.ts
@@ -127,11 +127,7 @@ export class ResourcePlugin extends InternalPlugin {
             if (this.context.config.recordResourceUrl) {
                 eventData.targetUrl = entryData.name;
             }
-            this.context.record(
-                PERFORMANCE_RESOURCE_EVENT_TYPE,
-                eventData,
-                entryData
-            );
+            this.context.record(PERFORMANCE_RESOURCE_EVENT_TYPE, eventData);
         }
     };
 

--- a/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
@@ -44,10 +44,6 @@ describe('NavigationPlugin tests', () => {
                 navigationType: navigationEvent.type
             })
         );
-        // expect to record with key=PerformanceNavigationEntry
-        expect(record.mock.calls[0][2]).toEqual(
-            expect.objectContaining(navigationEvent)
-        );
     });
 
     test('When navigation timing level 2 API is not present then navigation timing level 1 API is recorded', async () => {

--- a/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
@@ -77,9 +77,6 @@ describe('NavigationPlugin tests', () => {
                 navigationTimingLevel: 1
             })
         );
-
-        // // expect to record without key
-        expect(record.mock.calls[0].length).toEqual(2);
     });
 
     test('when enabled then events are recorded', async () => {

--- a/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
@@ -65,9 +65,6 @@ describe('ResourcePlugin tests', () => {
                 initiatorType: resourceEvent.initiatorType
             })
         );
-        expect(record.mock.calls[0][2]).toEqual(
-            expect.objectContaining(resourceEvent)
-        );
     });
 
     test('when recordResourceUrl is false then the resource name is not recorded', async () => {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2,7 +2,7 @@ import { Config } from '../orchestration/Orchestration';
 import { Session } from '../sessions/SessionManager';
 import EventBus, { Topic } from '../event-bus/EventBus';
 
-export type RecordEvent = (type: string, eventData: object, key?: any) => void;
+export type RecordEvent = (type: string, eventData: object) => void;
 export type RecordPageView = (pageId: string) => void;
 export type GetSession = () => Session | undefined;
 

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -17,7 +17,7 @@ import {
     UserDetails
 } from '../dispatch/dataplane';
 import { ReadableStream } from 'web-streams-polyfill';
-import EventBus, { Topic } from '../event-bus/EventBus';
+import EventBus from '../event-bus/EventBus';
 jest.mock('../event-bus/EventBus');
 
 export const AWS_RUM_ENDPOINT = new URL(


### PR DESCRIPTION
> Rewrite of #440 

### Purpose

This PR creates the structure necessary for sharing information between plugins. 

### Uses cases: 

1. Have PluginA find eventId's created by PluginB etc. Useful for LCP attribution
2. WebVitalsPlugin tracks current count of in-flight Xhr and Fetch requests

### Revisions

**Revision 1**

I have created `EventBus` with topic-based filtering. I implemented our own instead of taking on a dependency because we only need a few extremely simple features. 
* Plugins can subscribe to any topic via `context.bus.subscribe(topic, callback)`
* Plugins can publish to any topic via `context.bus.dispatch(topic, message)`
* All events are published on every record by EventCache via `bus.dispatch(eventType, message)`

**Revision 2**
* Plugins are responsible for dispatching events
* EventCache is not responsible for dispatching events
* EventCache.record returns a ParsedRumEvent so plugins can access things like eventId, metadata, details, etc. 
* Read this thread for full context https://github.com/aws-observability/aws-rum-web/pull/445#discussion_r1317539603

**Revision 3**
* EventCache dispatches every event that is successfully recorded to topic 'events'
* Resource event supplies additional key=PerformanceResourceTiming
* Navigation supplies additional key=PerformanceNavigationTiming for level 2
* Read for full context https://github.com/aws-observability/aws-rum-web/pull/445#discussion_r1317539603

**Revision 4**
* Remove key
* Target main branch
### Examples 

**Use case 1:** PluginA finds eventId's of events from PluginB
```typescript
class WebVitalsPlugin {
   imageEvents = []
   constructor() {
      this.context.bus.subscribe(PERFORMANCE_RESOURCE_EVENT, this.storeResourceEvent)
   }
   storeResourceEvent(event) {
      if (event.fileType === ResourceTypes.IMAGE) {
         this.imageEvents.push(event)
      }
   }

   ...
   onLCP(payload => {
       ...
       findMatchingLCPEvent()
       // teardown
       this.imageEvents = []
       this.context.bus.unsubscribe(...)
   })
}
```

**Use case 2:** Count in-flight fetch/xhr requests
```typescript
// FetchPlugin.ts
...
private fetch() {
   ...
   this.context.bus.dispatch('http_open_count', {payload: 1})
   return original()
   .apply()
   .then(() => {
        this.context.bus.dispatch('http_open_count', {payload: -1})
    })
   .catch(() => {
        this.context.bus.dispatch('http_open_count', {payload: -1})
    })
}

...

// WebVitalsPlugin
class WebVitalsPlugins {
    ...
    http_open_count = 0
    handleHttpCountChange({payload}) { this.http_open_count += payload }
    constructor() {
        this.context.bus.subscribe('http_open_count', this.handleHttpCountChange)
   }
   teardown() {
       this.context.bus.unsubscribe('http_open_count', this.handleHttpCountChange)
   }
   ....
}
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
