### PR TITLE
feat: Add trace id to http events

### DIFF
--- a/src/event-schemas/http-event.json
+++ b/src/event-schemas/http-event.json
@@ -9,6 +9,16 @@
             "type": "string",
             "description": "Schema version."
         },
+        "trace_id": {
+            "type": "string",
+            "minLength": 35,
+            "maxLength": 35
+        },
+        "segment_id": {
+            "type": "string",
+            "minLength": 16,
+            "maxLength": 16
+        },
         "request": {
             "type": "object",
             "properties": {

--- a/src/plugins/event-plugins/FetchPlugin.ts
+++ b/src/plugins/event-plugins/FetchPlugin.ts
@@ -274,6 +274,8 @@ export class FetchPlugin extends MonkeyPatched<Window, 'fetch'> {
 
         if (this.isTracingEnabled() && this.isSessionRecorded()) {
             trace = this.beginTrace(input, init, argsArray);
+            httpEvent.trace_id = trace.trace_id;
+            httpEvent.segment_id = trace.subsegments![0].id;
         }
 
         return original

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -814,4 +814,108 @@ describe('XhrPlugin tests', () => {
             ]
         });
     });
+
+    test('when the plugin records a trace then the trace id is added to the http event', async () => {
+        // Init
+        const config: PartialHttpPluginConfig = {
+            logicalServiceName: 'sample.rum.aws.amazon.com',
+            urlsToInclude: [/response\.json/],
+            recordAllRequests: true
+        };
+
+        mock.get(/.*/, {
+            body: JSON.stringify({ message: 'Hello World!' }),
+            headers: { 'Content-Length': '125' } as MockHeaders
+        });
+
+        const plugin: XhrPlugin = new XhrPlugin(config);
+        plugin.load(xRayOnContext);
+
+        // Run
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', './response.json', true);
+        xhr.send();
+
+        // Yield to the event queue so the event listeners can run
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(2);
+        expect(record.mock.calls[1][0]).toEqual(HTTP_EVENT_TYPE);
+        expect(record.mock.calls[1][1]).toMatchObject({
+            trace_id: '1-0-000000000000000000000000',
+            segment_id: '0000000000000000'
+        });
+    });
+
+    test('when XHR aborts with tracing then the trace id is added to the http event', async () => {
+        // Init
+        const config: PartialHttpPluginConfig = {
+            logicalServiceName: 'sample.rum.aws.amazon.com',
+            urlsToInclude: [/response\.json/]
+        };
+
+        mock.get(/.*/, {
+            body: JSON.stringify({ message: 'Hello World!' })
+        });
+
+        const plugin: XhrPlugin = new XhrPlugin(config);
+        plugin.load(xRayOnContext);
+
+        // Run
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', './response.json', true);
+        xhr.send();
+        xhr.abort();
+
+        // Yield to the event queue so the event listeners can run
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(2);
+        expect(record.mock.calls[1][0]).toEqual(HTTP_EVENT_TYPE);
+        expect(record.mock.calls[1][1]).toMatchObject({
+            trace_id: '1-0-000000000000000000000000',
+            segment_id: '0000000000000000'
+        });
+    });
+
+    test('when the plugin does not record a trace then the trace id is not added to the http event', async () => {
+        // Init
+        const config: PartialHttpPluginConfig = {
+            logicalServiceName: 'sample.rum.aws.amazon.com',
+            urlsToInclude: [/response\.json/],
+            recordAllRequests: true
+        };
+
+        mock.get(/.*/, {
+            body: JSON.stringify({ message: 'Hello World!' }),
+            headers: { 'Content-Length': '125' } as MockHeaders
+        });
+
+        const plugin: XhrPlugin = new XhrPlugin(config);
+        plugin.load(xRayOffContext);
+
+        // Run
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', './response.json', true);
+        xhr.send();
+
+        // Yield to the event queue so the event listeners can run
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        plugin.disable();
+
+        // Assert
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(HTTP_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).not.toMatchObject({
+            trace_id: '1-0-000000000000000000000000',
+            segment_id: '0000000000000000'
+        });
+    });
 });


### PR DESCRIPTION
There is currently no direct link between HTTP requests and their respective X-Ray traces. This makes it difficult to find the correct X-Ray trace when debugging client-side issues related to HTTP requests.

This change adds the trace Id and segment Id to http request events when tracing is enabled.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
