### PR TITLE
chore: cleanup AwsCredentialIdentity import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,3 @@ tests_output
 logs
 .idea
 app/smoke_local.html
-
-dummy

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ tests_output
 logs
 .idea
 app/smoke_local.html
+
+dummy

--- a/src/dispatch/DataPlaneClient.ts
+++ b/src/dispatch/DataPlaneClient.ts
@@ -1,8 +1,8 @@
 import { toHex } from '@aws-sdk/util-hex-encoding';
 import { SignatureV4 } from '@aws-sdk/signature-v4';
 import {
-    CredentialProvider,
-    Credentials,
+    AwsCredentialIdentityProvider,
+    AwsCredentialIdentity,
     HttpResponse,
     RequestPresigningArguments
 } from '@aws-sdk/types';
@@ -42,7 +42,10 @@ export declare type DataPlaneClientConfig = {
     beaconRequestHandler: HttpHandler;
     endpoint: URL;
     region: string;
-    credentials: CredentialProvider | Credentials | undefined;
+    credentials:
+        | AwsCredentialIdentityProvider
+        | AwsCredentialIdentity
+        | undefined;
 };
 
 export class DataPlaneClient {


### PR DESCRIPTION
The linter is complaining about the deprecated `Credentials` when we should instead use `AwsCredentialIdentity`. These objects are identical in shape so merging this PR will have no logical effect, except to make the linter a little happier. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
