### PR TITLE
fix: Allow title override in page attributes

### DIFF
--- a/src/sessions/PageManager.ts
+++ b/src/sessions/PageManager.ts
@@ -14,7 +14,6 @@ export type Page = {
 };
 
 export type Attributes = {
-    title: string;
     pageId: string;
     parentPageId?: string;
     interaction?: number;
@@ -187,7 +186,9 @@ export class PageManager {
         customPageAttributes?: PageAttributes
     ) {
         this.attributes = {
-            title: document.title,
+            title: customPageAttributes?.pageAttributes?.title
+                ? customPageAttributes.pageAttributes.title
+                : document.title,
             pageId: page.pageId
         };
 

--- a/src/sessions/__tests__/PageManager.test.ts
+++ b/src/sessions/__tests__/PageManager.test.ts
@@ -390,6 +390,63 @@ describe('PageManager tests', () => {
         );
     });
 
+    test('when title attribute is provided then provided title takes precedence', async () => {
+        // Init
+        const pageManager: PageManager = new PageManager(
+            {
+                ...DEFAULT_CONFIG,
+                allowCookies: true
+            },
+            record
+        );
+
+        pageManager.recordPageView({
+            pageId: '/rum/home',
+            pageAttributes: {
+                title: 'testingOverride'
+            }
+        });
+
+        // Assert
+        expect(record.mock.calls[0][0]).toEqual(PAGE_VIEW_EVENT_TYPE);
+        expect(pageManager.getAttributes()).toMatchObject({
+            pageId: '/rum/home',
+            title: 'testingOverride'
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
+
+    test('when no title attribute is provided then document.title is used', async () => {
+        // Init
+        const pageManager: PageManager = new PageManager(
+            {
+                ...DEFAULT_CONFIG,
+                allowCookies: true
+            },
+            record
+        );
+
+        pageManager.recordPageView({
+            pageId: '/rum/home'
+        });
+
+        // Assert
+        expect(record.mock.calls[0][0]).toEqual(PAGE_VIEW_EVENT_TYPE);
+        expect(pageManager.getAttributes()).toMatchObject({
+            pageId: '/rum/home',
+            title: 'Amazon AWS Console'
+        });
+
+        window.removeEventListener(
+            'popstate',
+            (pageManager as any).popstateListener
+        );
+    });
+
     test('when there is no pageId difference then no pages are created', async () => {
         // Init
         const config: Config = {


### PR DESCRIPTION
For every page view, the web client updates the `title` attribute with the value in `window.document.title`. This means that  the `title` attribute still cannot be overridden (i.e., #430 did not actually solve #493).

This change allows the `title` attribute to be overridden when `recordPageView` is used.

**Before**
```
document.title = "sensitive";
pageManager.recordPageView({
            pageId: '/home',
            pageAttributes: {
                title: 'override'
            }
        });
// attributes: { pageId: '/home', title: 'sensitive' }
```

**After**
```
document.title = "sensitive";
pageManager.recordPageView({
            pageId: '/home',
            pageAttributes: {
                title: 'override'
            }
        });
// attributes: { pageId: '/home', title: 'override' }
```

### Discussion

Options for fixing this include the following.
1. Stop recording the page title.
1. Record title at the start of the session only.
1. Session attributes cannot be overwritten.
1. Allow page attributes to be overwritten.

All of these options have problems.
- Regarding (1), we stop giving users a common piece of information.
- Regarding (2), if the title changes during route changes, the new title will not be recorded.
- Regarding (3), this would create special classes of attributes.
- Regarding (4), requires the application to explicitly recording page views, and overwrite the title for each page view.

I am recommending option (4), because it has the least risk with respect to backwards compatibility. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
