### PR TITLE
chore: Update smoke tests to use enhanced auth flow

### DIFF
--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
@@ -6,7 +6,6 @@ let awsRum;
 try {
     const config: AwsRumConfig = {
         sessionSampleRate: 1,
-        guestRoleArn: $GUEST_ARN,
         identityPoolId: $IDENTITY_POOL,
         endpoint: $ENDPOINT,
         telemetries: ['performance', 'errors', 'http', 'interaction'],

--- a/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
@@ -5,7 +5,6 @@ let awsRum;
 try {
     const config: AwsRumConfig = {
         sessionSampleRate: 1,
-        guestRoleArn: $GUEST_ARN,
         identityPoolId: $IDENTITY_POOL,
         endpoint: $ENDPOINT,
         telemetries: ['performance', 'errors', 'http', 'interaction'],


### PR DESCRIPTION
Remove `guestRoleArn` from rum config to use enhanced auth flow in smoke tests. 