### PR TITLE
chore: add check for package size regression

### DIFF
--- a/.github/workflows/package-size-report.yaml
+++ b/.github/workflows/package-size-report.yaml
@@ -1,0 +1,28 @@
+name: Package Size Report
+
+on:
+    pull_request:
+        types: [opened, ready_for_review]
+        branches: [main, release/*]
+
+permissions:
+    pull-requests: write
+
+jobs:
+    pkg-size-report:
+        name: Package Size Report
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: '18'
+
+            - name: Package size report
+              uses: pkg-size/action@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Analyzes the package size diff of every pull request, broken down by file. For example, https://github.com/williazz/aws-rum-web/pull/1#issuecomment-1743927215. Moving forward, this will help us keep aws-rum-web as small as possible.  

The GitHub Action depends on third party package https://github.com/pkg-size/action

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
