### PR TITLE
chore: Only set credentials for sampled sessions

### DIFF
--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -81,6 +81,13 @@ export class EventCache {
     };
 
     /**
+     * Returns true if the session is sampled, false otherwise.
+     */
+    public isSessionSampled(): boolean {
+        return this.sessionManager.isSampled();
+    }
+
+    /**
      * Add an event to the cache and reset the session timer.
      *
      * If the session is being recorded, the event will be recorded.

--- a/src/event-cache/__tests__/EventCache.integ.test.ts
+++ b/src/event-cache/__tests__/EventCache.integ.test.ts
@@ -116,4 +116,31 @@ describe('EventCache tests', () => {
             expect(JSON.parse(event.metadata)).toMatchObject(expectedMetaData);
         });
     });
+
+    test('when a session is not sampled then return false', async () => {
+        // Init
+        const config = {
+            ...DEFAULT_CONFIG,
+            ...{
+                sessionSampleRate: 0
+            }
+        };
+
+        const eventCache: EventCache = Utils.createEventCache(config);
+
+        // Assert
+        expect(eventCache.isSessionSampled()).toBeFalsy();
+    });
+
+    test('when a session is sampled then return true', async () => {
+        // Init
+        const config = {
+            ...DEFAULT_CONFIG
+        };
+
+        const eventCache: EventCache = Utils.createEventCache(config);
+
+        // Assert
+        expect(eventCache.isSessionSampled()).toBeTruthy();
+    });
 });

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -415,6 +415,13 @@ export class Orchestration {
             this.config
         );
 
+        // Only retrieves and sets credentials if the session is sampled.
+        // The nil session created during initialization will have the same sampling decision as
+        // the new session created when the first event is recorded.
+        if (!this.eventCache.isSessionSampled()) {
+            return dispatch;
+        }
+
         if (this.config.identityPoolId && this.config.guestRoleArn) {
             dispatch.setAwsCredentials(
                 new Authentication(this.config)


### PR DESCRIPTION
Currently, the RUM web client retrieves credentials for all sessions even if the `sessionSampleRate` is < 1. In order to reduce the number of unnecessary requests to Cognito and STS, we will only set/retrieve credentials for sessions that are sampled.

To do this, we will call `getSession()` to get the session and verify if it's recorded or not. Currently, a new session is created when we get a session and it doesn't exist. This PR introduces no change to this default behavior as the new boolean variable `createIfNull`, that is checked before creating a new session, is set to `true` by default. We will only set it to `false` when retrieving the session information to determine whether the web client should retrieve credentials.

I also considered checking if the eventCache had events instead of checking if the session was recorded. However, this approach was rejected as these two scenarios could diverge. We will only check if the session is recorded to keep a single source of truth.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
