### PR TITLE
feat: keep earliest event when cache is full

### DIFF
--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -216,8 +216,8 @@ export class EventCache {
         }
 
         if (this.events.length === this.config.eventCacheSize) {
-            // Make room in the cache by dropping the oldest event.
-            this.events.shift();
+            // Drop current event, prioritize the older ones
+            return;
         }
 
         // The data plane service model (i.e., LogEvents) does not adhere to the

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -217,6 +217,9 @@ export class EventCache {
 
         if (this.events.length === this.config.eventCacheSize) {
             // Drop current event, prioritize the older ones
+            // 1. Older events tend to be more relevant, such as session start
+            //    or performance entries that are attributed to web vitals
+            // 2. Dropping old events requires linear time
             return;
         }
 

--- a/src/event-cache/EventCache.ts
+++ b/src/event-cache/EventCache.ts
@@ -216,10 +216,10 @@ export class EventCache {
         }
 
         if (this.events.length === this.config.eventCacheSize) {
-            // Drop current event, prioritize the older ones
+            // Drop newest event and keep the older ones
             // 1. Older events tend to be more relevant, such as session start
             //    or performance entries that are attributed to web vitals
-            // 2. Dropping old events requires linear time
+            // 2. Dropping an old event requires linear time
             return;
         }
 

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -158,7 +158,7 @@ describe('EventCache tests', () => {
         expect(eventCache.getEventBatch()[0].type).toEqual(EVENT2_SCHEMA);
     });
 
-    test('when cache size reached, recordEvent drops oldest event', async () => {
+    test('when cache size reached, recordEvent drops the current event', async () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const EVENT2_SCHEMA = 'com.amazon.rum.event2';
@@ -175,7 +175,7 @@ describe('EventCache tests', () => {
             {
                 id: expect.stringMatching(/[0-9a-f\-]+/),
                 timestamp: new Date(),
-                type: EVENT2_SCHEMA,
+                type: EVENT1_SCHEMA,
                 metadata: `{"version":"1.0.0","aws:client":"${INSTALL_MODULE}","aws:clientVersion":"${WEB_CLIENT_VERSION}"}`,
                 details: '{}'
             }

--- a/src/event-cache/__tests__/EventCache.test.ts
+++ b/src/event-cache/__tests__/EventCache.test.ts
@@ -158,7 +158,7 @@ describe('EventCache tests', () => {
         expect(eventCache.getEventBatch()[0].type).toEqual(EVENT2_SCHEMA);
     });
 
-    test('when cache size reached, recordEvent drops the current event', async () => {
+    test('when cache size reached, recordEvent drops the newest event', async () => {
         // Init
         const EVENT1_SCHEMA = 'com.amazon.rum.event1';
         const EVENT2_SCHEMA = 'com.amazon.rum.event2';


### PR DESCRIPTION
### Problem statement

When the event cache is full, then we should drop the latest event and keep the earliest one. Currently, we are dropping the earliest event which causes two problems

1. We are causing performance issues during page load when compute resources are extremely limited. For example, if there are 300 events against a default cache limit of 200 during the initial PutRumEvents batch, then RUM will execute 100x200=20,000 operations shifting out the earliest events, when resources should instead be allocated towards loading the page. 
2. RUM users are missing important telemetries because earlier events tend to be more relevant than later ones. By keeping early events, we are more likely to capture events that attribute to page load performance, such as LCP resources. 

### Follow up

To ensure a good experience in the future, we need additional design to prioritize critical events in the cache, such as web vitals and session start. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
