### PR TITLE
chore: reduce size of auth modules 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -237,7 +237,6 @@ module.exports = {
             }
         ],
         'use-isnan': 'error',
-        'valid-typeof': 'off',
-        '@typescript-eslint/unbound-method': 'off'
+        'valid-typeof': 'off'
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -237,6 +237,7 @@ module.exports = {
             }
         ],
         'use-isnan': 'error',
-        'valid-typeof': 'off'
+        'valid-typeof': 'off',
+        '@typescript-eslint/unbound-method': 'off'
     }
 };

--- a/src/CommandQueue.ts
+++ b/src/CommandQueue.ts
@@ -1,4 +1,7 @@
-import { CredentialProvider, Credentials } from '@aws-sdk/types';
+import {
+    AwsCredentialIdentity,
+    AwsCredentialIdentityProvider
+} from '@aws-sdk/types';
 import { Plugin } from 'plugins/Plugin';
 import { INSTALL_SCRIPT } from './utils/constants';
 import { PartialConfig, Orchestration } from './orchestration/Orchestration';
@@ -52,7 +55,7 @@ export class CommandQueue {
 
     private commandHandlerMap: CommandFunctions = {
         setAwsCredentials: (
-            payload: Credentials | CredentialProvider
+            payload: AwsCredentialIdentity | AwsCredentialIdentityProvider
         ): void => {
             this.orchestration.setAwsCredentials(payload);
         },

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -50,8 +50,8 @@ export abstract class Authentication {
     public ChainAnonymousCredentialsProvider =
         async (): Promise<AwsCredentialIdentity> => {
             return this.AnonymousCredentialsProvider()
-                .catch(this.AnonymousStorageCredentialsProvider) // eslint-disable-line @typescript-eslint/unbound-method
-                .catch(this.AnonymousCognitoCredentialsProvider); // eslint-disable-line @typescript-eslint/unbound-method
+                .catch(this.AnonymousStorageCredentialsProvider)
+                .catch(this.AnonymousCognitoCredentialsProvider);
         };
 
     /**
@@ -108,7 +108,7 @@ export abstract class Authentication {
      *
      * Implements AwsCredentialIdentityProvider = Provider<AwsCredentialIdentity>
      */
-    protected abstract AnonymousCognitoCredentialsProvider(): Promise<AwsCredentialIdentity>;
+    protected abstract AnonymousCognitoCredentialsProvider: () => Promise<AwsCredentialIdentity>;
 
     /**
      * Returns {@code true} when the credentials need to be renewed.

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -50,8 +50,8 @@ export abstract class Authentication {
     public ChainAnonymousCredentialsProvider =
         async (): Promise<AwsCredentialIdentity> => {
             return this.AnonymousCredentialsProvider()
-                .catch(this.AnonymousStorageCredentialsProvider)
-                .catch(this.AnonymousCognitoCredentialsProvider);
+                .catch(this.AnonymousStorageCredentialsProvider) // eslint-disable-line @typescript-eslint/unbound-method
+                .catch(this.AnonymousCognitoCredentialsProvider); // eslint-disable-line @typescript-eslint/unbound-method
         };
 
     /**

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -111,7 +111,7 @@ export abstract class Authentication {
     protected abstract AnonymousCognitoCredentialsProvider(): Promise<AwsCredentialIdentity>;
 
     /**
-     * Checks if credentials should be renewed
+     * Returns {@code true} when the credentials need to be renewed.
      */
     private renewCredentials(): boolean {
         if (!this.credentials || !this.credentials.expiration) {

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -82,7 +82,7 @@ export abstract class Authentication {
                 try {
                     credentials = JSON.parse(localStorage.getItem(CRED_KEY)!);
                 } catch (e) {
-                    // Error decoding or parsing the cookie -- abort
+                    // Error retrieving, decoding or parsing the cred string -- abort
                     return reject();
                 }
                 // The expiration property of Credentials has a date type. Because the date was serialized as a string,

--- a/src/dispatch/BasicAuthentication.ts
+++ b/src/dispatch/BasicAuthentication.ts
@@ -1,5 +1,5 @@
 import { Config } from '../orchestration/Orchestration';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { StsClient } from './StsClient';
 import { CRED_KEY } from '../utils/constants';
@@ -23,10 +23,10 @@ export class BasicAuthentication extends Authentication {
      *
      * See https://docs.aws.amazon.com/cognito/latest/developerguide/authentication-flow.html
      *
-     * Implements CredentialsProvider = Provider<Credentials>
+     * Implements AwsCredentialIdentityProvider = Provider<AwsCredentialIdentity>
      */
     protected AnonymousCognitoCredentialsProvider =
-        async (): Promise<Credentials> => {
+        async (): Promise<AwsCredentialIdentity> => {
             return this.cognitoIdentityClient
                 .getId({
                     IdentityPoolId: this.config.identityPoolId as string
@@ -41,7 +41,7 @@ export class BasicAuthentication extends Authentication {
                         WebIdentityToken: getOpenIdTokenResponse.Token
                     })
                 )
-                .then((credentials: Credentials) => {
+                .then((credentials: AwsCredentialIdentity) => {
                     this.credentials = credentials;
                     try {
                         localStorage.setItem(

--- a/src/dispatch/BasicAuthentication.ts
+++ b/src/dispatch/BasicAuthentication.ts
@@ -51,7 +51,6 @@ export class BasicAuthentication extends Authentication {
                     } catch (e) {
                         // Ignore
                     }
-
                     return credentials;
                 });
         };

--- a/src/dispatch/BasicAuthentication.ts
+++ b/src/dispatch/BasicAuthentication.ts
@@ -1,0 +1,58 @@
+import { Config } from '../orchestration/Orchestration';
+import { Credentials } from '@aws-sdk/types';
+import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
+import { StsClient } from './StsClient';
+import { CRED_KEY } from '../utils/constants';
+import { Authentication } from './Authentication';
+
+export class BasicAuthentication extends Authentication {
+    private stsClient: StsClient;
+
+    constructor(config: Config) {
+        super(config);
+        const region: string = config.identityPoolId!.split(':')[0];
+        this.stsClient = new StsClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region
+        });
+    }
+
+    /**
+     * Provides credentials for an anonymous (guest) user. These credentials are retrieved from Cognito's basic
+     * (classic) authflow.
+     *
+     * See https://docs.aws.amazon.com/cognito/latest/developerguide/authentication-flow.html
+     *
+     * Implements CredentialsProvider = Provider<Credentials>
+     */
+    protected AnonymousCognitoCredentialsProvider =
+        async (): Promise<Credentials> => {
+            return this.cognitoIdentityClient
+                .getId({
+                    IdentityPoolId: this.config.identityPoolId as string
+                })
+                .then((getIdResponse) =>
+                    this.cognitoIdentityClient.getOpenIdToken(getIdResponse)
+                )
+                .then((getOpenIdTokenResponse) =>
+                    this.stsClient.assumeRoleWithWebIdentity({
+                        RoleArn: this.config.guestRoleArn as string,
+                        RoleSessionName: 'cwr',
+                        WebIdentityToken: getOpenIdTokenResponse.Token
+                    })
+                )
+                .then((credentials: Credentials) => {
+                    this.credentials = credentials;
+                    try {
+                        localStorage.setItem(
+                            CRED_KEY,
+                            JSON.stringify(credentials)
+                        );
+                    } catch (e) {
+                        // Ignore
+                    }
+
+                    return credentials;
+                });
+        };
+}

--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { HttpHandler, HttpRequest } from '@aws-sdk/protocol-http';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { responseToJson } from './utils';
 import { IDENTITY_KEY } from '../utils/constants';
 
@@ -110,7 +110,7 @@ export class CognitoIdentityClient {
 
     public getCredentialsForIdentity = async (
         identityId: string
-    ): Promise<Credentials> => {
+    ): Promise<AwsCredentialIdentity> => {
         try {
             const requestPayload = JSON.stringify({ IdentityId: identityId });
             const credentialRequest = this.getHttpRequest(

--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -14,19 +14,6 @@ const GET_TOKEN_TARGET = 'AWSCognitoIdentityService.GetOpenIdToken';
 const GET_CREDENTIALS_TARGET =
     'AWSCognitoIdentityService.GetCredentialsForIdentity';
 
-interface CognitoProviderParameters {
-    /**
-     * The unique identifier for the identity pool from which an identity should
-     * be retrieved or generated.
-     */
-    identityPoolId: string;
-    /**
-     * The SDK client with which the credential provider will contact the Amazon
-     * Cognito service.
-     */
-    client: CognitoIdentityClient;
-}
-
 interface CognitoCredentials {
     AccessKeyId: string;
     Expiration: number;

--- a/src/dispatch/Dispatch.ts
+++ b/src/dispatch/Dispatch.ts
@@ -1,4 +1,8 @@
-import { CredentialProvider, Credentials, HttpResponse } from '@aws-sdk/types';
+import {
+    AwsCredentialIdentityProvider,
+    AwsCredentialIdentity,
+    HttpResponse
+} from '@aws-sdk/types';
 import { EventCache } from '../event-cache/EventCache';
 import { DataPlaneClient } from './DataPlaneClient';
 import { BeaconHttpHandler } from './BeaconHttpHandler';
@@ -22,7 +26,7 @@ const NO_CRED_MSG = 'CWR: Cannot dispatch; no AWS credentials.';
 export type ClientBuilder = (
     endpoint: URL,
     region: string,
-    credentials: CredentialProvider | Credentials | undefined
+    credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider
 ) => DataPlaneClient;
 
 export class Dispatch {
@@ -85,7 +89,9 @@ export class Dispatch {
      * @param credentials A set of AWS credentials from the application's authflow.
      */
     public setAwsCredentials(
-        credentialProvider: Credentials | CredentialProvider
+        credentialProvider:
+            | AwsCredentialIdentity
+            | AwsCredentialIdentityProvider
     ): void {
         this.rum = this.buildClient(
             this.endpoint,
@@ -95,7 +101,7 @@ export class Dispatch {
         if (typeof credentialProvider === 'function') {
             // In case a beacon in the first dispatch, we must pre-fetch credentials into a cookie so there is no delay
             // to fetch credentials while the page is closing.
-            (credentialProvider as () => Promise<Credentials>)();
+            (credentialProvider as () => Promise<AwsCredentialIdentity>)();
         }
     }
 

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -1,104 +1,12 @@
-import { CognitoIdentityClient } from './CognitoIdentityClient';
 import { Config } from '../orchestration/Orchestration';
 import { Credentials } from '@aws-sdk/types';
-import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
-import { CRED_KEY, CRED_RENEW_MS } from '../utils/constants';
+import { CRED_KEY } from '../utils/constants';
+import { Authentication } from './Authentication';
 
-export class EnhancedAuthentication {
-    protected cognitoIdentityClient: CognitoIdentityClient;
-    protected config: Config;
-    protected credentials: Credentials | undefined;
-
+export class EnhancedAuthentication extends Authentication {
     constructor(config: Config) {
-        const region: string = config.identityPoolId!.split(':')[0];
-        this.config = config;
-        this.cognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region
-        });
+        super(config);
     }
-
-    /**
-     * A credential provider which provides AWS credentials for an anonymous
-     * (guest) user. These credentials are retrieved from the first successful
-     * provider in a chain.
-     *
-     * Credentials are stored in and retrieved from localStorage. This prevents the client from having to
-     * re-authenticate every time the client loads, which (1) improves the performance of the RUM web client and (2)
-     * reduces the load on AWS services Cognito and STS.
-     *
-     * While storing credentials in localStorage puts the credential at greater risk of being leaked through an
-     * XSS attack, there is no impact if the credentials were to be leaked. This is because (1) the identity pool ID
-     * and role ARN are public and (2) the credentials are for an anonymous (guest) user.
-     *
-     * Regarding (1), the identity pool ID and role ARN are, by necessity, public. These identifiers are shipped with
-     * each application as part of Cognito's Basic (Classic) authentication flow. The identity pool ID and role ARN
-     * are not secret.
-     *
-     * Regarding (2), the authentication chain implemented in this file only supports anonymous (guest)
-     * authentication. When the Cognito authentication flow is executed, {@code AnonymousCognitoCredentialsProvider}
-     * does not communicate with a login provider such as Amazon, Facebook or Google. Instead, it relies on (a) the
-     * identity pool supporting unauthenticated identities and (b) the IAM role policy enabling login through the
-     * identity pool. If the identity pool does not support unauthenticated identities, this authentication chain
-     * will not succeed.
-     *
-     * Taken together, (1) and (2) mean that if these temporary credentials were to be leaked, the leaked credentials
-     * would not allow a bad actor to gain access to anything which they did not already have public access to.
-     *
-     * Implements CredentialsProvider = Provider<Credentials>
-     */
-    public ChainAnonymousCredentialsProvider =
-        async (): Promise<Credentials> => {
-            return this.AnonymousCredentialsProvider()
-                .catch(this.AnonymousStorageCredentialsProvider)
-                .catch(this.AnonymousCognitoCredentialsProvider);
-        };
-
-    /**
-     * Provides credentials for an anonymous (guest) user. These credentials are read from a member variable.
-     *
-     * Implements CredentialsProvider = Provider<Credentials>
-     */
-    private AnonymousCredentialsProvider = async (): Promise<Credentials> => {
-        return new Promise<Credentials>((resolve, reject) => {
-            if (this.renewCredentials()) {
-                // The credentials have expired.
-                return reject();
-            }
-            resolve(this.credentials!);
-        });
-    };
-
-    /**
-     * Provides credentials for an anonymous (guest) user. These credentials are read from localStorage.
-     *
-     * Implements CredentialsProvider = Provider<Credentials>
-     */
-    private AnonymousStorageCredentialsProvider =
-        async (): Promise<Credentials> => {
-            return new Promise<Credentials>((resolve, reject) => {
-                let credentials: Credentials;
-                try {
-                    credentials = JSON.parse(localStorage.getItem(CRED_KEY)!);
-                } catch (e) {
-                    // Error decoding or parsing the cookie -- abort
-                    return reject();
-                }
-                // The expiration property of Credentials has a date type. Because the date was serialized as a string,
-                // we need to convert it back into a date, otherwise the AWS SDK signing middleware
-                // (@aws-sdk/middleware-signing) will throw an exception and no credentials will be returned.
-                this.credentials = {
-                    ...credentials,
-                    expiration: new Date(credentials.expiration as Date)
-                };
-                if (this.renewCredentials()) {
-                    // The credentials have expired.
-                    return reject();
-                }
-                resolve(this.credentials);
-            });
-        };
-
     /**
      * Provides credentials for an anonymous (guest) user. These credentials are retrieved from Cognito's enhanced
      * authflow.
@@ -126,18 +34,7 @@ export class EnhancedAuthentication {
                     } catch (e) {
                         // Ignore
                     }
-
                     return credentials;
                 });
         };
-
-    private renewCredentials(): boolean {
-        if (!this.credentials || !this.credentials.expiration) {
-            return true;
-        }
-        const renewalTime: Date = new Date(
-            this.credentials.expiration.getTime() - CRED_RENEW_MS
-        );
-        return new Date() > renewalTime;
-    }
 }

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -5,9 +5,9 @@ import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { CRED_KEY, CRED_RENEW_MS } from '../utils/constants';
 
 export class EnhancedAuthentication {
-    private cognitoIdentityClient: CognitoIdentityClient;
-    private config: Config;
-    private credentials: Credentials | undefined;
+    protected cognitoIdentityClient: CognitoIdentityClient;
+    protected config: Config;
+    protected credentials: Credentials | undefined;
 
     constructor(config: Config) {
         const region: string = config.identityPoolId!.split(':')[0];
@@ -107,7 +107,7 @@ export class EnhancedAuthentication {
      *
      * Implements CredentialsProvider = Provider<Credentials>
      */
-    private AnonymousCognitoCredentialsProvider =
+    protected AnonymousCognitoCredentialsProvider =
         async (): Promise<Credentials> => {
             return this.cognitoIdentityClient
                 .getId({ IdentityPoolId: this.config.identityPoolId as string })

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -1,5 +1,5 @@
 import { Config } from '../orchestration/Orchestration';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { CRED_KEY } from '../utils/constants';
 import { Authentication } from './Authentication';
 
@@ -13,10 +13,10 @@ export class EnhancedAuthentication extends Authentication {
      *
      * See https://docs.aws.amazon.com/cognito/latest/developerguide/authentication-flow.html
      *
-     * Implements CredentialsProvider = Provider<Credentials>
+     * Implements AwsCredentialIdentityProvider = Provider<AwsCredentialIdentity>
      */
     protected AnonymousCognitoCredentialsProvider =
-        async (): Promise<Credentials> => {
+        async (): Promise<AwsCredentialIdentity> => {
             return this.cognitoIdentityClient
                 .getId({ IdentityPoolId: this.config.identityPoolId as string })
                 .then((getIdResponse) =>
@@ -24,7 +24,7 @@ export class EnhancedAuthentication extends Authentication {
                         getIdResponse.IdentityId
                     )
                 )
-                .then((credentials: Credentials) => {
+                .then((credentials: AwsCredentialIdentity) => {
                     this.credentials = credentials;
                     try {
                         localStorage.setItem(

--- a/src/dispatch/StsClient.ts
+++ b/src/dispatch/StsClient.ts
@@ -1,6 +1,6 @@
 import { HttpHandler, HttpRequest } from '@aws-sdk/protocol-http';
 import { CognitoIdentityClientConfig } from './CognitoIdentityClient';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { responseToString } from './utils';
 
 const METHOD = 'POST';
@@ -26,7 +26,7 @@ export class StsClient {
 
     public assumeRoleWithWebIdentity = async (
         request: STSSendRequest
-    ): Promise<Credentials> => {
+    ): Promise<AwsCredentialIdentity> => {
         try {
             const requestObject = {
                 ...request,
@@ -65,7 +65,7 @@ export class StsClient {
                         .split('<Expiration>')[1]
                         .split('</Expiration>')[0]
                 )
-            } as Credentials;
+            } as AwsCredentialIdentity;
         } catch (e) {
             throw new Error(
                 `CWR: Failed to retrieve credentials from STS: ${e}`

--- a/src/dispatch/__tests__/BasicAuthentication.test.ts
+++ b/src/dispatch/__tests__/BasicAuthentication.test.ts
@@ -1,4 +1,4 @@
-import { Authentication } from '../Authentication';
+import { BasicAuthentication } from '../BasicAuthentication';
 import { CRED_KEY } from '../../utils/constants';
 import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
 
@@ -22,7 +22,7 @@ jest.mock('../StsClient', () => ({
 const IDENTITY_POOL_ID = 'us-west-2:a-b-c-d';
 const GUEST_ROLE_ARN = 'arn:aws:iam::123:role/Unauth';
 
-describe('Authentication tests', () => {
+describe('BasicAuthentication tests', () => {
     beforeEach(() => {
         mockGetId.mockReset();
         mockGetIdToken.mockReset();
@@ -54,7 +54,7 @@ describe('Authentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new Authentication(config);
+        const auth = new BasicAuthentication(config);
 
         localStorage.setItem(
             CRED_KEY,
@@ -88,7 +88,7 @@ describe('Authentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new Authentication(config);
+        const auth = new BasicAuthentication(config);
 
         localStorage.setItem(CRED_KEY, 'corrupt');
 
@@ -107,7 +107,7 @@ describe('Authentication tests', () => {
 
     test('when credential is not in localStorage then authentication chain retrieves credential from basic authflow', async () => {
         // Init
-        const auth = new Authentication({
+        const auth = new BasicAuthentication({
             ...DEFAULT_CONFIG,
             ...{
                 identityPoolId: IDENTITY_POOL_ID,
@@ -139,7 +139,7 @@ describe('Authentication tests', () => {
             }
         };
 
-        const auth = new Authentication(config);
+        const auth = new BasicAuthentication(config);
 
         localStorage.setItem(
             CRED_KEY,
@@ -181,7 +181,7 @@ describe('Authentication tests', () => {
                 sessionToken: 'z'
             });
 
-        const auth = new Authentication({
+        const auth = new BasicAuthentication({
             ...DEFAULT_CONFIG,
             ...{
                 identityPoolId: IDENTITY_POOL_ID,
@@ -210,7 +210,7 @@ describe('Authentication tests', () => {
             throw e;
         });
         // Init
-        const auth = new Authentication({
+        const auth = new BasicAuthentication({
             ...DEFAULT_CONFIG,
             ...{
                 identityPoolId: IDENTITY_POOL_ID,
@@ -230,7 +230,7 @@ describe('Authentication tests', () => {
             throw e;
         });
         // Init
-        const auth = new Authentication({
+        const auth = new BasicAuthentication({
             ...DEFAULT_CONFIG,
             ...{
                 identityPoolId: IDENTITY_POOL_ID,
@@ -250,7 +250,7 @@ describe('Authentication tests', () => {
             throw e;
         });
         // Init
-        const auth = new Authentication({
+        const auth = new BasicAuthentication({
             ...DEFAULT_CONFIG,
             ...{
                 identityPoolId: IDENTITY_POOL_ID,
@@ -272,7 +272,7 @@ describe('Authentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new Authentication(config);
+        const auth = new BasicAuthentication(config);
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -321,7 +321,7 @@ describe('Authentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new Authentication(config);
+        const auth = new BasicAuthentication(config);
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -358,7 +358,7 @@ describe('Authentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new Authentication(config);
+        const auth = new BasicAuthentication(config);
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();
@@ -396,7 +396,7 @@ describe('Authentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new Authentication(config);
+        const auth = new BasicAuthentication(config);
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -2,7 +2,7 @@ import * as Utils from '../../test-utils/test-utils';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { advanceTo } from 'jest-date-mock';
 import { CognitoIdentityClient } from '../CognitoIdentityClient';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { getReadableStream } from '../../test-utils/test-utils';
 import { IDENTITY_KEY } from '../../utils/constants';
 
@@ -47,9 +47,8 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Run
-        const creds: Credentials = await client.getCredentialsForIdentity(
-            'my-fake-identity-id'
-        );
+        const creds: AwsCredentialIdentity =
+            await client.getCredentialsForIdentity('my-fake-identity-id');
 
         // Assert
         expect(fetchHandler).toHaveBeenCalledTimes(1);

--- a/src/dispatch/__tests__/Dispatch.test.ts
+++ b/src/dispatch/__tests__/Dispatch.test.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from '../Dispatch';
 import * as Utils from '../../test-utils/test-utils';
 import { DataPlaneClient } from '../DataPlaneClient';
-import { CredentialProvider } from '@aws-sdk/types';
+import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { DEFAULT_CONFIG, mockFetch } from '../../test-utils/test-utils';
 import { EventCache } from 'event-cache/EventCache';
 
@@ -50,7 +50,7 @@ describe('Dispatch tests', () => {
 
     test('when CredentialProvider is used then credentials are immediately fetched', async () => {
         // Init
-        const credentialProvider: CredentialProvider = jest.fn();
+        const credentialProvider: AwsCredentialIdentityProvider = jest.fn();
         const dispatch = new Dispatch(
             Utils.AWS_RUM_REGION,
             Utils.AWS_RUM_ENDPOINT,

--- a/src/dispatch/__tests__/StsClient.test.ts
+++ b/src/dispatch/__tests__/StsClient.test.ts
@@ -1,5 +1,5 @@
 import * as Utils from '../../test-utils/test-utils';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { advanceTo } from 'jest-date-mock';
 import { getReadableStream } from '../../test-utils/test-utils';
@@ -43,11 +43,12 @@ describe('StsClient tests', () => {
         });
 
         // Run
-        const creds: Credentials = await client.assumeRoleWithWebIdentity({
-            RoleArn: 'mock-role-arn',
-            RoleSessionName: 'mock-session-name',
-            WebIdentityToken: 'mock-web-identity-token'
-        });
+        const creds: AwsCredentialIdentity =
+            await client.assumeRoleWithWebIdentity({
+                RoleArn: 'mock-role-arn',
+                RoleSessionName: 'mock-session-name',
+                WebIdentityToken: 'mock-web-identity-token'
+            });
 
         // Assert
         expect(fetchHandler).toHaveBeenCalledTimes(1);

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -1,7 +1,7 @@
 import { Plugin } from '../plugins/Plugin';
 import { PluginContext } from '../plugins/types';
 import { InternalPlugin } from '../plugins/InternalPlugin';
-import { Authentication } from '../dispatch/Authentication';
+import { BasicAuthentication } from '../dispatch/BasicAuthentication';
 import { EnhancedAuthentication } from '../dispatch/EnhancedAuthentication';
 import { PluginManager } from '../plugins/PluginManager';
 import {
@@ -424,7 +424,7 @@ export class Orchestration {
 
         if (this.config.identityPoolId && this.config.guestRoleArn) {
             dispatch.setAwsCredentials(
-                new Authentication(this.config)
+                new BasicAuthentication(this.config)
                     .ChainAnonymousCredentialsProvider
             );
         } else if (this.config.identityPoolId) {

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -15,7 +15,10 @@ import {
 } from '../plugins/event-plugins/JsErrorPlugin';
 import { EventCache } from '../event-cache/EventCache';
 import { ClientBuilder, Dispatch } from '../dispatch/Dispatch';
-import { CredentialProvider, Credentials } from '@aws-sdk/types';
+import {
+    AwsCredentialIdentityProvider,
+    AwsCredentialIdentity
+} from '@aws-sdk/types';
 import { NavigationPlugin } from '../plugins/event-plugins/NavigationPlugin';
 import { ResourcePlugin } from '../plugins/event-plugins/ResourcePlugin';
 import { WebVitalsPlugin } from '../plugins/event-plugins/WebVitalsPlugin';
@@ -287,7 +290,7 @@ export class Orchestration {
      * @param credentials A provider of AWS credentials.
      */
     public setAwsCredentials(
-        credentials: Credentials | CredentialProvider
+        credentials: AwsCredentialIdentity | AwsCredentialIdentityProvider
     ): void {
         this.dispatchManager.setAwsCredentials(credentials);
     }

--- a/src/test-utils/test-utils.ts
+++ b/src/test-utils/test-utils.ts
@@ -1,5 +1,5 @@
 import { EventCache } from '../event-cache/EventCache';
-import { Credentials } from '@aws-sdk/types';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
 import {
     Config,
     defaultConfig,
@@ -81,7 +81,7 @@ export const createDefaultEventCacheWithEvents = (): EventCache => {
     return eventCache;
 };
 
-export const createAwsCredentials = (): Credentials => {
+export const createAwsCredentials = (): AwsCredentialIdentity => {
     return {
         accessKeyId: 'abc123',
         secretAccessKey: 'abc123xyz'


### PR DESCRIPTION
Small refactor to share logic between BasicAuthentication and EnhancedAuthentication.

### 📊 Package size report&nbsp;&nbsp;&nbsp;<kbd>-0.56%↓</kbd>

| File                                                |     Before |                        After |
| --------------------------------------------------- | ---------: | ---------------------------: |
| `dist/cjs/dispatch/Authentication.d.ts`             |   `3.2 kB` |       <sup>5%↑</sup>`3.3 kB` |
| `dist/cjs/dispatch/Authentication.js`               |  `10.9 kB` |   <sup>-18.3%↓</sup>`8.9 kB` |
| `dist/cjs/dispatch/BasicAuthentication.d.ts`        |          — |                      `682 B` |
| `dist/cjs/dispatch/BasicAuthentication.js`          |          — |                     `5.9 kB` |
| `dist/cjs/dispatch/EnhancedAuthentication.d.ts`     |   `3.2 kB` |    <sup>-79.4%↓</sup>`655 B` |
| `dist/cjs/dispatch/EnhancedAuthentication.js`       |  `10.3 kB` |   <sup>-49.8%↓</sup>`5.2 kB` |
| `dist/cjs/orchestration/Orchestration.js`           |  `14.9 kB` |    <sup>0.1%↑</sup>`14.9 kB` |
| `dist/es/dispatch/Authentication.d.ts`              |   `3.2 kB` |       <sup>5%↑</sup>`3.3 kB` |
| `dist/es/dispatch/Authentication.js`                |  `10.7 kB` |   <sup>-18.3%↓</sup>`8.7 kB` |
| `dist/es/dispatch/BasicAuthentication.d.ts`         |          — |                      `682 B` |
| `dist/es/dispatch/BasicAuthentication.js`           |          — |                     `5.7 kB` |
| `dist/es/dispatch/EnhancedAuthentication.d.ts`      |   `3.2 kB` |    <sup>-79.4%↓</sup>`655 B` |
| `dist/es/dispatch/EnhancedAuthentication.js`        |  `10.1 kB` |   <sup>-50.4%↓</sup>`5.0 kB` |
| `dist/es/orchestration/Orchestration.js`            |  `14.2 kB` |    <sup>0.1%↑</sup>`14.2 kB` |
| `dist/webpack/dispatch/Authentication.d.ts`         |   `3.2 kB` |       <sup>5%↑</sup>`3.3 kB` |
| `dist/webpack/dispatch/BasicAuthentication.d.ts`    |          — |                      `682 B` |
| `dist/webpack/dispatch/EnhancedAuthentication.d.ts` |   `3.2 kB` |    <sup>-79.4%↓</sup>`655 B` |
| **Total** <sub>_(Includes all files)_</sub>         |   `1.4 MB` |   <sup>-0.56%↓</sup>`1.3 MB` |
| **Tarball size**                                    | `107.4 kB` | <sup>-1.26%↓</sup>`106.0 kB` |

<details><summary>Unchanged files</summary>

| File                                                                                                   |       Size |
| ------------------------------------------------------------------------------------------------------ | ---------: |
| [`CHANGELOG.md`](https://github.com/williazz/aws-rum-web/blob/AuthRefactor/CHANGELOG.md)               |  `18.5 kB` |
| `dist/cjs/dispatch/BeaconHttpHandler.d.ts`                                                             |    `255 B` |
| `dist/cjs/dispatch/BeaconHttpHandler.js`                                                               |   `1.4 kB` |
| `dist/cjs/dispatch/CognitoIdentityClient.d.ts`                                                         |    `847 B` |
| `dist/cjs/dispatch/CognitoIdentityClient.js`                                                           |   `9.6 kB` |
| `dist/cjs/dispatch/dataplane.d.ts`                                                                     |    `631 B` |
| `dist/cjs/dispatch/dataplane.js`                                                                       |    `448 B` |
| `dist/cjs/dispatch/DataPlaneClient.d.ts`                                                               |    `802 B` |
| `dist/cjs/dispatch/DataPlaneClient.js`                                                                 |   `9.3 kB` |
| `dist/cjs/dispatch/Dispatch.d.ts`                                                                      |   `2.5 kB` |
| `dist/cjs/dispatch/Dispatch.js`                                                                        |  `10.8 kB` |
| `dist/cjs/dispatch/FetchHttpHandler.d.ts`                                                              |    `971 B` |
| `dist/cjs/dispatch/FetchHttpHandler.js`                                                                |   `4.2 kB` |
| `dist/cjs/dispatch/request-timeout.d.ts`                                                               |     `79 B` |
| `dist/cjs/dispatch/request-timeout.js`                                                                 |    `615 B` |
| `dist/cjs/dispatch/RetryHttpHandler.d.ts`                                                              |    `728 B` |
| `dist/cjs/dispatch/RetryHttpHandler.js`                                                                |   `5.3 kB` |
| `dist/cjs/dispatch/StsClient.d.ts`                                                                     |    `459 B` |
| `dist/cjs/dispatch/StsClient.js`                                                                       |   `6.0 kB` |
| `dist/cjs/dispatch/utils.d.ts`                                                                         |    `221 B` |
| `dist/cjs/dispatch/utils.js`                                                                           |   `3.6 kB` |
| `dist/cjs/errors/XhrError.d.ts`                                                                        |     `82 B` |
| `dist/cjs/errors/XhrError.js`                                                                          |   `1.2 kB` |
| `dist/cjs/event-bus/EventBus.d.ts`                                                                     |    `411 B` |
| `dist/cjs/event-bus/EventBus.js`                                                                       |   `1.5 kB` |
| `dist/cjs/event-cache/EventCache.d.ts`                                                                 |   `3.5 kB` |
| `dist/cjs/event-cache/EventCache.js`                                                                   |   `8.3 kB` |
| `dist/cjs/events/cumulative-layout-shift-event.d.ts`                                                   |   `1.0 kB` |
| `dist/cjs/events/cumulative-layout-shift-event.js`                                                     |    `312 B` |
| `dist/cjs/events/dom-event.d.ts`                                                                       |    `675 B` |
| `dist/cjs/events/dom-event.js`                                                                         |    `312 B` |
| `dist/cjs/events/first-input-delay-event.d.ts`                                                         |   `1.0 kB` |
| `dist/cjs/events/first-input-delay-event.js`                                                           |    `312 B` |
| `dist/cjs/events/http-event.d.ts`                                                                      |    `840 B` |
| `dist/cjs/events/http-event.js`                                                                        |    `312 B` |
| `dist/cjs/events/js-error-event.d.ts`                                                                  |    `503 B` |
| `dist/cjs/events/js-error-event.js`                                                                    |    `312 B` |
| `dist/cjs/events/largest-contentful-paint-event.d.ts`                                                  |   `1.4 kB` |
| `dist/cjs/events/largest-contentful-paint-event.js`                                                    |    `312 B` |
| `dist/cjs/events/meta-data.d.ts`                                                                       |    `833 B` |
| `dist/cjs/events/meta-data.js`                                                                         |    `312 B` |
| `dist/cjs/events/navigation-event.d.ts`                                                                |   `1.5 kB` |
| `dist/cjs/events/navigation-event.js`                                                                  |    `312 B` |
| `dist/cjs/events/page-view-event.d.ts`                                                                 |    `510 B` |
| `dist/cjs/events/page-view-event.js`                                                                   |    `312 B` |
| `dist/cjs/events/resource-event.d.ts`                                                                  |    `974 B` |
| `dist/cjs/events/resource-event.js`                                                                    |    `312 B` |
| `dist/cjs/events/time-to-interactive-event.d.ts`                                                       |    `387 B` |
| `dist/cjs/events/time-to-interactive-event.js`                                                         |    `312 B` |
| `dist/cjs/events/xray-trace-event.d.ts`                                                                |   `1.8 kB` |
| `dist/cjs/events/xray-trace-event.js`                                                                  |    `312 B` |
| `dist/cjs/index.d.ts`                                                                                  |    `894 B` |
| `dist/cjs/index.js`                                                                                    |   `2.1 kB` |
| `dist/cjs/orchestration/Orchestration.d.ts`                                                            |   `8.1 kB` |
| `dist/cjs/plugins/event-plugins/DomEventPlugin.d.ts`                                                   |   `1.5 kB` |
| `dist/cjs/plugins/event-plugins/DomEventPlugin.js`                                                     |   `7.0 kB` |
| `dist/cjs/plugins/event-plugins/FetchPlugin.d.ts`                                                      |   `1.2 kB` |
| `dist/cjs/plugins/event-plugins/FetchPlugin.js`                                                        |  `10.3 kB` |
| `dist/cjs/plugins/event-plugins/JsErrorPlugin.d.ts`                                                    |    `806 B` |
| `dist/cjs/plugins/event-plugins/JsErrorPlugin.js`                                                      |   `3.9 kB` |
| `dist/cjs/plugins/event-plugins/NavigationPlugin.d.ts`                                                 |   `2.3 kB` |
| `dist/cjs/plugins/event-plugins/NavigationPlugin.js`                                                   |  `12.9 kB` |
| `dist/cjs/plugins/event-plugins/PageViewPlugin.d.ts`                                                   |   `1.1 kB` |
| `dist/cjs/plugins/event-plugins/PageViewPlugin.js`                                                     |   `4.3 kB` |
| `dist/cjs/plugins/event-plugins/ResourcePlugin.d.ts`                                                   |    `828 B` |
| `dist/cjs/plugins/event-plugins/ResourcePlugin.js`                                                     |   `5.9 kB` |
| `dist/cjs/plugins/event-plugins/TTIPlugin.d.ts`                                                        |    `368 B` |
| `dist/cjs/plugins/event-plugins/TTIPlugin.js`                                                          |   `2.3 kB` |
| `dist/cjs/plugins/event-plugins/WebVitalsPlugin.d.ts`                                                  |    `491 B` |
| `dist/cjs/plugins/event-plugins/WebVitalsPlugin.js`                                                    |   `5.6 kB` |
| `dist/cjs/plugins/event-plugins/XhrPlugin.d.ts`                                                        |   `2.7 kB` |
| `dist/cjs/plugins/event-plugins/XhrPlugin.js`                                                          |  `13.0 kB` |
| `dist/cjs/plugins/InternalPlugin.d.ts`                                                                 |    `699 B` |
| `dist/cjs/plugins/InternalPlugin.js`                                                                   |    `888 B` |
| `dist/cjs/plugins/MonkeyPatched.d.ts`                                                                  |    `638 B` |
| `dist/cjs/plugins/MonkeyPatched.js`                                                                    |   `2.3 kB` |
| `dist/cjs/plugins/Plugin.d.ts`                                                                         |   `1.0 kB` |
| `dist/cjs/plugins/Plugin.js`                                                                           |     `77 B` |
| `dist/cjs/plugins/PluginManager.d.ts`                                                                  |   `1.3 kB` |
| `dist/cjs/plugins/PluginManager.js`                                                                    |   `2.9 kB` |
| `dist/cjs/plugins/types.d.ts`                                                                          |    `608 B` |
| `dist/cjs/plugins/types.js`                                                                            |     `77 B` |
| `dist/cjs/plugins/utils/constant.d.ts`                                                                 |    `778 B` |
| `dist/cjs/plugins/utils/constant.js`                                                                   |   `2.0 kB` |
| `dist/cjs/plugins/utils/http-utils.d.ts`                                                               |   `2.3 kB` |
| `dist/cjs/plugins/utils/http-utils.js`                                                                 |   `7.2 kB` |
| `dist/cjs/plugins/utils/js-error-utils.d.ts`                                                           |    `239 B` |
| `dist/cjs/plugins/utils/js-error-utils.js`                                                             |   `2.6 kB` |
| `dist/cjs/plugins/utils/performance-utils.d.ts`                                                        |    `723 B` |
| `dist/cjs/plugins/utils/performance-utils.js`                                                          |    `839 B` |
| `dist/cjs/sessions/PageManager.d.ts`                                                                   |   `2.4 kB` |
| `dist/cjs/sessions/PageManager.js`                                                                     |   `7.8 kB` |
| `dist/cjs/sessions/SessionManager.d.ts`                                                                |   `3.1 kB` |
| `dist/cjs/sessions/SessionManager.js`                                                                  |   `9.0 kB` |
| `dist/cjs/sessions/VirtualPageLoadTimer.d.ts`                                                          |   `2.8 kB` |
| `dist/cjs/sessions/VirtualPageLoadTimer.js`                                                            |   `8.6 kB` |
| `dist/cjs/time-to-interactive/QuietWindowSearch.d.ts`                                                  |   `1.0 kB` |
| `dist/cjs/time-to-interactive/QuietWindowSearch.js`                                                    |   `8.3 kB` |
| `dist/cjs/time-to-interactive/TimeToInteractive.d.ts`                                                  |   `1.7 kB` |
| `dist/cjs/time-to-interactive/TimeToInteractive.js`                                                    |   `1.9 kB` |
| `dist/cjs/time-to-interactive/VisuallyReadySearch.d.ts`                                                |    `768 B` |
| `dist/cjs/time-to-interactive/VisuallyReadySearch.js`                                                  |   `5.3 kB` |
| `dist/cjs/utils/common-utils.d.ts`                                                                     |   `3.2 kB` |
| `dist/cjs/utils/common-utils.js`                                                                       |   `6.4 kB` |
| `dist/cjs/utils/constants.d.ts`                                                                        |    `391 B` |
| `dist/cjs/utils/constants.js`                                                                          |    `594 B` |
| `dist/cjs/utils/cookies-utils.d.ts`                                                                    |   `1.0 kB` |
| `dist/cjs/utils/cookies-utils.js`                                                                      |   `2.3 kB` |
| `dist/cjs/utils/random.d.ts`                                                                           |     `74 B` |
| `dist/cjs/utils/random.js`                                                                             |    `420 B` |
| `dist/es/dispatch/BeaconHttpHandler.d.ts`                                                              |    `255 B` |
| `dist/es/dispatch/BeaconHttpHandler.js`                                                                |   `1.2 kB` |
| `dist/es/dispatch/CognitoIdentityClient.d.ts`                                                          |    `847 B` |
| `dist/es/dispatch/CognitoIdentityClient.js`                                                            |   `9.4 kB` |
| `dist/es/dispatch/dataplane.d.ts`                                                                      |    `631 B` |
| `dist/es/dispatch/dataplane.js`                                                                        |    `382 B` |
| `dist/es/dispatch/DataPlaneClient.d.ts`                                                                |    `802 B` |
| `dist/es/dispatch/DataPlaneClient.js`                                                                  |   `9.1 kB` |
| `dist/es/dispatch/Dispatch.d.ts`                                                                       |   `2.5 kB` |
| `dist/es/dispatch/Dispatch.js`                                                                         |  `10.6 kB` |
| `dist/es/dispatch/FetchHttpHandler.d.ts`                                                               |    `971 B` |
| `dist/es/dispatch/FetchHttpHandler.js`                                                                 |   `3.9 kB` |
| `dist/es/dispatch/request-timeout.d.ts`                                                                |     `79 B` |
| `dist/es/dispatch/request-timeout.js`                                                                  |    `471 B` |
| `dist/es/dispatch/RetryHttpHandler.d.ts`                                                               |    `728 B` |
| `dist/es/dispatch/RetryHttpHandler.js`                                                                 |   `5.1 kB` |
| `dist/es/dispatch/StsClient.d.ts`                                                                      |    `459 B` |
| `dist/es/dispatch/StsClient.js`                                                                        |   `5.9 kB` |
| `dist/es/dispatch/utils.d.ts`                                                                          |    `221 B` |
| `dist/es/dispatch/utils.js`                                                                            |   `3.4 kB` |
| `dist/es/errors/XhrError.d.ts`                                                                         |     `82 B` |
| `dist/es/errors/XhrError.js`                                                                           |   `1.1 kB` |
| `dist/es/event-bus/EventBus.d.ts`                                                                      |    `411 B` |
| `dist/es/event-bus/EventBus.js`                                                                        |   `1.4 kB` |
| `dist/es/event-cache/EventCache.d.ts`                                                                  |   `3.5 kB` |
| `dist/es/event-cache/EventCache.js`                                                                    |   `8.1 kB` |
| `dist/es/events/cumulative-layout-shift-event.d.ts`                                                    |   `1.0 kB` |
| `dist/es/events/cumulative-layout-shift-event.js`                                                      |    `246 B` |
| `dist/es/events/dom-event.d.ts`                                                                        |    `675 B` |
| `dist/es/events/dom-event.js`                                                                          |    `246 B` |
| `dist/es/events/first-input-delay-event.d.ts`                                                          |   `1.0 kB` |
| `dist/es/events/first-input-delay-event.js`                                                            |    `246 B` |
| `dist/es/events/http-event.d.ts`                                                                       |    `840 B` |
| `dist/es/events/http-event.js`                                                                         |    `246 B` |
| `dist/es/events/js-error-event.d.ts`                                                                   |    `503 B` |
| `dist/es/events/js-error-event.js`                                                                     |    `246 B` |
| `dist/es/events/largest-contentful-paint-event.d.ts`                                                   |   `1.4 kB` |
| `dist/es/events/largest-contentful-paint-event.js`                                                     |    `246 B` |
| `dist/es/events/meta-data.d.ts`                                                                        |    `833 B` |
| `dist/es/events/meta-data.js`                                                                          |    `246 B` |
| `dist/es/events/navigation-event.d.ts`                                                                 |   `1.5 kB` |
| `dist/es/events/navigation-event.js`                                                                   |    `246 B` |
| `dist/es/events/page-view-event.d.ts`                                                                  |    `510 B` |
| `dist/es/events/page-view-event.js`                                                                    |    `246 B` |
| `dist/es/events/resource-event.d.ts`                                                                   |    `974 B` |
| `dist/es/events/resource-event.js`                                                                     |    `246 B` |
| `dist/es/events/time-to-interactive-event.d.ts`                                                        |    `387 B` |
| `dist/es/events/time-to-interactive-event.js`                                                          |    `246 B` |
| `dist/es/events/xray-trace-event.d.ts`                                                                 |   `1.8 kB` |
| `dist/es/events/xray-trace-event.js`                                                                   |    `246 B` |
| `dist/es/index.d.ts`                                                                                   |    `894 B` |
| `dist/es/index.js`                                                                                     |    `611 B` |
| `dist/es/orchestration/Orchestration.d.ts`                                                             |   `8.1 kB` |
| `dist/es/plugins/event-plugins/DomEventPlugin.d.ts`                                                    |   `1.5 kB` |
| `dist/es/plugins/event-plugins/DomEventPlugin.js`                                                      |   `6.8 kB` |
| `dist/es/plugins/event-plugins/FetchPlugin.d.ts`                                                       |   `1.2 kB` |
| `dist/es/plugins/event-plugins/FetchPlugin.js`                                                         |  `10.0 kB` |
| `dist/es/plugins/event-plugins/JsErrorPlugin.d.ts`                                                     |    `806 B` |
| `dist/es/plugins/event-plugins/JsErrorPlugin.js`                                                       |   `3.7 kB` |
| `dist/es/plugins/event-plugins/NavigationPlugin.d.ts`                                                  |   `2.3 kB` |
| `dist/es/plugins/event-plugins/NavigationPlugin.js`                                                    |  `12.7 kB` |
| `dist/es/plugins/event-plugins/PageViewPlugin.d.ts`                                                    |   `1.1 kB` |
| `dist/es/plugins/event-plugins/PageViewPlugin.js`                                                      |   `4.1 kB` |
| `dist/es/plugins/event-plugins/ResourcePlugin.d.ts`                                                    |    `828 B` |
| `dist/es/plugins/event-plugins/ResourcePlugin.js`                                                      |   `5.7 kB` |
| `dist/es/plugins/event-plugins/TTIPlugin.d.ts`                                                         |    `368 B` |
| `dist/es/plugins/event-plugins/TTIPlugin.js`                                                           |   `2.1 kB` |
| `dist/es/plugins/event-plugins/WebVitalsPlugin.d.ts`                                                   |    `491 B` |
| `dist/es/plugins/event-plugins/WebVitalsPlugin.js`                                                     |   `5.3 kB` |
| `dist/es/plugins/event-plugins/XhrPlugin.d.ts`                                                         |   `2.7 kB` |
| `dist/es/plugins/event-plugins/XhrPlugin.js`                                                           |  `12.7 kB` |
| `dist/es/plugins/InternalPlugin.d.ts`                                                                  |    `699 B` |
| `dist/es/plugins/InternalPlugin.js`                                                                    |    `758 B` |
| `dist/es/plugins/MonkeyPatched.d.ts`                                                                   |    `638 B` |
| `dist/es/plugins/MonkeyPatched.js`                                                                     |   `2.2 kB` |
| `dist/es/plugins/Plugin.d.ts`                                                                          |   `1.0 kB` |
| `dist/es/plugins/Plugin.js`                                                                            |     `11 B` |
| `dist/es/plugins/PluginManager.d.ts`                                                                   |   `1.3 kB` |
| `dist/es/plugins/PluginManager.js`                                                                     |   `2.7 kB` |
| `dist/es/plugins/types.d.ts`                                                                           |    `608 B` |
| `dist/es/plugins/types.js`                                                                             |     `11 B` |
| `dist/es/plugins/utils/constant.d.ts`                                                                  |    `778 B` |
| `dist/es/plugins/utils/constant.js`                                                                    |   `1.4 kB` |
| `dist/es/plugins/utils/http-utils.d.ts`                                                                |   `2.3 kB` |
| `dist/es/plugins/utils/http-utils.js`                                                                  |   `6.0 kB` |
| `dist/es/plugins/utils/js-error-utils.d.ts`                                                            |    `239 B` |
| `dist/es/plugins/utils/js-error-utils.js`                                                              |   `2.4 kB` |
| `dist/es/plugins/utils/performance-utils.d.ts`                                                         |    `723 B` |
| `dist/es/plugins/utils/performance-utils.js`                                                           |    `561 B` |
| `dist/es/sessions/PageManager.d.ts`                                                                    |   `2.4 kB` |
| `dist/es/sessions/PageManager.js`                                                                      |   `7.7 kB` |
| `dist/es/sessions/SessionManager.d.ts`                                                                 |   `3.1 kB` |
| `dist/es/sessions/SessionManager.js`                                                                   |   `8.5 kB` |
| `dist/es/sessions/VirtualPageLoadTimer.d.ts`                                                           |   `2.8 kB` |
| `dist/es/sessions/VirtualPageLoadTimer.js`                                                             |   `8.4 kB` |
| `dist/es/time-to-interactive/QuietWindowSearch.d.ts`                                                   |   `1.0 kB` |
| `dist/es/time-to-interactive/QuietWindowSearch.js`                                                     |   `8.2 kB` |
| `dist/es/time-to-interactive/TimeToInteractive.d.ts`                                                   |   `1.7 kB` |
| `dist/es/time-to-interactive/TimeToInteractive.js`                                                     |   `1.7 kB` |
| `dist/es/time-to-interactive/VisuallyReadySearch.d.ts`                                                 |    `768 B` |
| `dist/es/time-to-interactive/VisuallyReadySearch.js`                                                   |   `5.1 kB` |
| `dist/es/utils/common-utils.d.ts`                                                                      |   `3.2 kB` |
| `dist/es/utils/common-utils.js`                                                                        |   `5.9 kB` |
| `dist/es/utils/constants.d.ts`                                                                         |    `391 B` |
| `dist/es/utils/constants.js`                                                                           |    `326 B` |
| `dist/es/utils/cookies-utils.d.ts`                                                                     |   `1.0 kB` |
| `dist/es/utils/cookies-utils.js`                                                                       |   `2.0 kB` |
| `dist/es/utils/random.d.ts`                                                                            |     `74 B` |
| `dist/es/utils/random.js`                                                                              |    `273 B` |
| `dist/webpack/CommandQueue.d.ts`                                                                       |   `1.3 kB` |
| `dist/webpack/dispatch/BeaconHttpHandler.d.ts`                                                         |    `255 B` |
| `dist/webpack/dispatch/CognitoIdentityClient.d.ts`                                                     |    `847 B` |
| `dist/webpack/dispatch/dataplane.d.ts`                                                                 |    `631 B` |
| `dist/webpack/dispatch/DataPlaneClient.d.ts`                                                           |    `802 B` |
| `dist/webpack/dispatch/Dispatch.d.ts`                                                                  |   `2.5 kB` |
| `dist/webpack/dispatch/FetchHttpHandler.d.ts`                                                          |    `971 B` |
| `dist/webpack/dispatch/request-timeout.d.ts`                                                           |     `79 B` |
| `dist/webpack/dispatch/RetryHttpHandler.d.ts`                                                          |    `728 B` |
| `dist/webpack/dispatch/StsClient.d.ts`                                                                 |    `459 B` |
| `dist/webpack/dispatch/utils.d.ts`                                                                     |    `221 B` |
| `dist/webpack/errors/XhrError.d.ts`                                                                    |     `82 B` |
| `dist/webpack/event-bus/EventBus.d.ts`                                                                 |    `411 B` |
| `dist/webpack/event-cache/EventCache.d.ts`                                                             |   `3.5 kB` |
| `dist/webpack/events/cumulative-layout-shift-event.d.ts`                                               |   `1.0 kB` |
| `dist/webpack/events/dom-event.d.ts`                                                                   |    `675 B` |
| `dist/webpack/events/first-input-delay-event.d.ts`                                                     |   `1.0 kB` |
| `dist/webpack/events/http-event.d.ts`                                                                  |    `840 B` |
| `dist/webpack/events/js-error-event.d.ts`                                                              |    `503 B` |
| `dist/webpack/events/largest-contentful-paint-event.d.ts`                                              |   `1.4 kB` |
| `dist/webpack/events/meta-data.d.ts`                                                                   |    `833 B` |
| `dist/webpack/events/navigation-event.d.ts`                                                            |   `1.5 kB` |
| `dist/webpack/events/page-view-event.d.ts`                                                             |    `510 B` |
| `dist/webpack/events/resource-event.d.ts`                                                              |    `974 B` |
| `dist/webpack/events/xray-trace-event.d.ts`                                                            |   `1.8 kB` |
| `dist/webpack/index-browser.d.ts`                                                                      |    `184 B` |
| `dist/webpack/orchestration/Orchestration.d.ts`                                                        |   `8.1 kB` |
| `dist/webpack/plugins/event-plugins/DomEventPlugin.d.ts`                                               |   `1.5 kB` |
| `dist/webpack/plugins/event-plugins/FetchPlugin.d.ts`                                                  |   `1.2 kB` |
| `dist/webpack/plugins/event-plugins/JsErrorPlugin.d.ts`                                                |    `806 B` |
| `dist/webpack/plugins/event-plugins/NavigationPlugin.d.ts`                                             |   `2.3 kB` |
| `dist/webpack/plugins/event-plugins/PageViewPlugin.d.ts`                                               |   `1.1 kB` |
| `dist/webpack/plugins/event-plugins/ResourcePlugin.d.ts`                                               |    `828 B` |
| `dist/webpack/plugins/event-plugins/WebVitalsPlugin.d.ts`                                              |    `491 B` |
| `dist/webpack/plugins/event-plugins/XhrPlugin.d.ts`                                                    |   `2.7 kB` |
| `dist/webpack/plugins/InternalPlugin.d.ts`                                                             |    `699 B` |
| `dist/webpack/plugins/MonkeyPatched.d.ts`                                                              |    `638 B` |
| `dist/webpack/plugins/Plugin.d.ts`                                                                     |   `1.0 kB` |
| `dist/webpack/plugins/PluginManager.d.ts`                                                              |   `1.3 kB` |
| `dist/webpack/plugins/types.d.ts`                                                                      |    `608 B` |
| `dist/webpack/plugins/utils/constant.d.ts`                                                             |    `778 B` |
| `dist/webpack/plugins/utils/http-utils.d.ts`                                                           |   `2.3 kB` |
| `dist/webpack/plugins/utils/js-error-utils.d.ts`                                                       |    `239 B` |
| `dist/webpack/plugins/utils/performance-utils.d.ts`                                                    |    `723 B` |
| `dist/webpack/remote-config/remote-config.d.ts`                                                        |    `510 B` |
| `dist/webpack/sessions/PageManager.d.ts`                                                               |   `2.4 kB` |
| `dist/webpack/sessions/SessionManager.d.ts`                                                            |   `3.1 kB` |
| `dist/webpack/sessions/VirtualPageLoadTimer.d.ts`                                                      |   `2.8 kB` |
| `dist/webpack/utils/common-utils.d.ts`                                                                 |   `3.2 kB` |
| `dist/webpack/utils/constants.d.ts`                                                                    |    `391 B` |
| `dist/webpack/utils/cookies-utils.d.ts`                                                                |   `1.0 kB` |
| `dist/webpack/utils/random.d.ts`                                                                       |     `74 B` |
| [`LICENSE`](https://github.com/williazz/aws-rum-web/blob/AuthRefactor/LICENSE)                         |  `10.1 kB` |
| [`LICENSE-THIRD-PARTY`](https://github.com/williazz/aws-rum-web/blob/AuthRefactor/LICENSE-THIRD-PARTY) | `632.4 kB` |
| [`NOTICE`](https://github.com/williazz/aws-rum-web/blob/AuthRefactor/NOTICE)                           |     `67 B` |
| [`package.json`](https://github.com/williazz/aws-rum-web/blob/AuthRefactor/package.json)               |   `6.5 kB` |
| [`README.md`](https://github.com/williazz/aws-rum-web/blob/AuthRefactor/README.md)                     |   `4.0 kB` |
</details>



<sub>🤖 This report was automatically generated by [pkg-size-action](https://github.com/pkg-size/action/)</sub>

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
