### PR TITLE
fix: keep alive when dispatch fails with 401

### DIFF
--- a/src/dispatch/Dispatch.ts
+++ b/src/dispatch/Dispatch.ts
@@ -38,7 +38,7 @@ export class Dispatch {
     private dispatchTimerId: number | undefined;
     private buildClient: ClientBuilder;
     private config: Config;
-    private disableCodes = ['401', '403', '404'];
+    private disableCodes = ['403', '404'];
 
     constructor(
         region: string,

--- a/src/dispatch/__tests__/Dispatch.test.ts
+++ b/src/dispatch/__tests__/Dispatch.test.ts
@@ -479,36 +479,6 @@ describe('Dispatch tests', () => {
         expect((dispatch as unknown as any).enabled).toBe(true);
     });
 
-    test('when a fetch request is rejected with 401 then dispatch is disabled', async () => {
-        // Init
-        (DataPlaneClient as any).mockImplementationOnce(() => ({
-            sendFetch: () => Promise.reject(new Error('401'))
-        }));
-
-        const eventCache: EventCache =
-            Utils.createDefaultEventCacheWithEvents();
-
-        const dispatch = new Dispatch(
-            Utils.AWS_RUM_REGION,
-            Utils.AWS_RUM_ENDPOINT,
-            eventCache,
-            {
-                ...DEFAULT_CONFIG,
-                ...{ dispatchInterval: Utils.AUTO_DISPATCH_OFF, retries: 0 }
-            }
-        );
-        dispatch.setAwsCredentials(Utils.createAwsCredentials());
-
-        // Run
-        eventCache.recordEvent('com.amazon.rum.event1', {});
-
-        // Assert
-        await expect(dispatch.dispatchFetch()).rejects.toEqual(
-            new Error('401')
-        );
-        expect((dispatch as unknown as any).enabled).toBe(false);
-    });
-
     test('when a fetch request is rejected with 403 then dispatch is disabled', async () => {
         // Init
         (DataPlaneClient as any).mockImplementationOnce(() => ({


### PR DESCRIPTION
When dispatch fails with 401, then RUM should keep alive.

RUM backend does not respond with 401 so this is change is not relevant for standard setups. However, some users have setup proxy servers with valid use cases.

For example https://github.com/aws-observability/aws-rum-web/pull/524#issuecomment-2097987765

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
