### PR TITLE
fix: Record 0 for headerSize if transferSize is 0

### DIFF
--- a/src/plugins/event-plugins/NavigationPlugin.ts
+++ b/src/plugins/event-plugins/NavigationPlugin.ts
@@ -253,7 +253,10 @@ export class NavigationPlugin extends InternalPlugin {
 
             duration: entryData.duration,
 
-            headerSize: entryData.transferSize - entryData.encodedBodySize,
+            headerSize:
+                entryData.transferSize > 0
+                    ? entryData.transferSize - entryData.encodedBodySize
+                    : 0,
             transferSize: entryData.transferSize,
             compressionRatio:
                 entryData.encodedBodySize > 0

--- a/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/NavigationPlugin.test.ts
@@ -46,6 +46,23 @@ describe('NavigationPlugin tests', () => {
         );
     });
 
+    test('When transferSize is 0 then headerSize is 0', async () => {
+        const plugin: NavigationPlugin = buildNavigationPlugin();
+        // Run
+        plugin.load(context);
+        window.dispatchEvent(new Event('load'));
+        plugin.disable();
+
+        expect(record.mock.calls[0][0]).toEqual(
+            PERFORMANCE_NAVIGATION_EVENT_TYPE
+        );
+        expect(record.mock.calls[0][1]).toEqual(
+            expect.objectContaining({
+                headerSize: 0
+            })
+        );
+    });
+
     test('When navigation timing level 2 API is not present then navigation timing level 1 API is recorded', async () => {
         jest.useFakeTimers();
         mockPerformanceObjectWith([putRumEventsDocument], [], []);

--- a/src/test-utils/mock-data.ts
+++ b/src/test-utils/mock-data.ts
@@ -41,7 +41,7 @@ export const navigationEvent = {
     secureConnectionStart: 6.495000001450535,
     serverTiming: [],
     startTime: 0,
-    transferSize: 36525,
+    transferSize: 0,
     type: 'navigate',
     unloadEventEnd: 0,
     unloadEventStart: 0,


### PR DESCRIPTION
The navigation event schema validates that the `transferSize` field is non-negative. The `transferSize` field is currently calculated by: `headerSize - encodedBodySize`. However, [`headerSize` is 0 if it the resource was instantaneously retrieved from a cache](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize). This results in a negative `headerSize` and thus, an invalid event that is dropped by CWR DP. 

This PR adds a check to ensure `transferSize` is greater than 0 when calculating the `headerSize`. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
