### PR TITLE
feat: getResourceType() uses initiatorType when file extension missing

### DIFF
--- a/src/plugins/event-plugins/ResourcePlugin.ts
+++ b/src/plugins/event-plugins/ResourcePlugin.ts
@@ -1,9 +1,5 @@
 import { InternalPlugin } from '../InternalPlugin';
-import {
-    getResourceFileType,
-    ResourceType,
-    shuffle
-} from '../../utils/common-utils';
+import { getResourceFileType, shuffle } from '../../utils/common-utils';
 import { ResourceEvent } from '../../events/resource-event';
 import { PERFORMANCE_RESOURCE_EVENT_TYPE } from '../utils/constant';
 import {
@@ -63,7 +59,9 @@ export class ResourcePlugin extends InternalPlugin {
         list.filter((e) => e.entryType === RESOURCE)
             .filter((e) => !this.config.ignore(e))
             .forEach((event) => {
-                const type: ResourceType = getResourceFileType(event.name);
+                const { name, initiatorType } =
+                    event as PerformanceResourceTiming;
+                const type = getResourceFileType(name, initiatorType);
                 if (this.config.recordAllTypes.includes(type)) {
                     recordAll.push(event);
                 } else if (this.config.sampleTypes.includes(type)) {
@@ -84,10 +82,15 @@ export class ResourcePlugin extends InternalPlugin {
         }
     };
 
-    recordResourceEvent = (entryData: PerformanceResourceTiming): void => {
+    recordResourceEvent = ({
+        name,
+        initiatorType,
+        duration,
+        transferSize
+    }: PerformanceResourceTiming): void => {
         const pathRegex =
             /.*\/application\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/events/;
-        const entryUrl = new URL(entryData.name);
+        const entryUrl = new URL(name);
         if (
             entryUrl.host === this.context.config.endpointUrl.host &&
             pathRegex.test(entryUrl.pathname)
@@ -101,13 +104,13 @@ export class ResourcePlugin extends InternalPlugin {
         if (this.context?.record) {
             const eventData: ResourceEvent = {
                 version: '1.0.0',
-                initiatorType: entryData.initiatorType,
-                duration: entryData.duration,
-                fileType: getResourceFileType(entryData.name),
-                transferSize: entryData.transferSize
+                initiatorType,
+                duration,
+                fileType: getResourceFileType(name, initiatorType),
+                transferSize
             };
             if (this.context.config.recordResourceUrl) {
-                eventData.targetUrl = entryData.name;
+                eventData.targetUrl = name;
             }
             this.context.record(PERFORMANCE_RESOURCE_EVENT_TYPE, eventData);
         }

--- a/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
@@ -1,5 +1,5 @@
 import {
-    resourceEvent,
+    resourceTiming,
     putRumEventsDocument,
     putRumEventsGammaDocument,
     dataPlaneDocument,
@@ -27,7 +27,7 @@ const buildResourcePlugin = (config?: PartialPerformancePluginConfig) => {
 
 describe('ResourcePlugin tests', () => {
     beforeEach(() => {
-        doMockPerformanceObserver([navigationEvent, resourceEvent]);
+        doMockPerformanceObserver([navigationEvent, resourceTiming]);
         record.mockClear();
     });
 
@@ -50,11 +50,12 @@ describe('ResourcePlugin tests', () => {
         );
         expect(record.mock.calls[0][1]).toEqual(
             expect.objectContaining({
-                fileType: resourceEvent.fileType,
-                duration: resourceEvent.duration,
-                transferSize: resourceEvent.transferSize,
-                targetUrl: resourceEvent.name,
-                initiatorType: resourceEvent.initiatorType
+                version: '1.0.0',
+                fileType: 'script',
+                duration: resourceTiming.duration,
+                transferSize: resourceTiming.transferSize,
+                targetUrl: resourceTiming.name,
+                initiatorType: resourceTiming.initiatorType
             })
         );
     });

--- a/src/test-utils/mock-data.ts
+++ b/src/test-utils/mock-data.ts
@@ -85,7 +85,7 @@ export const navigationEventNotLoaded = {
     navigationTimingLevel: 2
 };
 
-export const resourceEvent = {
+export const resourceTiming: PerformanceResourceTiming = {
     connectEnd: 0,
     connectStart: 0,
     decodedBodySize: 0,
@@ -108,7 +108,7 @@ export const resourceEvent = {
     startTime: 357.59500000131084,
     transferSize: 0,
     workerStart: 0,
-    fileType: 'other'
+    toJSON: function () {} // eslint-disable-line
 };
 
 export const resourceEvent2 = {
@@ -335,7 +335,7 @@ export class MockPerformanceObserver {
     }
 
     observe(options: ObserveInterface): void {
-        this.cb({ getEntries: () => [navigationEvent, resourceEvent] });
+        this.cb({ getEntries: () => [navigationEvent, resourceTiming] });
     }
 
     disconnect(): void {

--- a/src/utils/__tests__/common-utils.test.ts
+++ b/src/utils/__tests__/common-utils.test.ts
@@ -60,4 +60,49 @@ describe('Common utils tests', () => {
             utils.ResourceType.FONT
         );
     });
+
+    test('when resource is image but file extension is no match, then initiatorType resolves to image', async () => {
+        // Init
+        const resourceUrl = 'example.com';
+        // Assert
+        expect(
+            utils.getResourceFileType(resourceUrl, utils.InitiatorType.IMG)
+        ).toEqual(utils.ResourceType.IMAGE);
+        expect(
+            utils.getResourceFileType(resourceUrl, utils.InitiatorType.IMAGE)
+        ).toEqual(utils.ResourceType.IMAGE);
+        expect(
+            utils.getResourceFileType(resourceUrl, utils.InitiatorType.INPUT)
+        ).toEqual(utils.ResourceType.IMAGE);
+    });
+
+    test('when resource is document but file extension is no match, then initiatorType resolves to document', async () => {
+        // Init
+        const resourceUrl = 'example.com';
+        // Assert
+        expect(
+            utils.getResourceFileType(resourceUrl, utils.InitiatorType.IFRAME)
+        ).toEqual(utils.ResourceType.DOCUMENT);
+        expect(
+            utils.getResourceFileType(resourceUrl, utils.InitiatorType.FRAME)
+        ).toEqual(utils.ResourceType.DOCUMENT);
+    });
+
+    test('when resource is script but file extension is no match, then initiatorType resolves to script', async () => {
+        // Init
+        const resourceUrl = 'example.com';
+        // Assert
+        expect(
+            utils.getResourceFileType(resourceUrl, utils.InitiatorType.SCRIPT)
+        ).toEqual(utils.ResourceType.SCRIPT);
+    });
+
+    test('when resource is stylesheet but file extension is no match, then initiatorType resolves to stylesheet', async () => {
+        // Init
+        const resourceUrl = 'example.com';
+        // Assert
+        expect(
+            utils.getResourceFileType(resourceUrl, utils.InitiatorType.CSS)
+        ).toEqual(utils.ResourceType.STYLESHEET);
+    });
 });

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -105,7 +105,7 @@ export const getResourceFileType = (
      * In these cases, they are mislablled as "other". In these cases, we can infer the correct
      * fileType from the initiator.
      */
-    if (ext === ResourceType.OTHER) {
+    if (initiatorType && ext === ResourceType.OTHER) {
         switch (initiatorType) {
             case InitiatorType.IMAGE:
             case InitiatorType.IMG:

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -7,6 +7,36 @@ export enum ResourceType {
     FONT = 'font'
 }
 
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/initiatorType
+ */
+export enum InitiatorType {
+    /**
+     * IMAGES
+     * PerformanceResourceTiming with initiatorType=Input must be an image
+     * Per MDN docs: "if the request was initiated by an <input> element of type image.""
+     */
+    IMG = 'img',
+    IMAGE = 'image',
+    INPUT = 'input',
+
+    /**
+     * DOCUMENTS
+     */
+    IFRAME = 'iframe',
+    FRAME = 'frame',
+
+    /**
+     * SCRIPTS
+     */
+    SCRIPT = 'script',
+
+    /**
+     * STYLESHEETS
+     */
+    CSS = 'css'
+}
+
 const extensions = [
     {
         name: ResourceType.STYLESHEET,
@@ -52,18 +82,48 @@ export const shuffle = (a: any[]) => {
     }
 };
 
-export const getResourceFileType = (url: string): ResourceType => {
-    const filename = url.substring(url.lastIndexOf('/') + 1);
-    const extension = filename
-        .substring(filename.lastIndexOf('.') + 1)
-        .split(/[?#]/)[0];
-
+export const getResourceFileType = (
+    url: string,
+    initiatorType?: string
+): ResourceType => {
     let ext = ResourceType.OTHER;
-    extensions.forEach((type) => {
-        if (type.list.indexOf(extension) > -1) {
-            ext = type.name;
+    if (url) {
+        const filename = url.substring(url.lastIndexOf('/') + 1);
+        const extension = filename
+            .substring(filename.lastIndexOf('.') + 1)
+            .split(/[?#]/)[0];
+
+        extensions.forEach((type) => {
+            if (type.list.indexOf(extension) > -1) {
+                ext = type.name;
+            }
+        });
+    }
+
+    /**
+     * Resource name sometimes does not have the correct file extension names due to redirects.
+     * In these cases, they are mislablled as "other". In these cases, we can infer the correct
+     * fileType from the initiator.
+     */
+    if (ext === ResourceType.OTHER) {
+        switch (initiatorType) {
+            case InitiatorType.IMAGE:
+            case InitiatorType.IMG:
+            case InitiatorType.INPUT:
+                ext = ResourceType.IMAGE;
+                break;
+            case InitiatorType.IFRAME:
+            case InitiatorType.FRAME:
+                ext = ResourceType.DOCUMENT;
+                break;
+            case InitiatorType.SCRIPT:
+                ext = ResourceType.SCRIPT;
+                break;
+            case InitiatorType.CSS:
+                ext = ResourceType.STYLESHEET;
+                break;
         }
-    });
+    }
     return ext;
 };
 


### PR DESCRIPTION
This is a follow up from an issue spotted in #450 and #448. See https://github.com/aws-observability/aws-rum-web/pull/450#discussion_r1330455383

The ResourcePlugin mislabels `fileType`. Currently, `fileType` maps to buckets of file extensions from `PerformanceResourceTiming.name` (e.g. ".jpg" and ".png" map to "image"). However, file extensions cannot be trusted to exist, such as during redirects. When extensions are missing, events are mislabelled as "other". 

I have considered two solutions:
1. Use [initiatorType](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/initiatorType) to infer fileType when file extension is missing. 
2. Remove the idea of "fileType" altogether and only use initiatorType. 

**My recommendation is (1), which this PR implements.** This is the least obtrusive method and we can always go to (2) later. If we were implementing this from scratch, I would instead recommend (2) because fileType is NOT a W3C schema found in the [PerformanceResourceTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming) schema. 

To help me review, please also read [initiatorType](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/initiatorType) documentation to see if I missed any mappings from `initiatorType` -> `fileType`. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
