### PR TITLE
fix: Invalidate cognito identity and re-try

### DIFF
--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -100,7 +100,9 @@ export class CognitoIdentityClient {
             const { response } = await this.fetchRequestHandler.handle(
                 tokenRequest
             );
-            return (await responseToJson(response)) as OpenIdTokenResponse;
+            return this.validateOpenIdTokenResponse(
+                await responseToJson(response)
+            );
         } catch (e) {
             throw new Error(
                 `CWR: Failed to retrieve Cognito OpenId token: ${e}`
@@ -120,13 +122,10 @@ export class CognitoIdentityClient {
             const { response } = await this.fetchRequestHandler.handle(
                 credentialRequest
             );
-            const credentialsResponse = (await responseToJson(
-                response
-            )) as CredentialsResponse;
-            this.validateCredenentialsResponse(credentialsResponse);
-            const Credentials = credentialsResponse.Credentials;
             const { AccessKeyId, Expiration, SecretKey, SessionToken } =
-                Credentials;
+                this.validateCredenentialsResponse(
+                    await responseToJson(response)
+                );
             return {
                 accessKeyId: AccessKeyId as string,
                 secretAccessKey: SecretKey as string,
@@ -140,19 +139,37 @@ export class CognitoIdentityClient {
         }
     };
 
-    private validateCredenentialsResponse = (cr: any) => {
-        if (
-            cr &&
-            cr.__type &&
-            (cr.__type === 'ResourceNotFoundException' ||
-                cr.__type === 'ValidationException')
-        ) {
+    private validateOpenIdTokenResponse = (r: any): OpenIdTokenResponse => {
+        if ('IdentityId' in r && 'Token' in r) {
+            return r as OpenIdTokenResponse;
+        } else if (r && '__type' in r && 'message' in r) {
             // The request may have failed because of ValidationException or
             // ResourceNotFoundException, which means the identity Id is bad. In
             // any case, we invalidate the identity Id so the entire process can
             // be re-tried.
             localStorage.removeItem(IDENTITY_KEY);
-            throw new Error(`${cr.__type}: ${cr.message}`);
+            throw new Error(`${r.__type}: ${r.message}`);
+        } else {
+            // We don't recognize ths response format.
+            localStorage.removeItem(IDENTITY_KEY);
+            throw new Error('Unknown OpenIdToken response');
+        }
+    };
+
+    private validateCredenentialsResponse = (r: any): CognitoCredentials => {
+        if ('IdentityId' in r && 'Credentials' in r) {
+            return (r as CredentialsResponse).Credentials;
+        } else if (r && '__type' in r && 'message' in r) {
+            // The request may have failed because of ValidationException or
+            // ResourceNotFoundException, which means the identity Id is bad. In
+            // any case, we invalidate the identity Id so the entire process can
+            // be re-tried.
+            localStorage.removeItem(IDENTITY_KEY);
+            throw new Error(`${r.__type}: ${r.message}`);
+        } else {
+            // We don't recognize ths response format.
+            localStorage.removeItem(IDENTITY_KEY);
+            throw new Error('Unknown Credentials response');
         }
     };
 

--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -104,6 +104,7 @@ export class CognitoIdentityClient {
                 await responseToJson(response)
             );
         } catch (e) {
+            localStorage.removeItem(IDENTITY_KEY);
             throw new Error(
                 `CWR: Failed to retrieve Cognito OpenId token: ${e}`
             );
@@ -133,6 +134,7 @@ export class CognitoIdentityClient {
                 expiration: new Date(Expiration * 1000)
             };
         } catch (e) {
+            localStorage.removeItem(IDENTITY_KEY);
             throw new Error(
                 `CWR: Failed to retrieve credentials for Cognito identity: ${e}`
             );
@@ -147,11 +149,9 @@ export class CognitoIdentityClient {
             // ResourceNotFoundException, which means the identity Id is bad. In
             // any case, we invalidate the identity Id so the entire process can
             // be re-tried.
-            localStorage.removeItem(IDENTITY_KEY);
             throw new Error(`${r.__type}: ${r.message}`);
         } else {
             // We don't recognize ths response format.
-            localStorage.removeItem(IDENTITY_KEY);
             throw new Error('Unknown OpenIdToken response');
         }
     };
@@ -164,11 +164,9 @@ export class CognitoIdentityClient {
             // ResourceNotFoundException, which means the identity Id is bad. In
             // any case, we invalidate the identity Id so the entire process can
             // be re-tried.
-            localStorage.removeItem(IDENTITY_KEY);
             throw new Error(`${r.__type}: ${r.message}`);
         } else {
             // We don't recognize ths response format.
-            localStorage.removeItem(IDENTITY_KEY);
             throw new Error('Unknown Credentials response');
         }
     };

--- a/src/dispatch/__tests__/BasicAuthentication.test.ts
+++ b/src/dispatch/__tests__/BasicAuthentication.test.ts
@@ -407,4 +407,31 @@ describe('BasicAuthentication tests', () => {
             storageExpiration.getTime()
         );
     });
+
+    test('when mockGetIdToken fails then retry', async () => {
+        const e: Error = new Error('mockGetId error');
+        mockGetIdToken.mockImplementationOnce(() => {
+            throw e;
+        });
+        // Init
+        const auth = new BasicAuthentication({
+            ...DEFAULT_CONFIG,
+            ...{
+                identityPoolId: IDENTITY_POOL_ID,
+                guestRoleArn: GUEST_ROLE_ARN
+            }
+        });
+
+        // Run
+        const credentials = await auth.ChainAnonymousCredentialsProvider();
+
+        // Assert
+        expect(credentials).toEqual(
+            expect.objectContaining({
+                accessKeyId: 'x',
+                secretAccessKey: 'y',
+                sessionToken: 'z'
+            })
+        );
+    });
 });

--- a/src/dispatch/__tests__/EnhancedAuthentication.test.ts
+++ b/src/dispatch/__tests__/EnhancedAuthentication.test.ts
@@ -380,4 +380,31 @@ describe('EnhancedAuthentication tests', () => {
             storageExpiration.getTime()
         );
     });
+
+    test('when getCredentialsForIdentity fails then retry', async () => {
+        // Init
+        mockGetId.mockImplementationOnce(() => {
+            throw new Error('mockGetId error');
+        });
+
+        const auth = new EnhancedAuthentication({
+            ...DEFAULT_CONFIG,
+            ...{
+                identityPoolId: IDENTITY_POOL_ID,
+                guestRoleArn: GUEST_ROLE_ARN
+            }
+        });
+
+        // Run
+        const credentials = await auth.ChainAnonymousCredentialsProvider();
+
+        // Assert
+        expect(credentials).toEqual(
+            expect.objectContaining({
+                accessKeyId: 'x',
+                secretAccessKey: 'y',
+                sessionToken: 'z'
+            })
+        );
+    });
 });


### PR DESCRIPTION
When the Cognito identity id (`cwr_i`) is present in localStorage, `GetOpenIdToken` (basic authflow) can fail in a way that is not recoverable (see #497). For example, this can happen when a ResourceNotFound error is returned by Cognito.

This change (1) invalidates the identity Id when Cognito throws an error during basic authflow, (2) extends error handling to unknown errors for both authflows, and (3) adds a re-try mechanism to both authflows.

Resolves #497.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
