### PR TITLE
chore: Update node-version for actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
+                  node-version: '20.x'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Cache NPM modules

--- a/.github/workflows/cdn_rollback.yaml
+++ b/.github/workflows/cdn_rollback.yaml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
+                  node-version: '20.x'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Fetch AWS Credentials for Deployment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
+                  node-version: '20.x'
 
             - name: Cache NPM modules
               uses: actions/cache@v3
@@ -61,7 +61,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
+                  node-version: '20.x'
 
             - name: Cache NPM modules
               uses: actions/cache@v3

--- a/.github/workflows/npm_deprecate.yaml
+++ b/.github/workflows/npm_deprecate.yaml
@@ -21,7 +21,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '16.x'
+                  node-version: '20.x'
                   registry-url: 'https://registry.npmjs.org'
             - name: Deprecate Version
               run: npm deprecate aws-rum-web@${{ github.event.inputs.version }} ${{ github.event.inputs.message }}


### PR DESCRIPTION
We need to transition from Node16 to Node20 to use GitHub Actions that is used in our release process. Based on the [docs](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), we have to update the node-version to 20.x in the yaml files.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
