### PR TITLE
chore: restore XhrPlugin var names

### DIFF
--- a/src/plugins/event-plugins/XhrPlugin.ts
+++ b/src/plugins/event-plugins/XhrPlugin.ts
@@ -111,10 +111,6 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
         this.enable();
     }
 
-    get cacheSize() {
-        return this.xhrMap.size;
-    }
-
     protected get patches() {
         return [
             {

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -65,7 +65,7 @@ describe('XhrPlugin tests', () => {
                 statusText: 'OK'
             }
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when XHR is called then the plugin records a trace', async () => {
@@ -120,7 +120,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when plugin is disabled then the plugin does not record any events', async () => {
@@ -148,7 +148,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when plugin is re-enabled then the plugin records a trace', async () => {
@@ -178,7 +178,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when XHR returns an error code then the plugin adds the error to the trace', async () => {
@@ -239,7 +239,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when XHR returns an error code then the plugin adds the error to the http event', async () => {
@@ -278,7 +278,7 @@ describe('XhrPlugin tests', () => {
                 message: '0'
             }
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when XHR times out then the plugin adds the error to the trace', async () => {
@@ -326,7 +326,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when XHR times out then the plugin adds the error to the http event', async () => {
@@ -364,7 +364,7 @@ describe('XhrPlugin tests', () => {
                 type: 'XMLHttpRequest timeout'
             }
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when XHR aborts then the plugin adds the error to the trace', async () => {
@@ -414,7 +414,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when XHR aborts then the plugin adds the error to the http event', async () => {
@@ -453,7 +453,7 @@ describe('XhrPlugin tests', () => {
                 type: 'XMLHttpRequest abort'
             }
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when default config is used then X-Amzn-Trace-Id header is not to the HTTP request', async () => {
@@ -484,7 +484,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(header).toEqual(null);
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('X-Amzn-Trace-Id header is added to the HTTP request', async () => {
@@ -517,7 +517,7 @@ describe('XhrPlugin tests', () => {
         expect(header).toEqual(
             'Root=1-0-000000000000000000000000;Parent=0000000000000000;Sampled=1'
         );
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when trace is disabled then the plugin does not record a trace', async () => {
@@ -545,7 +545,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when session is not being recorded then the plugin does not record a trace', async () => {
@@ -582,7 +582,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when getSession returns undefined then the plugin does not record a trace', async () => {
@@ -614,7 +614,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalledTimes(1);
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when recordAllRequests is false then the plugin does record a request with status OK', async () => {
@@ -643,7 +643,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when recordAllRequests is false then the plugin does not record a request with status OK', async () => {
@@ -672,7 +672,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when recordAllRequests is false then the plugin records a request with status 500', async () => {
@@ -702,7 +702,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when a url is excluded then the plugin does not record a request to that url', async () => {
@@ -731,7 +731,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('all urls are included by default', async () => {
@@ -759,7 +759,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when a request is made to cognito or sts using default exclude list then the requests are not recorded', async () => {
@@ -795,7 +795,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when a url is relative then the subsegment name is location.hostname', async () => {
@@ -827,7 +827,7 @@ describe('XhrPlugin tests', () => {
                 }
             ]
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when the plugin records a trace then the trace id is added to the http event', async () => {
@@ -863,7 +863,7 @@ describe('XhrPlugin tests', () => {
             trace_id: '1-0-000000000000000000000000',
             segment_id: '0000000000000000'
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when XHR aborts with tracing then the trace id is added to the http event', async () => {
@@ -898,7 +898,7 @@ describe('XhrPlugin tests', () => {
             trace_id: '1-0-000000000000000000000000',
             segment_id: '0000000000000000'
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when the plugin does not record a trace then the trace id is not added to the http event', async () => {
@@ -934,7 +934,7 @@ describe('XhrPlugin tests', () => {
             trace_id: '1-0-000000000000000000000000',
             segment_id: '0000000000000000'
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when user agent is CW Synthetics then plugin does not record a trace', async () => {
@@ -976,7 +976,7 @@ describe('XhrPlugin tests', () => {
 
         // Assert
         expect(record).not.toHaveBeenCalled();
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 
     test('when user agent is CW Synthetics then the plugin records the http request/response', async () => {
@@ -1030,6 +1030,6 @@ describe('XhrPlugin tests', () => {
                 statusText: 'OK'
             }
         });
-        expect(plugin.cacheSize).toEqual(0);
+        expect((plugin as any).xhrMap.size).toEqual(0);
     });
 });


### PR DESCRIPTION
Follow up to https://github.com/aws-observability/aws-rum-web/pull/454#discussion_r1335028410

1. Restores XhrPlugin names, as requested
2. Remove cacheSize() getter, which was only used for testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
