### PR TITLE
fix: XhrPlugin cleans cache on every record

### DIFF
--- a/src/plugins/event-plugins/XhrPlugin.ts
+++ b/src/plugins/event-plugins/XhrPlugin.ts
@@ -95,13 +95,13 @@ export const XHR_PLUGIN_ID = 'xhr';
  */
 export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
     private config: HttpPluginConfig;
-    private xhrMap: Map<XMLHttpRequest, XhrDetails>;
+    private map: Map<XMLHttpRequest, XhrDetails>;
     private isSyntheticsUA: boolean;
 
     constructor(config?: PartialHttpPluginConfig) {
         super(XHR_PLUGIN_ID);
         this.config = { ...defaultConfig, ...config };
-        this.xhrMap = new Map<XMLHttpRequest, XhrDetails>();
+        this.map = new Map<XMLHttpRequest, XhrDetails>();
         this.isSyntheticsUA = navigator.userAgent.includes(
             'CloudWatchSynthetics'
         );
@@ -112,7 +112,7 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
     }
 
     get cacheSize() {
-        return this.xhrMap.size;
+        return this.map.size;
     }
 
     protected get patches() {
@@ -143,56 +143,56 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
     };
 
     private handleXhrLoadEvent = (e: Event) => {
-        const xhr: XMLHttpRequest = e.target as XMLHttpRequest;
-        const xhrDetails: XhrDetails = this.xhrMap.get(xhr) as XhrDetails;
-        if (xhrDetails) {
-            const endTimee = epochTime();
-            xhrDetails.trace!.end_time = endTimee;
-            xhrDetails.trace!.subsegments![0].end_time = endTimee;
-            xhrDetails.trace!.subsegments![0].http!.response = {
-                status: xhr.status
+        const request = e.target as XMLHttpRequest;
+        const details = this.map.get(request);
+        if (details) {
+            const endTime = epochTime();
+            details.trace!.end_time = endTime;
+            details.trace!.subsegments![0].end_time = endTime;
+            details.trace!.subsegments![0].http!.response = {
+                status: request.status
             };
 
-            if (is429(xhr.status)) {
-                xhrDetails.trace!.subsegments![0].throttle = true;
-                xhrDetails.trace!.throttle = true;
-            } else if (is4xx(xhr.status)) {
-                xhrDetails.trace!.subsegments![0].error = true;
-                xhrDetails.trace!.error = true;
-            } else if (is5xx(xhr.status)) {
-                xhrDetails.trace!.subsegments![0].fault = true;
-                xhrDetails.trace!.fault = true;
+            if (is429(request.status)) {
+                details.trace!.subsegments![0].throttle = true;
+                details.trace!.throttle = true;
+            } else if (is4xx(request.status)) {
+                details.trace!.subsegments![0].error = true;
+                details.trace!.error = true;
+            } else if (is5xx(request.status)) {
+                details.trace!.subsegments![0].fault = true;
+                details.trace!.fault = true;
             }
 
-            const clStr = xhr.getResponseHeader('Content-Length');
+            const clStr = request.getResponseHeader('Content-Length');
             const cl = clStr ? parseInt(clStr, 10) : NaN;
             if (!isNaN(cl)) {
-                xhrDetails.trace!.subsegments![0].http!.response.content_length =
+                details.trace!.subsegments![0].http!.response.content_length =
                     cl;
             }
-            this.recordTraceEvent(xhrDetails.trace!);
-            this.recordHttpEventWithResponse(xhrDetails, xhr);
+            this.recordTraceEvent(details.trace!);
+            this.recordHttpEventWithResponse(details, request);
         }
     };
 
     private handleXhrErrorEvent = (e: Event) => {
-        const xhr: XMLHttpRequest = e.target as XMLHttpRequest;
-        const xhrDetails = this.xhrMap.get(xhr);
+        const request = e.target as XMLHttpRequest;
+        const details = this.map.get(request);
         const errorName = 'XMLHttpRequest error';
-        const errorMessage: string = xhr.statusText
-            ? xhr.status.toString() + ': ' + xhr.statusText
-            : xhr.status.toString();
-        if (xhrDetails) {
+        const errorMessage: string = request.statusText
+            ? request.status.toString() + ': ' + request.statusText
+            : request.status.toString();
+        if (details) {
             const endTime = epochTime();
             // Guidance from X-Ray documentation:
             // > Record errors in segments when your application returns an
             // > error to the user, and in subsegments when a downstream call
             // > returns an error.
-            xhrDetails.trace!.fault = true;
-            xhrDetails.trace!.end_time = endTime;
-            xhrDetails.trace!.subsegments![0].end_time = endTime;
-            xhrDetails.trace!.subsegments![0].fault = true;
-            xhrDetails.trace!.subsegments![0].cause = {
+            details.trace!.fault = true;
+            details.trace!.end_time = endTime;
+            details.trace!.subsegments![0].end_time = endTime;
+            details.trace!.subsegments![0].fault = true;
+            details.trace!.subsegments![0].cause = {
                 exceptions: [
                     {
                         type: errorName,
@@ -200,53 +200,53 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
                     }
                 ]
             };
-            this.recordTraceEvent(xhrDetails.trace!);
+            this.recordTraceEvent(details.trace!);
             this.recordHttpEventWithError(
-                xhrDetails,
-                xhr,
+                details,
+                request,
                 new XhrError(errorMessage)
             );
         }
     };
 
     private handleXhrAbortEvent = (e: Event) => {
-        const xhr: XMLHttpRequest = e.target as XMLHttpRequest;
-        const xhrDetails = this.xhrMap.get(xhr);
-        if (xhrDetails) {
+        const request = e.target as XMLHttpRequest;
+        const details = this.map.get(request);
+        if (details) {
             this.handleXhrDetailsOnError(
-                xhrDetails,
-                xhr,
+                details,
+                request,
                 'XMLHttpRequest abort'
             );
         }
     };
 
     private handleXhrTimeoutEvent = (e: Event) => {
-        const xhr: XMLHttpRequest = e.target as XMLHttpRequest;
-        const xhrDetails = this.xhrMap.get(xhr);
+        const request = e.target as XMLHttpRequest;
+        const details = this.map.get(request);
         const errorName = 'XMLHttpRequest timeout';
-        this.handleXhrDetailsOnError(xhrDetails, xhr, errorName);
+        this.handleXhrDetailsOnError(details, request, errorName);
     };
 
     private handleXhrDetailsOnError(
-        xhrDetails: XhrDetails | undefined,
-        xhr: XMLHttpRequest,
+        details: XhrDetails | undefined,
+        request: XMLHttpRequest,
         errorName: string
     ) {
-        if (xhrDetails) {
+        if (details) {
             const endTime = epochTime();
-            xhrDetails.trace!.end_time = endTime;
-            xhrDetails.trace!.subsegments![0].end_time = endTime;
-            xhrDetails.trace!.subsegments![0].error = true;
-            xhrDetails.trace!.subsegments![0].cause = {
+            details.trace!.end_time = endTime;
+            details.trace!.subsegments![0].end_time = endTime;
+            details.trace!.subsegments![0].error = true;
+            details.trace!.subsegments![0].cause = {
                 exceptions: [
                     {
                         type: errorName
                     }
                 ]
             };
-            this.recordTraceEvent(xhrDetails.trace!);
-            this.recordHttpEventWithError(xhrDetails, xhr, errorName);
+            this.recordTraceEvent(details.trace!);
+            this.recordHttpEventWithError(details, request, errorName);
         }
     }
 
@@ -255,33 +255,36 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
     }
 
     private recordHttpEventWithResponse(
-        xhrDetails: XhrDetails,
-        xhr: XMLHttpRequest
+        details: XhrDetails,
+        request: XMLHttpRequest
     ) {
-        this.xhrMap.delete(xhr);
+        this.map.delete(request);
         const httpEvent: HttpEvent = {
             version: '1.0.0',
-            request: { method: xhrDetails.method, url: xhrDetails.url },
-            response: { status: xhr.status, statusText: xhr.statusText }
+            request: { method: details.method, url: details.url },
+            response: {
+                status: request.status,
+                statusText: request.statusText
+            }
         };
         if (this.isTracingEnabled()) {
-            httpEvent.trace_id = xhrDetails.trace!.trace_id;
-            httpEvent.segment_id = xhrDetails.trace!.subsegments![0].id;
+            httpEvent.trace_id = details.trace!.trace_id;
+            httpEvent.segment_id = details.trace!.subsegments![0].id;
         }
-        if (this.config.recordAllRequests || !this.statusOk(xhr.status)) {
+        if (this.config.recordAllRequests || !this.statusOk(request.status)) {
             this.context.record(HTTP_EVENT_TYPE, httpEvent);
         }
     }
 
     private recordHttpEventWithError(
-        xhrDetails: XhrDetails,
-        xhr: XMLHttpRequest,
+        details: XhrDetails,
+        request: XMLHttpRequest,
         error: Error | string | number | boolean | undefined | null
     ) {
-        this.xhrMap.delete(xhr);
+        this.map.delete(request);
         const httpEvent: HttpEvent = {
             version: '1.0.0',
-            request: { method: xhrDetails.method, url: xhrDetails.url },
+            request: { method: details.method, url: details.url },
             error: errorEventToJsErrorEvent(
                 {
                     type: 'error',
@@ -291,8 +294,8 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
             )
         };
         if (this.isTracingEnabled()) {
-            httpEvent.trace_id = xhrDetails.trace!.trace_id;
-            httpEvent.segment_id = xhrDetails.trace!.subsegments![0].id;
+            httpEvent.trace_id = details.trace!.trace_id;
+            httpEvent.segment_id = details.trace!.subsegments![0].id;
         }
         this.context.record(HTTP_EVENT_TYPE, httpEvent);
     }
@@ -307,20 +310,20 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
         }
     }
 
-    private initializeTrace = (xhrDetails: XhrDetails) => {
+    private initializeTrace = (details: XhrDetails) => {
         const startTime = epochTime();
-        xhrDetails.trace = createXRayTraceEvent(
+        details.trace = createXRayTraceEvent(
             this.config.logicalServiceName,
             startTime
         );
-        xhrDetails.trace.subsegments!.push(
+        details.trace.subsegments!.push(
             createXRaySubsegment(
-                requestInfoToHostname(xhrDetails.url),
+                requestInfoToHostname(details.url),
                 startTime,
                 {
                     request: {
-                        method: xhrDetails.method,
-                        url: xhrDetails.url,
+                        method: details.method,
+                        url: details.url,
                         traced: true
                     }
                 }
@@ -332,8 +335,8 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
         const self = this;
         return (original: any) => {
             return function (this: XMLHttpRequest): void {
-                const xhrDetails = self.xhrMap.get(this);
-                if (xhrDetails) {
+                const details = self.map.get(this);
+                if (details) {
                     this.addEventListener('load', self.handleXhrLoadEvent);
                     this.addEventListener('error', self.handleXhrErrorEvent);
                     this.addEventListener('abort', self.handleXhrAbortEvent);
@@ -342,7 +345,7 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
                         self.handleXhrTimeoutEvent
                     );
 
-                    self.initializeTrace(xhrDetails);
+                    self.initializeTrace(details);
 
                     if (
                         !self.isSyntheticsUA &&
@@ -353,8 +356,8 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
                         this.setRequestHeader(
                             X_AMZN_TRACE_ID,
                             getAmznTraceIdHeaderValue(
-                                xhrDetails.trace!.trace_id,
-                                xhrDetails.trace!.subsegments![0].id
+                                details.trace!.trace_id,
+                                details.trace!.subsegments![0].id
                             )
                         );
                     }
@@ -374,7 +377,7 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
                 async: boolean
             ): void {
                 if (isUrlAllowed(url, self.config)) {
-                    self.xhrMap.set(this, { url, method, async });
+                    self.map.set(this, { url, method, async });
                 }
                 return original.apply(this, arguments);
             };

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -65,6 +65,7 @@ describe('XhrPlugin tests', () => {
                 statusText: 'OK'
             }
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when XHR is called then the plugin records a trace', async () => {
@@ -119,6 +120,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when plugin is disabled then the plugin does not record any events', async () => {
@@ -146,6 +148,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when plugin is re-enabled then the plugin records a trace', async () => {
@@ -175,6 +178,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when XHR returns an error code then the plugin adds the error to the trace', async () => {
@@ -235,6 +239,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when XHR returns an error code then the plugin adds the error to the http event', async () => {
@@ -273,6 +278,7 @@ describe('XhrPlugin tests', () => {
                 message: '0'
             }
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when XHR times out then the plugin adds the error to the trace', async () => {
@@ -320,6 +326,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when XHR times out then the plugin adds the error to the http event', async () => {
@@ -357,6 +364,7 @@ describe('XhrPlugin tests', () => {
                 type: 'XMLHttpRequest timeout'
             }
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when XHR aborts then the plugin adds the error to the trace', async () => {
@@ -406,6 +414,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when XHR aborts then the plugin adds the error to the http event', async () => {
@@ -444,6 +453,7 @@ describe('XhrPlugin tests', () => {
                 type: 'XMLHttpRequest abort'
             }
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when default config is used then X-Amzn-Trace-Id header is not to the HTTP request', async () => {
@@ -474,6 +484,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(header).toEqual(null);
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('X-Amzn-Trace-Id header is added to the HTTP request', async () => {
@@ -506,6 +517,7 @@ describe('XhrPlugin tests', () => {
         expect(header).toEqual(
             'Root=1-0-000000000000000000000000;Parent=0000000000000000;Sampled=1'
         );
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when trace is disabled then the plugin does not record a trace', async () => {
@@ -533,6 +545,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when session is not being recorded then the plugin does not record a trace', async () => {
@@ -569,6 +582,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when getSession returns undefined then the plugin does not record a trace', async () => {
@@ -600,6 +614,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when recordAllRequests is false then the plugin does record a request with status OK', async () => {
@@ -628,6 +643,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when recordAllRequests is false then the plugin does not record a request with status OK', async () => {
@@ -656,6 +672,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when recordAllRequests is false then the plugin records a request with status 500', async () => {
@@ -685,6 +702,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when a url is excluded then the plugin does not record a request to that url', async () => {
@@ -713,6 +731,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('all urls are included by default', async () => {
@@ -740,6 +759,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when a request is made to cognito or sts using default exclude list then the requests are not recorded', async () => {
@@ -775,6 +795,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when a url is relative then the subsegment name is location.hostname', async () => {
@@ -806,6 +827,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when the plugin records a trace then the trace id is added to the http event', async () => {
@@ -841,6 +863,7 @@ describe('XhrPlugin tests', () => {
             trace_id: '1-0-000000000000000000000000',
             segment_id: '0000000000000000'
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when XHR aborts with tracing then the trace id is added to the http event', async () => {
@@ -875,6 +898,7 @@ describe('XhrPlugin tests', () => {
             trace_id: '1-0-000000000000000000000000',
             segment_id: '0000000000000000'
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when the plugin does not record a trace then the trace id is not added to the http event', async () => {
@@ -910,6 +934,7 @@ describe('XhrPlugin tests', () => {
             trace_id: '1-0-000000000000000000000000',
             segment_id: '0000000000000000'
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when user agent is CW Synthetics then plugin does not record a trace', async () => {
@@ -951,6 +976,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
+        expect(plugin.cacheSize).toEqual(0);
     });
 
     test('when user agent is CW Synthetics then the plugin records the http request/response', async () => {
@@ -1004,5 +1030,6 @@ describe('XhrPlugin tests', () => {
                 statusText: 'OK'
             }
         });
+        expect(plugin.cacheSize).toEqual(0);
     });
 });


### PR DESCRIPTION
closes #452 

XhrPlugin is leaking memory because the internal map is never cleaned. This is causing the web client to be unusable for customers with a high volume of xhr requests. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
