### PR TITLE
feat: add sessionLimitOverride always record by type

### DIFF
--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -101,7 +101,7 @@ export class EventCache {
         }
         this.sessionManager.getSession(); // refresh
         if (this.isCurrentUrlAllowed()) {
-            this.sessionManager.incrementSessionEventCount();
+            this.sessionManager.countEvent();
             if (this.sessionManager.shouldSample()) {
                 this.addRecordToCache(type, eventData);
             }
@@ -187,7 +187,7 @@ export class EventCache {
             return;
         }
 
-        this.sessionManager.incrementSessionEventCount();
+        this.sessionManager.countEvent();
 
         if (this.sessionManager.shouldSample()) {
             this.addRecordToCache(type, eventData);

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -101,7 +101,7 @@ export class EventCache {
         }
         this.sessionManager.getSession(); // refresh session if needed
         if (this.isCurrentUrlAllowed()) {
-            if (this.sessionManager.shouldSample()) {
+            if (this.sessionManager.shouldSample(type)) {
                 this.addRecordToCache(type, eventData);
                 this.sessionManager.countEvent();
             }

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -99,12 +99,10 @@ export class EventCache {
         if (!this.enabled) {
             return;
         }
-
+        this.sessionManager.getSession(); // refresh
         if (this.isCurrentUrlAllowed()) {
-            const session: Session = this.sessionManager.getSession();
             this.sessionManager.incrementSessionEventCount();
-
-            if (this.canRecord(session)) {
+            if (this.sessionManager.shouldSample()) {
                 this.addRecordToCache(type, eventData);
             }
         }
@@ -118,7 +116,6 @@ export class EventCache {
         if (this.isCurrentUrlAllowed()) {
             return this.sessionManager.getSession();
         }
-        return undefined;
     };
 
     /**
@@ -192,17 +189,9 @@ export class EventCache {
 
         this.sessionManager.incrementSessionEventCount();
 
-        if (this.canRecord(session)) {
+        if (this.sessionManager.shouldSample()) {
             this.addRecordToCache(type, eventData);
         }
-    };
-
-    private canRecord = (session: Session): boolean => {
-        return (
-            session.record &&
-            (session.eventCount <= this.config.sessionEventLimit ||
-                this.config.sessionEventLimit <= 0)
-        );
     };
 
     /**

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -99,11 +99,11 @@ export class EventCache {
         if (!this.enabled) {
             return;
         }
-        this.sessionManager.getSession(); // refresh
+        this.sessionManager.getSession(); // refresh session if needed
         if (this.isCurrentUrlAllowed()) {
-            this.sessionManager.countEvent();
             if (this.sessionManager.shouldSample()) {
                 this.addRecordToCache(type, eventData);
+                this.sessionManager.countEvent();
             }
         }
     };

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -15,7 +15,7 @@ const getSession = jest.fn(() => ({
 }));
 const getUserId = jest.fn(() => 'b');
 const getAttributes = jest.fn();
-const incrementSessionEventCount = jest.fn();
+const countEvent = jest.fn();
 const addSessionAttributes = jest.fn();
 let samplingDecision = true;
 let shouldSample = true;
@@ -25,7 +25,7 @@ jest.mock('../../sessions/SessionManager', () => ({
         getSession,
         getUserId,
         getAttributes,
-        incrementSessionEventCount,
+        countEvent,
         addSessionAttributes,
         isSampled,
         shouldSample: jest.fn().mockImplementation(() => shouldSample)
@@ -42,7 +42,7 @@ describe('EventCache tests', () => {
     beforeEach(() => {
         getSession.mockClear();
         getUserId.mockClear();
-        incrementSessionEventCount.mockClear();
+        countEvent.mockClear();
     });
 
     test('record does nothing when cache is disabled', async () => {

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -28,6 +28,7 @@ import { PageViewPlugin } from '../plugins/event-plugins/PageViewPlugin';
 import { PageAttributes } from '../sessions/PageManager';
 import { INSTALL_MODULE } from '../utils/constants';
 import EventBus, { Topic } from '../event-bus/EventBus';
+import { CountByType } from '../sessions/SessionManager';
 
 const DEFAULT_REGION = 'us-west-2';
 const DEFAULT_ENDPOINT = `https://dataplane.rum.${DEFAULT_REGION}.amazonaws.com`;
@@ -142,6 +143,7 @@ export interface Config {
     routeChangeComplete: number;
     routeChangeTimeout: number;
     sessionEventLimit: number;
+    sessionEventLimitOverride?: CountByType;
     sessionLengthSeconds: number;
     sessionSampleRate: number;
     /**

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -24,6 +24,13 @@ export type RecordSessionInitEvent = (
     eventData: object
 ) => void;
 
+/**
+ * Represents a mapping of RUM event types to their respective session count
+ */
+export type CountByType = {
+    [key: string]: number;
+};
+
 export type Session = {
     sessionId: string;
     record: boolean;
@@ -151,9 +158,14 @@ export class SessionManager {
         this.renewSession();
     }
 
-    public shouldSample(): boolean {
+    public shouldSample(type?: string): boolean {
         if (!this.isSampled()) {
             return false;
+        }
+
+        // Handle events with always record configuration
+        if (type && this.config.sessionEventLimitOverride?.[type] === 0) {
+            return true;
         }
 
         return (

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -157,7 +157,7 @@ export class SessionManager {
         }
 
         return (
-            this.session.eventCount <= this.config.sessionEventLimit ||
+            this.session.eventCount < this.config.sessionEventLimit ||
             this.config.sessionEventLimit <= 0
         );
     }

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -146,7 +146,7 @@ export class SessionManager {
         return NIL_UUID;
     }
 
-    public incrementSessionEventCount() {
+    public countEvent() {
         this.session.eventCount++;
         this.renewSession();
     }

--- a/src/sessions/__tests__/SessionManager.test.ts
+++ b/src/sessions/__tests__/SessionManager.test.ts
@@ -386,9 +386,9 @@ describe('SessionManager tests', () => {
         });
 
         const sessionOne = sessionManager.getSession();
-        sessionManager.incrementSessionEventCount();
-        sessionManager.incrementSessionEventCount();
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
+        sessionManager.countEvent();
+        sessionManager.countEvent();
 
         await new Promise((resolve) => setTimeout(resolve, 10));
         const sessionTwo = sessionManager.getSession();
@@ -500,11 +500,11 @@ describe('SessionManager tests', () => {
             sessionEventLimit: 2
         });
         expect(sessionManager.shouldSample()).toBe(true);
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         expect(sessionManager.shouldSample()).toBe(true);
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         expect(sessionManager.shouldSample()).toBe(true);
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         expect(sessionManager.shouldSample()).toBe(false);
     });
 
@@ -516,11 +516,11 @@ describe('SessionManager tests', () => {
             sessionEventLimit: 0
         });
         expect(sessionManager.shouldSample()).toBe(true);
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         expect(sessionManager.shouldSample()).toBe(true);
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         expect(sessionManager.shouldSample()).toBe(true);
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         expect(sessionManager.shouldSample()).toBe(true);
     });
 
@@ -625,7 +625,7 @@ describe('SessionManager tests', () => {
         expect(session.eventCount).toEqual(0);
     });
 
-    test('when cookies are allowed then incrementSessionEventCount increments session.eventCount in cookie', async () => {
+    test('when cookies are allowed then countEvent increments session.eventCount in cookie', async () => {
         // Init
         const config = {
             ...DEFAULT_CONFIG,
@@ -641,14 +641,14 @@ describe('SessionManager tests', () => {
         const sessionManager = defaultSessionManager(config);
 
         sessionManager.getSession();
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         const session = JSON.parse(atob(getCookie(SESSION_COOKIE_NAME)));
 
         // Assert
         expect(session.eventCount).toEqual(2);
     });
 
-    test('when cookies are not allowed then incrementSessionEventCount increments session.eventCount in member', async () => {
+    test('when cookies are not allowed then countEvent increments session.eventCount in member', async () => {
         // Init
         const sessionManager = defaultSessionManager({
             ...DEFAULT_CONFIG,
@@ -656,7 +656,7 @@ describe('SessionManager tests', () => {
         });
 
         sessionManager.getSession();
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         const session = sessionManager.getSession();
 
         // Assert
@@ -764,7 +764,7 @@ describe('SessionManager tests', () => {
         sessionManager.getSession();
         const userIdFromCookie1 = getCookie(USER_COOKIE_NAME);
         config.allowCookies = true;
-        sessionManager.incrementSessionEventCount();
+        sessionManager.countEvent();
         const userIdFromCookie2 = getCookie(USER_COOKIE_NAME);
 
         // Assert

--- a/src/sessions/__tests__/SessionManager.test.ts
+++ b/src/sessions/__tests__/SessionManager.test.ts
@@ -503,7 +503,7 @@ describe('SessionManager tests', () => {
         sessionManager.countEvent();
         expect(sessionManager.shouldSample()).toBe(true);
         sessionManager.countEvent();
-        expect(sessionManager.shouldSample()).toBe(true);
+        expect(sessionManager.shouldSample()).toBe(false);
         sessionManager.countEvent();
         expect(sessionManager.shouldSample()).toBe(false);
     });


### PR DESCRIPTION
### Purpose

If merged, RUM users can use the below example to bypass `sessionEventLimit` and record whatever events they need. However, this PR is limited to "always record" configuration and does not support specific limits, which would need us to migrate event counts from cookies to localStorage to avoid pollution. 

```typescript
const config: AwsRumConfig = {
    ...
    sessionEventLimitOverride: {
        'com.amazonaws.rum.http_event': 0, // always record
        'custom_type': 1 // non-zero limits are not supported in this PR, and will be handled by sessionEventLimit
    }
}
```

Documentation updates will be addressed in a separate PR. 

### Depends on

#504 

---

Engineering plan for #480 summarized here https://github.com/aws-observability/aws-rum-web/issues/480#issuecomment-1933212088


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
