### PR TITLE
chore: replace deprecated Credentials with AwsCredentialIdentity

### DIFF
--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { HttpHandler, HttpRequest } from '@aws-sdk/protocol-http';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { responseToJson } from './utils';
 import { IDENTITY_KEY } from '../utils/constants';
 
@@ -123,7 +123,7 @@ export class CognitoIdentityClient {
 
     public getCredentialsForIdentity = async (
         identityId: string
-    ): Promise<Credentials> => {
+    ): Promise<AwsCredentialIdentity> => {
         try {
             const requestPayload = JSON.stringify({ IdentityId: identityId });
             const credentialRequest = this.getHttpRequest(

--- a/src/dispatch/StsClient.ts
+++ b/src/dispatch/StsClient.ts
@@ -1,6 +1,6 @@
 import { HttpHandler, HttpRequest } from '@aws-sdk/protocol-http';
 import { CognitoIdentityClientConfig } from './CognitoIdentityClient';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { responseToString } from './utils';
 
 const METHOD = 'POST';
@@ -26,7 +26,7 @@ export class StsClient {
 
     public assumeRoleWithWebIdentity = async (
         request: STSSendRequest
-    ): Promise<Credentials> => {
+    ): Promise<AwsCredentialIdentity> => {
         try {
             const requestObject = {
                 ...request,
@@ -65,7 +65,7 @@ export class StsClient {
                         .split('<Expiration>')[1]
                         .split('</Expiration>')[0]
                 )
-            } as Credentials;
+            } as AwsCredentialIdentity;
         } catch (e) {
             throw new Error(
                 `CWR: Failed to retrieve credentials from STS: ${e}`

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -2,7 +2,7 @@ import * as Utils from '../../test-utils/test-utils';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { advanceTo } from 'jest-date-mock';
 import { CognitoIdentityClient } from '../CognitoIdentityClient';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { getReadableStream } from '../../test-utils/test-utils';
 import { IDENTITY_KEY } from '../../utils/constants';
 
@@ -47,9 +47,8 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Run
-        const creds: Credentials = await client.getCredentialsForIdentity(
-            'my-fake-identity-id'
-        );
+        const creds: AwsCredentialIdentity =
+            await client.getCredentialsForIdentity('my-fake-identity-id');
 
         // Assert
         expect(fetchHandler).toHaveBeenCalledTimes(1);

--- a/src/dispatch/__tests__/StsClient.test.ts
+++ b/src/dispatch/__tests__/StsClient.test.ts
@@ -1,5 +1,5 @@
 import * as Utils from '../../test-utils/test-utils';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { advanceTo } from 'jest-date-mock';
 import { getReadableStream } from '../../test-utils/test-utils';
@@ -43,11 +43,12 @@ describe('StsClient tests', () => {
         });
 
         // Run
-        const creds: Credentials = await client.assumeRoleWithWebIdentity({
-            RoleArn: 'mock-role-arn',
-            RoleSessionName: 'mock-session-name',
-            WebIdentityToken: 'mock-web-identity-token'
-        });
+        const creds: AwsCredentialIdentity =
+            await client.assumeRoleWithWebIdentity({
+                RoleArn: 'mock-role-arn',
+                RoleSessionName: 'mock-session-name',
+                WebIdentityToken: 'mock-web-identity-token'
+            });
 
         // Assert
         expect(fetchHandler).toHaveBeenCalledTimes(1);

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -1,5 +1,5 @@
 import { EventCache } from '../event-cache/EventCache';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import {
     Config,
     defaultConfig,
@@ -81,7 +81,7 @@ export const createDefaultEventCacheWithEvents = (): EventCache => {
     return eventCache;
 };
 
-export const createAwsCredentials = (): Credentials => {
+export const createAwsCredentials = (): AwsCredentialIdentity => {
     return {
         accessKeyId: 'abc123',
         secretAccessKey: 'abc123xyz'


### PR DESCRIPTION
Quick CR to replace the deprecated `Credentials` in @aws-sdk with the recommended `AwsCredentialIdentity`.

https://github.com/aws/aws-sdk-js-v3/blob/64c731e16dcfbbe0f56e1499828e8b16ad1a8c0e/packages/types/src/credentials.ts#L9

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
