### PR TITLE
fix: Avoid overwriting existing trace header

### DIFF
--- a/src/plugins/utils/__tests__/http-utils.test.ts
+++ b/src/plugins/utils/__tests__/http-utils.test.ts
@@ -1,0 +1,53 @@
+import { X_AMZN_TRACE_ID, getTraceHeader } from '../http-utils';
+
+const Request = function (input: RequestInfo, init?: RequestInit) {
+    if (typeof input === 'string') {
+        this.url = input;
+        this.method = 'GET';
+        this.headers = new Headers();
+    } else {
+        this.url = input.url;
+        this.method = input.method ? input.method : 'GET';
+        this.headers = input.headers ? input.headers : new Headers();
+    }
+    if (init) {
+        this.method = init.method ? init.method : this.method;
+        if (
+            this.headers &&
+            typeof (init.headers as Headers).get === 'function'
+        ) {
+            this.headers = init.headers;
+        } else if (this.headers) {
+            this.headers = new Headers(init.headers as Record<string, string>);
+        }
+    }
+};
+
+describe('http-utils', () => {
+    test('when request header contains trace header then return traceId and segmentId', async () => {
+        const existingTraceId = '1-0-000000000000000000000001';
+        const existingSegmentId = '0000000000000001';
+        const existingTraceHeaderValue = `Root=${existingTraceId};Parent=${existingSegmentId};Sampled=1`;
+
+        const init: RequestInit = {
+            headers: {
+                [X_AMZN_TRACE_ID]: existingTraceHeaderValue
+            }
+        };
+        const request: Request = new Request('https://aws.amazon.com', init);
+
+        const traceHeader = getTraceHeader(request.headers);
+
+        expect(traceHeader.traceId).toEqual(existingTraceId);
+        expect(traceHeader.segmentId).toEqual(existingSegmentId);
+    });
+
+    test('when request header does not contain trace header then returned traceId and segmentId are undefined', async () => {
+        const request: Request = new Request('https://aws.amazon.com');
+
+        const traceHeader = getTraceHeader(request.headers);
+
+        expect(traceHeader.traceId).toEqual(undefined);
+        expect(traceHeader.segmentId).toEqual(undefined);
+    });
+});

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -39,6 +39,11 @@ export type HttpPluginConfig = {
     addXRayTraceIdHeader: boolean;
 };
 
+export type TraceHeader = {
+    traceId?: string;
+    segmentId?: string;
+};
+
 export const defaultConfig: HttpPluginConfig = {
     logicalServiceName: 'rum.aws.amazon.com',
     urlsToInclude: [/.*/],
@@ -181,6 +186,18 @@ export const getAmznTraceIdHeaderValue = (
     return 'Root=' + traceId + ';Parent=' + segmentId + ';Sampled=1';
 };
 
+export const getTraceHeader = (headers: Headers) => {
+    const traceHeader: TraceHeader = {};
+
+    if (headers) {
+        const headerComponents = headers.get(X_AMZN_TRACE_ID)?.split(';');
+        if (headerComponents?.length === 3) {
+            traceHeader.traceId = headerComponents[0].split('Root=')[1];
+            traceHeader.segmentId = headerComponents[1].split('Parent=')[1];
+        }
+    }
+    return traceHeader;
+};
 /**
  * Extracts an URL string from the fetch resource parameter.
  */


### PR DESCRIPTION
When a CW Synthetics canary has `ActiveTracing` enabled and generates activity on a web application monitored by a CW RUM app monitor that also has `ActiveTracing` enabled, users experience a broken X-Ray trace experience where the segment from the canary to the web application is disconnected from the downstream segments. This is because the RUM Web Client overwrites the X-Ray trace header in the HTTP requests with a new trace while the RUM DataPlane drops activity generated by CW Synthetics canaries (and thus the trace is never created/sent to X-Ray for ingestion). 

This PR will update the Web Client tracing behavior to (1) not trace HTTP requests if the activity is generated by a CW Synthetics canary and (2) not overwrite existing trace headers.

Unit tests should be enough to cover this change, so no integrations were written.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
