### PR TITLE
fix: Remove unnecessary TTIPlugin import

### DIFF
--- a/src/plugins/event-plugins/TTIPlugin.ts
+++ b/src/plugins/event-plugins/TTIPlugin.ts
@@ -1,7 +1,6 @@
 import { TTIMetric, onTTI } from '../../time-to-interactive/TimeToInteractive';
 import { TimeToInteractiveEvent } from '../../events/time-to-interactive-event';
 import { TIME_TO_INTERACTIVE_EVENT_TYPE } from '../utils/constant';
-import { PluginContext } from './../types';
 import { InternalPlugin } from '../InternalPlugin';
 
 export const TTI_EVENT_PLUGIN_ID = 'time-to-interactive';
@@ -13,8 +12,6 @@ export class TTIPlugin extends InternalPlugin {
         super(TTI_EVENT_PLUGIN_ID);
         this.fpsEnabled = fpsMeasurementEnabled;
     }
-
-    protected context!: PluginContext;
 
     enable(): void {
         /* Nothing to do. */

--- a/src/plugins/event-plugins/TTIPlugin.ts
+++ b/src/plugins/event-plugins/TTIPlugin.ts
@@ -1,7 +1,7 @@
 import { TTIMetric, onTTI } from '../../time-to-interactive/TimeToInteractive';
 import { TimeToInteractiveEvent } from '../../events/time-to-interactive-event';
 import { TIME_TO_INTERACTIVE_EVENT_TYPE } from '../utils/constant';
-import { PluginContext } from 'plugins/types';
+import { PluginContext } from './../types';
 import { InternalPlugin } from '../InternalPlugin';
 
 export const TTI_EVENT_PLUGIN_ID = 'time-to-interactive';


### PR DESCRIPTION
An import in the newly released TTI plugin uses an absolute import. This appears to be causing [issues](https://github.com/aws-observability/aws-rum-web/issues/474) with a users' tests. 


This change removes the import entirely as it is unnecessary. 


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
