### PR TITLE
docs: fix error handler name in angular docs

### DIFF
--- a/docs/cdn_angular.md
+++ b/docs/cdn_angular.md
@@ -67,7 +67,7 @@ import { ErrorHandler } from "@angular/core";
 
 declare function cwr(operation: string, payload: any): void;
 
-export class CwrErrorHandler implements ErrorHandler {
+export class RumErrorHandler implements ErrorHandler {
   handleError(error: any) {
     cwr('recordError', error);
   }
@@ -79,7 +79,6 @@ export class CwrErrorHandler implements ErrorHandler {
 `src/app/app.module.ts`
 ```typescript
 import { RumErrorHandler } from './cwr-error-handler';
-
 @NgModule({
   imports: [
       ...
@@ -93,7 +92,7 @@ import { RumErrorHandler } from './cwr-error-handler';
   providers: [
     {
       provide: ErrorHandler,
-      useClass: CwrErrorHandler
+      useClass: RumErrorHandler
     }
   ]
 })


### PR DESCRIPTION
resolves #485 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
