### PR TITLE
feat: retry with new credentials on 403

### DIFF
--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -19,6 +19,20 @@ export abstract class Authentication {
     }
 
     /**
+     *
+     * @returns {boolean} if credentials were purged
+     */
+    clear(): boolean {
+        try {
+            this.credentials = undefined;
+            localStorage.removeItem(CRED_KEY);
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    /**
      * A credential provider which provides AWS credentials for an anonymous
      * (guest) user. These credentials are retrieved from the first successful
      * provider in a chain.

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -394,15 +394,9 @@ export class Orchestration {
         }
 
         if (this.config.identityPoolId && this.config.guestRoleArn) {
-            dispatch.setAwsCredentials(
-                new BasicAuthentication(this.config)
-                    .ChainAnonymousCredentialsProvider
-            );
+            dispatch.setAuthentication(new BasicAuthentication(this.config));
         } else if (this.config.identityPoolId) {
-            dispatch.setAwsCredentials(
-                new EnhancedAuthentication(this.config)
-                    .ChainAnonymousCredentialsProvider
-            );
+            dispatch.setAuthentication(new EnhancedAuthentication(this.config));
         }
 
         return dispatch;

--- a/src/orchestration/__tests__/Orchestration.test.ts
+++ b/src/orchestration/__tests__/Orchestration.test.ts
@@ -14,12 +14,14 @@ global.fetch = jest.fn();
 const enableDispatch = jest.fn();
 const disableDispatch = jest.fn();
 const setAwsCredentials = jest.fn();
+const setAuthentication = jest.fn();
 
 jest.mock('../../dispatch/Dispatch', () => ({
     Dispatch: jest.fn().mockImplementation(() => ({
         enable: enableDispatch,
         disable: disableDispatch,
-        setAwsCredentials
+        setAwsCredentials,
+        setAuthentication
     }))
 }));
 
@@ -529,7 +531,7 @@ describe('Orchestration tests', () => {
         });
 
         // Assert
-        expect(setAwsCredentials).toHaveBeenCalledTimes(0);
+        expect(setAuthentication).toHaveBeenCalledTimes(0);
 
         // Reset
         samplingDecision = true;
@@ -544,6 +546,6 @@ describe('Orchestration tests', () => {
         });
 
         // Assert
-        expect(setAwsCredentials).toHaveBeenCalledTimes(1);
+        expect(setAuthentication).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -71,6 +71,8 @@ export const is429 = (status: number) => {
     return status === 429;
 };
 
+export const is403 = (status: number) => status === 403;
+
 export const isUrlAllowed = (url: string, config: HttpPluginConfig) => {
     const include = config.urlsToInclude.some((urlPattern) =>
         urlPattern.test(url)


### PR DESCRIPTION
Credentials cached in LocalStorage may be invalid and causing a 403. In this PR, we purge the local credentials before retrying. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
