### PR TITLE
chore: reduce size of partial types

### DIFF
--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -52,57 +52,6 @@ export type Telemetry = string | (string | object)[];
 
 export type PageIdFormat = 'PATH' | 'HASH' | 'PATH_AND_HASH';
 
-export type PartialCookieAttributes = {
-    unique?: boolean;
-    domain?: string;
-    path?: string;
-    sameSite?: string;
-    secure?: boolean;
-};
-
-export type PartialConfig = {
-    allowCookies?: boolean;
-    batchLimit?: number;
-    client?: string;
-    clientBuilder?: ClientBuilder;
-    cookieAttributes?: PartialCookieAttributes;
-    disableAutoPageView?: boolean;
-    dispatchInterval?: number;
-    enableRumClient?: boolean;
-    enableXRay?: boolean;
-    endpoint?: string;
-    eventCacheSize?: number;
-    eventPluginsToLoad?: Plugin[];
-    guestRoleArn?: string;
-    identityPoolId?: string;
-    pageIdFormat?: PageIdFormat;
-    pagesToExclude?: RegExp[];
-    pagesToInclude?: RegExp[];
-    signing?: boolean;
-    recordResourceUrl?: boolean;
-    routeChangeComplete?: number;
-    routeChangeTimeout?: number;
-    sessionAttributes?: { [k: string]: string | number | boolean };
-    sessionEventLimit?: number;
-    sessionLengthSeconds?: number;
-    sessionSampleRate?: number;
-    /**
-     * Application owners think about data collection in terms of the categories
-     * of data being collected. For example, JavaScript errors, page load
-     * performance, user journeys and user interactions are data collection
-     * categories. However, there is not a 1-1 mapping between data collection
-     * categories and plugins.
-     *
-     * This configuration option allows application owners to define the data
-     * categories they want to collect without needing to understand and
-     * instantiate each plugin themselves. The toolkit will instantiate the
-     * plugins which map to the selected categories.
-     */
-    telemetries?: Telemetry[];
-    useBeacon?: boolean;
-    userIdRetentionDays?: number;
-};
-
 export const defaultCookieAttributes = (): CookieAttributes => {
     return {
         unique: false,
@@ -153,7 +102,9 @@ export type CookieAttributes = {
     secure: boolean;
 };
 
-export type Config = {
+export type PartialCookieAttributes = Partial<CookieAttributes>;
+
+export interface Config {
     allowCookies: boolean;
     batchLimit: number;
     client: string;
@@ -190,10 +141,27 @@ export type Config = {
     sessionEventLimit: number;
     sessionLengthSeconds: number;
     sessionSampleRate: number;
+    /**
+     * Application owners think about data collection in terms of the categories
+     * of data being collected. For example, JavaScript errors, page load
+     * performance, user journeys and user interactions are data collection
+     * categories. However, there is not a 1-1 mapping between data collection
+     * categories and plugins.
+     *
+     * This configuration option allows application owners to define the data
+     * categories they want to collect without needing to understand and
+     * instantiate each plugin themselves. The toolkit will instantiate the
+     * plugins which map to the selected categories.
+     */
     telemetries: Telemetry[];
     useBeacon: boolean;
     userIdRetentionDays: number;
-};
+}
+
+export interface PartialConfig
+    extends Omit<Partial<Config>, 'cookieAttributes'> {
+    cookieAttributes?: PartialCookieAttributes;
+}
 
 /**
  * An orchestrator which (1) initializes cwr components and (2) provides the API for the application to interact

--- a/src/plugins/event-plugins/DomEventPlugin.ts
+++ b/src/plugins/event-plugins/DomEventPlugin.ts
@@ -26,12 +26,6 @@ export type TargetDomEvent = {
     element?: HTMLElement;
 };
 
-export type PartialDomEventPluginConfig = {
-    interactionId?: (event: Event) => string;
-    enableMutationObserver?: boolean;
-    events?: TargetDomEvent[];
-};
-
 export type DomEventPluginConfig = {
     interactionId: (event: Event) => string;
     enableMutationObserver?: boolean;
@@ -62,7 +56,7 @@ export class DomEventPlugin<
     private config: DomEventPluginConfig;
     private observer: MutationObserver | undefined;
 
-    constructor(config?: PartialDomEventPluginConfig) {
+    constructor(config?: Partial<DomEventPluginConfig>) {
         super(DOM_EVENT_PLUGIN_ID);
         this.eventListenerMap = new Map<
             TargetDomEvent,

--- a/src/plugins/event-plugins/FetchPlugin.ts
+++ b/src/plugins/event-plugins/FetchPlugin.ts
@@ -5,7 +5,6 @@ import {
 } from '../../events/xray-trace-event';
 import { MonkeyPatched } from '../MonkeyPatched';
 import {
-    PartialHttpPluginConfig,
     defaultConfig,
     epochTime,
     createXRayTraceEvent,
@@ -55,7 +54,7 @@ export const FETCH_PLUGIN_ID = 'fetch';
 export class FetchPlugin extends MonkeyPatched<Window, 'fetch'> {
     private readonly config: HttpPluginConfig;
 
-    constructor(config?: PartialHttpPluginConfig) {
+    constructor(config?: Partial<HttpPluginConfig>) {
         super(FETCH_PLUGIN_ID);
         this.config = { ...defaultConfig, ...config };
     }

--- a/src/plugins/event-plugins/NavigationPlugin.ts
+++ b/src/plugins/event-plugins/NavigationPlugin.ts
@@ -2,7 +2,6 @@ import { InternalPlugin } from '../InternalPlugin';
 import { NavigationEvent } from '../../events/navigation-event';
 import { PERFORMANCE_NAVIGATION_EVENT_TYPE } from '../utils/constant';
 import {
-    PartialPerformancePluginConfig,
     PerformancePluginConfig,
     defaultPerformancePluginConfig
 } from '../utils/performance-utils';
@@ -19,7 +18,7 @@ const LOAD = 'load';
  */
 export class NavigationPlugin extends InternalPlugin {
     private config: PerformancePluginConfig;
-    constructor(config?: PartialPerformancePluginConfig) {
+    constructor(config?: Partial<PerformancePluginConfig>) {
         super(NAVIGATION_EVENT_PLUGIN_ID);
         this.config = { ...defaultPerformancePluginConfig, ...config };
     }

--- a/src/plugins/event-plugins/ResourcePlugin.ts
+++ b/src/plugins/event-plugins/ResourcePlugin.ts
@@ -4,7 +4,6 @@ import { ResourceEvent } from '../../events/resource-event';
 import { PERFORMANCE_RESOURCE_EVENT_TYPE } from '../utils/constant';
 import {
     defaultPerformancePluginConfig,
-    PartialPerformancePluginConfig,
     PerformancePluginConfig
 } from '../utils/performance-utils';
 
@@ -20,7 +19,7 @@ export class ResourcePlugin extends InternalPlugin {
     private resourceObserver: PerformanceObserver;
     private eventCount: number;
 
-    constructor(config?: PartialPerformancePluginConfig) {
+    constructor(config?: Partial<PerformancePluginConfig>) {
         super(RESOURCE_EVENT_PLUGIN_ID);
         this.config = { ...defaultPerformancePluginConfig, ...config };
         this.eventCount = 0;

--- a/src/plugins/event-plugins/XhrPlugin.ts
+++ b/src/plugins/event-plugins/XhrPlugin.ts
@@ -2,7 +2,6 @@ import { XRayTraceEvent } from '../../events/xray-trace-event';
 import { HttpEvent } from '../../events/http-event';
 import { MonkeyPatch, MonkeyPatched } from '../MonkeyPatched';
 import {
-    PartialHttpPluginConfig,
     defaultConfig,
     epochTime,
     createXRayTraceEvent,
@@ -99,7 +98,7 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
     private xhrMap: Map<XMLHttpRequest, XhrDetails>;
     private isSyntheticsUA: boolean;
 
-    constructor(config?: PartialHttpPluginConfig) {
+    constructor(config?: Partial<HttpPluginConfig>) {
         super(XHR_PLUGIN_ID);
         this.config = { ...defaultConfig, ...config };
         this.xhrMap = new Map<XMLHttpRequest, XhrDetails>();

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.integ.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.integ.test.ts
@@ -1,6 +1,6 @@
 import { Orchestration } from '../../../orchestration/Orchestration';
 import { createAwsCredentials } from '../../../test-utils/test-utils';
-import { PartialHttpPluginConfig } from '../../utils/http-utils';
+import { HttpPluginConfig } from '../../utils/http-utils';
 import { FetchPlugin } from '../FetchPlugin';
 
 const mockFetch = jest.fn(
@@ -27,7 +27,7 @@ describe('FetchPlugin integ tests', () => {
 
     test('dispatch requests are not recorded by the http plugin', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true
         };
 

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -1,8 +1,5 @@
 import { FetchPlugin } from '../FetchPlugin';
-import {
-    PartialHttpPluginConfig,
-    X_AMZN_TRACE_ID
-} from '../../utils/http-utils';
+import { HttpPluginConfig, X_AMZN_TRACE_ID } from '../../utils/http-utils';
 import { advanceTo } from 'jest-date-mock';
 import {
     getSession,
@@ -81,7 +78,7 @@ describe('FetchPlugin tests', () => {
 
     test('when fetch is called then the plugin records the http request/response', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: true
         };
@@ -111,7 +108,7 @@ describe('FetchPlugin tests', () => {
 
     test('when fetch is called with a Request/RequestInfo then the plugin records the http request/response', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: true
         };
@@ -147,7 +144,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch throws an error then the plugin adds the error to the http event', async () => {
         // Init
         global.fetch = mockFetchWithError;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -180,7 +177,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch throws an error object then the plugin adds the error object to the http event', async () => {
         // Init
         global.fetch = mockFetchWithErrorObject;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -214,7 +211,7 @@ describe('FetchPlugin tests', () => {
 
     test('when fetch is called then the plugin records a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -259,7 +256,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch throws an error then the plugin adds the error to the trace', async () => {
         // Init
         global.fetch = mockFetchWithError;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -313,7 +310,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch returns a 404 then segment error is true', async () => {
         // Init
         global.fetch = mockFetchWith400;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -343,7 +340,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch returns a 429 then segment throttle is true', async () => {
         // Init
         global.fetch = mockFetchWith429;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -373,7 +370,7 @@ describe('FetchPlugin tests', () => {
     test('when fetch returns a 500 then segment fault is true', async () => {
         // Init
         global.fetch = mockFetchWith500;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -402,7 +399,7 @@ describe('FetchPlugin tests', () => {
 
     test('when plugin is disabled then the plugin does not record a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -421,7 +418,7 @@ describe('FetchPlugin tests', () => {
 
     test('when plugin is re-enabled then the plugin records a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -442,7 +439,7 @@ describe('FetchPlugin tests', () => {
 
     test('when default config is used then X-Amzn-Trace-Id header is not added to the HTTP request', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {};
+        const config: Partial<HttpPluginConfig> = {};
 
         const plugin: FetchPlugin = new FetchPlugin(config);
         plugin.load(xRayOnContext);
@@ -458,7 +455,7 @@ describe('FetchPlugin tests', () => {
 
     test('when addXRayTraceIdHeader is true then X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: true
         };
 
@@ -479,7 +476,7 @@ describe('FetchPlugin tests', () => {
 
     test('when addXRayTraceIdHeader is false then X-Amzn-Trace-Id header is not added to the HTTP request', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: false
         };
 
@@ -497,7 +494,7 @@ describe('FetchPlugin tests', () => {
 
     test('when url matches some regex in addXRayTraceIdHeader then X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: [/noMatch/, new RegExp(URL)]
         };
 
@@ -520,7 +517,7 @@ describe('FetchPlugin tests', () => {
 
     test('when url matches no regex in addXRayTraceIdHeader then X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: [/noMatch/]
         };
 
@@ -538,7 +535,7 @@ describe('FetchPlugin tests', () => {
 
     test('when addXRayTraceIdHeader is an empty array then X-Amzn-Trace-Id header is not added to the HTTP request', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: []
         };
 
@@ -556,7 +553,7 @@ describe('FetchPlugin tests', () => {
 
     test('when init object is provided then X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: true
         };
 
@@ -585,7 +582,7 @@ describe('FetchPlugin tests', () => {
 
     test('when init object is provided then request options are persisted after adding trace id header', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: true
         };
 
@@ -609,7 +606,7 @@ describe('FetchPlugin tests', () => {
     });
 
     test('when trace is disabled then the plugin does not record a trace', async () => {
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -632,7 +629,7 @@ describe('FetchPlugin tests', () => {
             record: false,
             eventCount: 0
         }));
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -653,7 +650,7 @@ describe('FetchPlugin tests', () => {
         const getSession: jest.MockedFunction<GetSession> = jest.fn(
             () => undefined
         );
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -674,7 +671,7 @@ describe('FetchPlugin tests', () => {
     test('the plugin records a stack trace by default', async () => {
         // Init
         global.fetch = mockFetchWithErrorObjectAndStack;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/]
         };
@@ -708,7 +705,7 @@ describe('FetchPlugin tests', () => {
     test('when stack trace length is zero then the plugin does not record a stack trace', async () => {
         // Init
         global.fetch = mockFetchWithErrorObjectAndStack;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             stackTraceLength: 0
@@ -744,7 +741,7 @@ describe('FetchPlugin tests', () => {
 
     test('when recordAllRequests is true then the plugin records a request with status OK', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: true
         };
@@ -763,7 +760,7 @@ describe('FetchPlugin tests', () => {
 
     test('when recordAllRequests is false then the plugin does not record a request with status OK', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: false
         };
@@ -783,7 +780,7 @@ describe('FetchPlugin tests', () => {
     test('when recordAllRequests is false then the plugin records a request with status 500', async () => {
         // Init
         global.fetch = mockFetchWith500;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: false
         };
@@ -803,7 +800,7 @@ describe('FetchPlugin tests', () => {
 
     test('when a url is excluded then the plugin does not record a request to that url', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/aws\.amazon\.com/],
             urlsToExclude: [/aws\.amazon\.com/],
             recordAllRequests: true
@@ -823,7 +820,7 @@ describe('FetchPlugin tests', () => {
 
     test('when a Request url is excluded then the plugin does not record a request to that url', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/.*/],
             urlsToExclude: [/aws\.amazon\.com/],
             recordAllRequests: true
@@ -843,7 +840,7 @@ describe('FetchPlugin tests', () => {
 
     test('all urls are included by default', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true
         };
 
@@ -861,7 +858,7 @@ describe('FetchPlugin tests', () => {
 
     test('when a request is made to cognito or sts using default exclude list then the requests are not recorded', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true
         };
 
@@ -880,7 +877,7 @@ describe('FetchPlugin tests', () => {
 
     test('when a request is made to cognito or sts using an empty exclude list then the requests are recorded', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true,
             urlsToExclude: []
         };
@@ -899,7 +896,7 @@ describe('FetchPlugin tests', () => {
 
     test('when a url is relative then the subsegment name is location.hostname', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {};
+        const config: Partial<HttpPluginConfig> = {};
         const plugin: FetchPlugin = new FetchPlugin(config);
         plugin.load(xRayOnContext);
 
@@ -924,7 +921,7 @@ describe('FetchPlugin tests', () => {
         const SIGN_HEADER_KEY = 'x-amzn-security-token';
         const SIGN_HEADER_VAL = 'abc123';
 
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: true,
             recordAllRequests: true
         };
@@ -951,7 +948,7 @@ describe('FetchPlugin tests', () => {
 
     test('when fetch uses request object then the URL is added to the event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: true
         };
@@ -983,7 +980,7 @@ describe('FetchPlugin tests', () => {
 
     test('when tracing is enabled then the trace id is added to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: true
@@ -1007,7 +1004,7 @@ describe('FetchPlugin tests', () => {
 
     test('when tracing is not enabled then the trace id is not added to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: true
@@ -1032,7 +1029,7 @@ describe('FetchPlugin tests', () => {
     });
     test('when fetch is called and request has existing trace header then existing trace data is added to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/aws\.amazon\.com/],
             recordAllRequests: true
@@ -1064,7 +1061,7 @@ describe('FetchPlugin tests', () => {
 
     test('when the url does not match urlsToInclude then the plugin does not record a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true,
             urlsToInclude: [/a^/]
         };
@@ -1082,7 +1079,7 @@ describe('FetchPlugin tests', () => {
 
     test('when the url matches urlsToInclude then the plugin records a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/https:\/\/aws\.amazon\.com/]
         };
 

--- a/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
@@ -10,9 +10,9 @@ import {
 import { NavigationPlugin } from '../NavigationPlugin';
 import { context, record } from '../../../test-utils/test-utils';
 import { PERFORMANCE_NAVIGATION_EVENT_TYPE } from '../../utils/constant';
-import { PartialPerformancePluginConfig } from 'plugins/utils/performance-utils';
+import { PerformancePluginConfig } from 'plugins/utils/performance-utils';
 
-const buildNavigationPlugin = (config?: PartialPerformancePluginConfig) => {
+const buildNavigationPlugin = (config?: Partial<PerformancePluginConfig>) => {
     return new NavigationPlugin(config);
 };
 

--- a/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/ResourcePlugin.test.ts
@@ -19,9 +19,9 @@ import {
 } from '../../../test-utils/test-utils';
 import { PERFORMANCE_RESOURCE_EVENT_TYPE } from '../../utils/constant';
 import { ResourceEvent } from '../../../events/resource-event';
-import { PartialPerformancePluginConfig } from 'plugins/utils/performance-utils';
+import { PerformancePluginConfig } from 'plugins/utils/performance-utils';
 
-const buildResourcePlugin = (config?: PartialPerformancePluginConfig) => {
+const buildResourcePlugin = (config?: Partial<PerformancePluginConfig>) => {
     return new ResourcePlugin(config);
 };
 

--- a/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/XhrPlugin.test.ts
@@ -1,4 +1,4 @@
-import { PartialHttpPluginConfig } from '../../utils/http-utils';
+import { HttpPluginConfig } from '../../utils/http-utils';
 import { advanceTo } from 'jest-date-mock';
 import { XhrPlugin } from '../XhrPlugin';
 import {
@@ -29,7 +29,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR is called then the plugin records the http request/response', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
         };
@@ -68,7 +68,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR is called then the plugin records a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/]
         };
@@ -122,7 +122,7 @@ describe('XhrPlugin tests', () => {
 
     test('when xhr loads successfully then cache is empty', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true
         };
 
@@ -154,7 +154,7 @@ describe('XhrPlugin tests', () => {
 
     test('when plugin is disabled then the plugin does not record any events', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
         };
@@ -181,7 +181,7 @@ describe('XhrPlugin tests', () => {
 
     test('when plugin is re-enabled then the plugin records a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/]
         };
 
@@ -210,7 +210,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR returns an error code then the plugin adds the error to the trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             ...DEFAULT_CONFIG,
             ...{
                 logicalServiceName: 'sample.rum.aws.amazon.com',
@@ -270,7 +270,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR returns an error code then the plugin adds the error to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/]
         };
@@ -333,7 +333,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR times out then the plugin adds the error to the trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/]
         };
@@ -380,7 +380,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR times out then the plugin adds the error to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/]
         };
@@ -448,7 +448,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR aborts then the plugin adds the error to the trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/]
         };
@@ -497,7 +497,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR aborts then the plugin adds the error to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/]
         };
 
@@ -565,7 +565,7 @@ describe('XhrPlugin tests', () => {
     test('when default config is used then X-Amzn-Trace-Id header is not to the HTTP request', async () => {
         // Init
         let header: string;
-        const config: PartialHttpPluginConfig = {};
+        const config: Partial<HttpPluginConfig> = {};
 
         mock.get(/.*/, (req, res) => {
             header = req.header('X-Amzn-Trace-Id');
@@ -595,7 +595,9 @@ describe('XhrPlugin tests', () => {
     test('when addXrayTraceIdHeader is true then X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
         let header: string;
-        const config: PartialHttpPluginConfig = { addXRayTraceIdHeader: true };
+        const config: Partial<HttpPluginConfig> = {
+            addXRayTraceIdHeader: true
+        };
 
         mock.get(/.*/, (req, res) => {
             header = req.header('X-Amzn-Trace-Id');
@@ -627,7 +629,9 @@ describe('XhrPlugin tests', () => {
     test('when addXrayTraceIdHeader is false then X-Amzn-Trace-Id header is not added to the HTTP request', async () => {
         // Init
         let header: string | null;
-        const config: PartialHttpPluginConfig = { addXRayTraceIdHeader: false };
+        const config: Partial<HttpPluginConfig> = {
+            addXRayTraceIdHeader: false
+        };
 
         mock.get(/.*/, (req, res) => {
             header = req.header('X-Amzn-Trace-Id');
@@ -657,7 +661,7 @@ describe('XhrPlugin tests', () => {
     test('when url matches some regex in addXrayTraceIdHeader then X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
         let header: string | null;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: [/noMatch/, /.*response.json$/]
         };
 
@@ -691,7 +695,7 @@ describe('XhrPlugin tests', () => {
     test('when url matches no regex in addXrayTraceIdHeader then X-Amzn-Trace-Id header is added to the HTTP request', async () => {
         // Init
         let header: string | null;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: [/noMatch/]
         };
 
@@ -723,7 +727,7 @@ describe('XhrPlugin tests', () => {
     test('when addXrayTraceIdHeader is empty then X-Amzn-Trace-Id header is not added to the HTTP request', async () => {
         // Init
         let header: string | null;
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             addXRayTraceIdHeader: []
         };
 
@@ -754,7 +758,7 @@ describe('XhrPlugin tests', () => {
 
     test('when trace is disabled then the plugin does not record a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/]
         };
 
@@ -789,7 +793,7 @@ describe('XhrPlugin tests', () => {
 
         const context = { ...mockContext, getSession };
 
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/]
         };
@@ -819,7 +823,7 @@ describe('XhrPlugin tests', () => {
         // Init
         const getSession: jest.MockedFunction<GetSession> = jest.fn();
         const context = { ...mockContext, getSession };
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
@@ -848,7 +852,7 @@ describe('XhrPlugin tests', () => {
 
     test('when recordAllRequests is false then the plugin does record a request with status OK', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
         };
@@ -876,7 +880,7 @@ describe('XhrPlugin tests', () => {
 
     test('when recordAllRequests is false then the plugin does not record a request with status OK', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: false
         };
@@ -904,7 +908,7 @@ describe('XhrPlugin tests', () => {
 
     test('when recordAllRequests is false then the plugin records a request with status 500', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: false
         };
@@ -933,7 +937,7 @@ describe('XhrPlugin tests', () => {
 
     test('when a url is excluded then the plugin does not record a request to that url', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/],
             urlsToExclude: [/response\.json/]
         };
@@ -961,7 +965,7 @@ describe('XhrPlugin tests', () => {
 
     test('all urls are included by default', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true
         };
 
@@ -988,7 +992,7 @@ describe('XhrPlugin tests', () => {
 
     test('when a request is made to cognito or sts using default exclude list then the requests are not recorded', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true
         };
 
@@ -1023,7 +1027,7 @@ describe('XhrPlugin tests', () => {
 
     test('when a url is relative then the subsegment name is location.hostname', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {};
+        const config: Partial<HttpPluginConfig> = {};
 
         mock.get(/.*/, () => Promise.reject(new Error()));
 
@@ -1054,7 +1058,7 @@ describe('XhrPlugin tests', () => {
 
     test('when the plugin records a trace then the trace id is added to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
@@ -1089,7 +1093,7 @@ describe('XhrPlugin tests', () => {
 
     test('when XHR aborts with tracing then the trace id is added to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/]
         };
@@ -1123,7 +1127,7 @@ describe('XhrPlugin tests', () => {
 
     test('when the plugin does not record a trace then the trace id is not added to the http event', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             logicalServiceName: 'sample.rum.aws.amazon.com',
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
@@ -1165,7 +1169,7 @@ describe('XhrPlugin tests', () => {
             configurable: true
         });
 
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/]
         };
 
@@ -1206,7 +1210,7 @@ describe('XhrPlugin tests', () => {
             configurable: true
         });
 
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/response\.json/],
             recordAllRequests: true
         };
@@ -1252,7 +1256,7 @@ describe('XhrPlugin tests', () => {
 
     test('when the url does not match urlsToTrace then the plugin does not record a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             recordAllRequests: true,
             urlsToInclude: [/a^/]
         };
@@ -1281,7 +1285,7 @@ describe('XhrPlugin tests', () => {
 
     test('when the url matches urlsToTrace then the plugin records a trace', async () => {
         // Init
-        const config: PartialHttpPluginConfig = {
+        const config: Partial<HttpPluginConfig> = {
             urlsToInclude: [/\.\/response.json/]
         };
 

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -13,15 +13,6 @@ for (let i = 0; i < 256; i++) {
 
 export const X_AMZN_TRACE_ID = 'X-Amzn-Trace-Id';
 
-export type PartialHttpPluginConfig = {
-    logicalServiceName?: string;
-    urlsToInclude?: RegExp[];
-    urlsToExclude?: RegExp[];
-    stackTraceLength?: number;
-    recordAllRequests?: boolean;
-    addXRayTraceIdHeader?: boolean | RegExp[];
-};
-
 export type HttpPluginConfig = {
     logicalServiceName: string;
     urlsToInclude: RegExp[];

--- a/src/plugins/utils/performance-utils.ts
+++ b/src/plugins/utils/performance-utils.ts
@@ -7,13 +7,6 @@ export const defaultIgnore = (entry: PerformanceEntry) =>
             (entry as PerformanceResourceTiming).initiatorType
         ));
 
-export type PartialPerformancePluginConfig = {
-    eventLimit?: number;
-    ignore?: (event: PerformanceEntry) => any;
-    recordAllTypes?: ResourceType[];
-    sampleTypes?: ResourceType[];
-};
-
 export type PerformancePluginConfig = {
     eventLimit: number;
     ignore: (event: PerformanceEntry) => any;


### PR DESCRIPTION
Small cleanup, remove 57 lines by leveraging keyword `Partial<Type>`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
