### PR TITLE
feat: support unique credential cookie names

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 src/events/*
+**/src/loader-npm-rum.ts
+**/src/loader-npm-rum-2.ts

--- a/.github/scripts/update_smoke_test.sh
+++ b/.github/scripts/update_smoke_test.sh
@@ -5,6 +5,9 @@ GUEST_ARN=$3
 IDENTITY_POOL=$4
 ENDPOINT=$5
 CDN=$6
+MONITOR_ID_2=$7
+GUEST_ARN_2=$8
+IDENTITY_POOL_2=$9
 VERSION=$(npm pkg get version | sed 's/"//g')/cwr.js
 CDN+=${VERSION}
 
@@ -16,6 +19,12 @@ awk '{sub(/\$MONITOR_ID/,MONITOR_ID);sub(/\$REGION/,REGION);sub(/\$CDN/,CDN);sub
 awk '{sub(/\$MONITOR_ID/,MONITOR_ID);sub(/\$REGION/,REGION);sub(/\$CDN/,CDN);sub(/\$GUEST_ARN/,GUEST_ARN);sub(/\$IDENTITY_POOL/,IDENTITY_POOL);sub(/\$ENDPOINT/,ENDPOINT);}1' \
  MONITOR_ID="'$MONITOR_ID'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN="'$GUEST_ARN'" IDENTITY_POOL="'$IDENTITY_POOL'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts > smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-tmp.ts
 
+awk '{sub(/\$MONITOR_ID_2/,MONITOR_ID_2);sub(/\$REGION/,REGION);sub(/\$CDN/,CDN);sub(/\$GUEST_ARN_2/,GUEST_ARN_2);sub(/\$IDENTITY_POOL_2/,IDENTITY_POOL_2);sub(/\$ENDPOINT/,ENDPOINT);}1' \
+ MONITOR_ID_2="'$MONITOR_ID_2'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN_2="'$GUEST_ARN_2'" IDENTITY_POOL_2="'$IDENTITY_POOL_2'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-2.ts > smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-tmp-2.ts
+
 # Module CJS
 awk '{sub(/\$MONITOR_ID/,MONITOR_ID);sub(/\$REGION/,REGION);sub(/\$CDN/,CDN);sub(/\$GUEST_ARN/,GUEST_ARN);sub(/\$IDENTITY_POOL/,IDENTITY_POOL);sub(/\$ENDPOINT/,ENDPOINT);}1' \
  MONITOR_ID="'$MONITOR_ID'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN="'$GUEST_ARN'" IDENTITY_POOL="'$IDENTITY_POOL'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts > smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-tmp.ts
+
+awk '{sub(/\$MONITOR_ID_2/,MONITOR_ID_2);sub(/\$REGION/,REGION);sub(/\$CDN/,CDN);sub(/\$GUEST_ARN_2/,GUEST_ARN_2);sub(/\$IDENTITY_POOL_2/,IDENTITY_POOL_2);sub(/\$ENDPOINT/,ENDPOINT);}1' \
+ MONITOR_ID_2="'$MONITOR_ID_2'" REGION="'$REGION'" CDN="'$CDN'" GUEST_ARN_2="'$GUEST_ARN_2'" IDENTITY_POOL_2="'$IDENTITY_POOL_2'" ENDPOINT="'$ENDPOINT'" smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-2.ts > smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-tmp-2.ts

--- a/.github/scripts/upload_smoke_test.sh
+++ b/.github/scripts/upload_smoke_test.sh
@@ -7,7 +7,9 @@ aws s3api put-object --bucket $bucket --key "smoke-$version.html" --body process
 # NPM ES 
 aws s3api put-object --bucket $bucket --key "npm/es/$version/smoke.html" --body smoke/smoke-test-application-NPM-ES/app/smoke.html --content-type "text/html"
 aws s3api put-object --bucket $bucket --key "npm/es/$version/loader_npm_rum_tmp.js" --body smoke/smoke-test-application-NPM-ES/build/dev/loader_npm_rum_tmp.js --content-type application/x-javascript
+aws s3api put-object --bucket $bucket --key "npm/es/$version/loader_npm_rum_tmp_2.js" --body smoke/smoke-test-application-NPM-ES/build/dev/loader_npm_rum_tmp_2.js --content-type application/x-javascript
 
 # NPM CJS
 aws s3api put-object --bucket $bucket --key "npm/cjs/$version/smoke.html" --body smoke/smoke-test-application-NPM-CJS/app/smoke.html --content-type "text/html"
 aws s3api put-object --bucket $bucket --key "npm/cjs/$version/loader_npm_rum_tmp.js" --body smoke/smoke-test-application-NPM-CJS/build/dev/loader_npm_rum_tmp.js --content-type application/x-javascript
+aws s3api put-object --bucket $bucket --key "npm/cjs/$version/loader_npm_rum_tmp_2.js" --body smoke/smoke-test-application-NPM-CJS/build/dev/loader_npm_rum_tmp_2.js --content-type application/x-javascript

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -124,7 +124,6 @@ jobs:
               env:
                   URL: ${{ secrets.SMOKE_URL }}
                   MONITOR: ${{ secrets.SMOKE_MONITOR }}
-                  MONITOR2: ${{ secrets.SMOKE_MONITOR_2 }}
                   ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
                   NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
                   INSTALL_METHOD: 'CDN'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -74,7 +74,7 @@ jobs:
               id: update-smoke-test-gamma-cdn
               run: |
                   chmod u+x .github/scripts/update_smoke_test.sh
-                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN_GAMMA }}
+                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN_GAMMA }} ${{ secrets.SMOKE_MONITOR_2 }} ${{ secrets.SMOKE_ARN_2 }} ${{ secrets.SMOKE_IDENTITY_2 }}
 
             - name: Build Smoke Test Application - NPM/ES
               id: build-npm-es-application-pre-release
@@ -98,6 +98,7 @@ jobs:
               env:
                   URL: ${{ secrets.SMOKE_URL }}
                   MONITOR: ${{ secrets.SMOKE_MONITOR }}
+                  MONITOR2: ${{ secrets.SMOKE_MONITOR_2 }}
                   ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
                   NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
                   INSTALL_METHOD: 'NPM-ES'
@@ -110,6 +111,7 @@ jobs:
               env:
                   URL: ${{ secrets.SMOKE_URL }}
                   MONITOR: ${{ secrets.SMOKE_MONITOR }}
+                  MONITOR_2: ${{ secrets.SMOKE_MONITOR_2 }}
                   ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
                   NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
                   INSTALL_METHOD: 'NPM-CJS'
@@ -122,6 +124,7 @@ jobs:
               env:
                   URL: ${{ secrets.SMOKE_URL }}
                   MONITOR: ${{ secrets.SMOKE_MONITOR }}
+                  MONITOR2: ${{ secrets.SMOKE_MONITOR_2 }}
                   ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
                   NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
                   INSTALL_METHOD: 'CDN'
@@ -129,87 +132,88 @@ jobs:
                   curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
                   npm run smoke:headless
 
-            - name: Fetch AWS Credentials for Prod Deployment
-              run: |
-                  export AWS_ROLE_ARN=${{ secrets.ROLE }}
-                  export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-                  export AWS_DEFAULT_REGION=us-east-1
+            # - name: Fetch AWS Credentials for Prod Deployment
+            #   run: |
+            #       export AWS_ROLE_ARN=${{ secrets.ROLE }}
+            #       export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
+            #       export AWS_DEFAULT_REGION=us-east-1
 
-                  echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-                  echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-                  echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
+            #       echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
+            #       echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
+            #       echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
 
-                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+            #       curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
 
-            - name: Publish to CloudWatch RUM Prod CDN
-              id: publish-cdn-prod
-              run: |
-                  chmod u+x .github/scripts/deploy.sh
-                  .github/scripts/deploy.sh ${{ secrets.BUCKET }}
+            # - name: Publish to CloudWatch RUM Prod CDN
+            #   id: publish-cdn-prod
+            #   run: |
+            #       chmod u+x .github/scripts/deploy.sh
+            #       .github/scripts/deploy.sh ${{ secrets.BUCKET }}
 
-            - name: Validate Prod versions.csv file
-              run: |
-                  chmod u+x .github/scripts/validate_versions.sh
-                  .github/scripts/validate_versions.sh ${{ secrets.BUCKET }}
+            # - name: Validate Prod versions.csv file
+            #   run: |
+            #       chmod u+x .github/scripts/validate_versions.sh
+            #       .github/scripts/validate_versions.sh ${{ secrets.BUCKET }}
 
-            - name: Fetch AWS Credentials for Prod Smoke Test
-              run: |
-                  export AWS_ROLE_ARN=${{ secrets.SMOKE_TEST_ROLE }}
-                  export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-                  export AWS_DEFAULT_REGION=us-east-1
+            # - name: Fetch AWS Credentials for Prod Smoke Test
+            #   run: |
+            #       export AWS_ROLE_ARN=${{ secrets.SMOKE_TEST_ROLE }}
+            #       export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
+            #       export AWS_DEFAULT_REGION=us-east-1
 
-                  echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-                  echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-                  echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
+            #       echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
+            #       echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
+            #       echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
 
-                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+            #       curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
 
-            - name: Update Prod Smoke Test Application
-              id: update-smoke-test-prod-cdn
-              run: |
-                  chmod u+x .github/scripts/update_smoke_test.sh
-                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }}
+            # - name: Update Prod Smoke Test Application
+            #   id: update-smoke-test-prod-cdn
+            #   run: |
+            #       chmod u+x .github/scripts/update_smoke_test.sh
+            #       .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }} ${{ secrets.SMOKE_MONITOR_2 }} ${{ secrets.SMOKE_ARN_2 }} ${{ secrets.SMOKE_IDENTITY_2 }}
 
-            - name: Upload Prod Smoke Tests to CloudFront
-              id: upload-smoke-test-prod
-              run: |
-                  chmod u+x .github/scripts/upload_smoke_test.sh
-                  .github/scripts/upload_smoke_test.sh ${{ secrets.SMOKE_BUCKET }}
+            # - name: Upload Prod Smoke Tests to CloudFront
+            #   id: upload-smoke-test-prod
+            #   run: |
+            #       chmod u+x .github/scripts/upload_smoke_test.sh
+            #       .github/scripts/upload_smoke_test.sh ${{ secrets.SMOKE_BUCKET }}
 
-            - name: Run Prod Smoke Test (CDN)
-              env:
-                  URL: ${{ secrets.SMOKE_URL }}
-                  MONITOR: ${{ secrets.SMOKE_MONITOR }}
-                  ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
-                  NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
-                  INSTALL_METHOD: 'CDN'
-              run: npm run smoke:headless
+            # - name: Run Prod Smoke Test (CDN)
+            #   env:
+            #       URL: ${{ secrets.SMOKE_URL }}
+            #       MONITOR: ${{ secrets.SMOKE_MONITOR }}
+            #       MONITOR_2: ${{ secrets.SMOKE_MONITOR_2 }}
+            #       ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
+            #       NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
+            #       INSTALL_METHOD: 'CDN'
+            #   run: npm run smoke:headless
 
-            - name: Publish to NPM
-              run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            # - name: Publish to NPM
+            #   run: npm publish
+            #   env:
+            #       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Build Smoke Test Application - NPM/ES (Post NPM Release)
-              id: build-npm-es-application-post-release
-              run: |
-                  chmod u+x .github/scripts/build_npm_applications.sh
-                  .github/scripts/build_npm_applications.sh "POST" "NPM-ES"
+            # - name: Build Smoke Test Application - NPM/ES (Post NPM Release)
+            #   id: build-npm-es-application-post-release
+            #   run: |
+            #       chmod u+x .github/scripts/build_npm_applications.sh
+            #       .github/scripts/build_npm_applications.sh "POST" "NPM-ES"
 
-            - name: Build Smoke Test Application - NPM/CJS (Post NPM Release)
-              id: build-npm-cjs-application-post-release
-              run: |
-                  chmod u+x .github/scripts/build_npm_applications.sh
-                  .github/scripts/build_npm_applications.sh "POST" "NPM-CJS"
+            # - name: Build Smoke Test Application - NPM/CJS (Post NPM Release)
+            #   id: build-npm-cjs-application-post-release
+            #   run: |
+            #       chmod u+x .github/scripts/build_npm_applications.sh
+            #       .github/scripts/build_npm_applications.sh "POST" "NPM-CJS"
 
-            - name: Create GitHub Release
-              id: create_release
-              uses: actions/create-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  tag_name: 'v${{ steps.publish-cdn.outputs.current-version }}'
-                  release_name: 'Release ${{ steps.publish-cdn.outputs.current-version }}'
-                  body: 'See [CHANGELOG](https://github.com/aws-observability/aws-rum-web/blob/main/CHANGELOG.md) for details.'
-                  draft: true
-                  prerelease: false
+            # - name: Create GitHub Release
+            #   id: create_release
+            #   uses: actions/create-release@v1
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            #   with:
+            #       tag_name: 'v${{ steps.publish-cdn.outputs.current-version }}'
+            #       release_name: 'Release ${{ steps.publish-cdn.outputs.current-version }}'
+            #       body: 'See [CHANGELOG](https://github.com/aws-observability/aws-rum-web/blob/main/CHANGELOG.md) for details.'
+            #       draft: true
+            #       prerelease: false

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -132,88 +132,88 @@ jobs:
                   curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
                   npm run smoke:headless
 
-            # - name: Fetch AWS Credentials for Prod Deployment
-            #   run: |
-            #       export AWS_ROLE_ARN=${{ secrets.ROLE }}
-            #       export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-            #       export AWS_DEFAULT_REGION=us-east-1
+            - name: Fetch AWS Credentials for Prod Deployment
+              run: |
+                  export AWS_ROLE_ARN=${{ secrets.ROLE }}
+                  export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
+                  export AWS_DEFAULT_REGION=us-east-1
 
-            #       echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-            #       echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-            #       echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
+                  echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
+                  echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
+                  echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
 
-            #       curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
 
-            # - name: Publish to CloudWatch RUM Prod CDN
-            #   id: publish-cdn-prod
-            #   run: |
-            #       chmod u+x .github/scripts/deploy.sh
-            #       .github/scripts/deploy.sh ${{ secrets.BUCKET }}
+            - name: Publish to CloudWatch RUM Prod CDN
+              id: publish-cdn-prod
+              run: |
+                  chmod u+x .github/scripts/deploy.sh
+                  .github/scripts/deploy.sh ${{ secrets.BUCKET }}
 
-            # - name: Validate Prod versions.csv file
-            #   run: |
-            #       chmod u+x .github/scripts/validate_versions.sh
-            #       .github/scripts/validate_versions.sh ${{ secrets.BUCKET }}
+            - name: Validate Prod versions.csv file
+              run: |
+                  chmod u+x .github/scripts/validate_versions.sh
+                  .github/scripts/validate_versions.sh ${{ secrets.BUCKET }}
 
-            # - name: Fetch AWS Credentials for Prod Smoke Test
-            #   run: |
-            #       export AWS_ROLE_ARN=${{ secrets.SMOKE_TEST_ROLE }}
-            #       export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
-            #       export AWS_DEFAULT_REGION=us-east-1
+            - name: Fetch AWS Credentials for Prod Smoke Test
+              run: |
+                  export AWS_ROLE_ARN=${{ secrets.SMOKE_TEST_ROLE }}
+                  export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/awscreds
+                  export AWS_DEFAULT_REGION=us-east-1
 
-            #       echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
-            #       echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
-            #       echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
+                  echo AWS_WEB_IDENTITY_TOKEN_FILE=$AWS_WEB_IDENTITY_TOKEN_FILE >> $GITHUB_ENV
+                  echo AWS_ROLE_ARN=$AWS_ROLE_ARN >> $GITHUB_ENV
+                  echo AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION >> $GITHUB_ENV
 
-            #       curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
+                  curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value' > $AWS_WEB_IDENTITY_TOKEN_FILE
 
-            # - name: Update Prod Smoke Test Application
-            #   id: update-smoke-test-prod-cdn
-            #   run: |
-            #       chmod u+x .github/scripts/update_smoke_test.sh
-            #       .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }} ${{ secrets.SMOKE_MONITOR_2 }} ${{ secrets.SMOKE_ARN_2 }} ${{ secrets.SMOKE_IDENTITY_2 }}
+            - name: Update Prod Smoke Test Application
+              id: update-smoke-test-prod-cdn
+              run: |
+                  chmod u+x .github/scripts/update_smoke_test.sh
+                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }} ${{ secrets.SMOKE_MONITOR_2 }} ${{ secrets.SMOKE_ARN_2 }} ${{ secrets.SMOKE_IDENTITY_2 }}
 
-            # - name: Upload Prod Smoke Tests to CloudFront
-            #   id: upload-smoke-test-prod
-            #   run: |
-            #       chmod u+x .github/scripts/upload_smoke_test.sh
-            #       .github/scripts/upload_smoke_test.sh ${{ secrets.SMOKE_BUCKET }}
+            - name: Upload Prod Smoke Tests to CloudFront
+              id: upload-smoke-test-prod
+              run: |
+                  chmod u+x .github/scripts/upload_smoke_test.sh
+                  .github/scripts/upload_smoke_test.sh ${{ secrets.SMOKE_BUCKET }}
 
-            # - name: Run Prod Smoke Test (CDN)
-            #   env:
-            #       URL: ${{ secrets.SMOKE_URL }}
-            #       MONITOR: ${{ secrets.SMOKE_MONITOR }}
-            #       MONITOR_2: ${{ secrets.SMOKE_MONITOR_2 }}
-            #       ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
-            #       NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
-            #       INSTALL_METHOD: 'CDN'
-            #   run: npm run smoke:headless
+            - name: Run Prod Smoke Test (CDN)
+              env:
+                  URL: ${{ secrets.SMOKE_URL }}
+                  MONITOR: ${{ secrets.SMOKE_MONITOR }}
+                  MONITOR_2: ${{ secrets.SMOKE_MONITOR_2 }}
+                  ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
+                  NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
+                  INSTALL_METHOD: 'CDN'
+              run: npm run smoke:headless
 
-            # - name: Publish to NPM
-            #   run: npm publish
-            #   env:
-            #       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: Publish to NPM
+              run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            # - name: Build Smoke Test Application - NPM/ES (Post NPM Release)
-            #   id: build-npm-es-application-post-release
-            #   run: |
-            #       chmod u+x .github/scripts/build_npm_applications.sh
-            #       .github/scripts/build_npm_applications.sh "POST" "NPM-ES"
+            - name: Build Smoke Test Application - NPM/ES (Post NPM Release)
+              id: build-npm-es-application-post-release
+              run: |
+                  chmod u+x .github/scripts/build_npm_applications.sh
+                  .github/scripts/build_npm_applications.sh "POST" "NPM-ES"
 
-            # - name: Build Smoke Test Application - NPM/CJS (Post NPM Release)
-            #   id: build-npm-cjs-application-post-release
-            #   run: |
-            #       chmod u+x .github/scripts/build_npm_applications.sh
-            #       .github/scripts/build_npm_applications.sh "POST" "NPM-CJS"
+            - name: Build Smoke Test Application - NPM/CJS (Post NPM Release)
+              id: build-npm-cjs-application-post-release
+              run: |
+                  chmod u+x .github/scripts/build_npm_applications.sh
+                  .github/scripts/build_npm_applications.sh "POST" "NPM-CJS"
 
-            # - name: Create GitHub Release
-            #   id: create_release
-            #   uses: actions/create-release@v1
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            #   with:
-            #       tag_name: 'v${{ steps.publish-cdn.outputs.current-version }}'
-            #       release_name: 'Release ${{ steps.publish-cdn.outputs.current-version }}'
-            #       body: 'See [CHANGELOG](https://github.com/aws-observability/aws-rum-web/blob/main/CHANGELOG.md) for details.'
-            #       draft: true
-            #       prerelease: false
+            - name: Create GitHub Release
+              id: create_release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: 'v${{ steps.publish-cdn.outputs.current-version }}'
+                  release_name: 'Release ${{ steps.publish-cdn.outputs.current-version }}'
+                  body: 'See [CHANGELOG](https://github.com/aws-observability/aws-rum-web/blob/main/CHANGELOG.md) for details.'
+                  draft: true
+                  prerelease: false

--- a/.github/workflows/cdn_rollback.yaml
+++ b/.github/workflows/cdn_rollback.yaml
@@ -66,7 +66,7 @@ jobs:
               id: update-smoke-test
               run: |
                   chmod u+x .github/scripts/update_smoke_test.sh
-                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }} >> processed_smoke.html
+                  .github/scripts/update_smoke_test.sh ${{ secrets.SMOKE_MONITOR }} ${{ secrets.SMOKE_REGION }} ${{ secrets.SMOKE_ARN }} ${{ secrets.SMOKE_IDENTITY }} ${{ secrets.CONFIG_ENDPOINT }} ${{ secrets.CDN }} ${{ secrets.SMOKE_MONITOR_2 }} ${{ secrets.SMOKE_ARN_2 }} ${{ secrets.SMOKE_IDENTITY_2 }} >> processed_smoke.html
 
             - name: Upload Smoke Test to CloudFront
               id: upload-smoke-test
@@ -81,6 +81,7 @@ jobs:
               env:
                   URL: ${{ secrets.SMOKE_URL }}
                   MONITOR: ${{ secrets.SMOKE_MONITOR }}
+                  MONITOR_2: ${{ secrets.SMOKE_MONITOR_2 }}
                   ENDPOINT: ${{ secrets.SMOKE_ENDPOINT }}
                   NAME: ${{ secrets.SMOKE_MONITOR_NAME }}
               run: npm run smoke:headless

--- a/app/smoke.html
+++ b/app/smoke.html
@@ -40,40 +40,6 @@
             });
         </script>
 
-        <script>
-            (function (n, i, v, r, s, c, x, z) {
-                x = window.AwsRumClient = {
-                    q: [],
-                    n: n,
-                    i: i,
-                    v: v,
-                    r: r,
-                    c: c
-                };
-                window[n] = function (c, p) {
-                    x.q.push({ c: c, p: p });
-                };
-                z = document.createElement('script');
-                z.async = true;
-                z.src = s;
-                document.head.insertBefore(
-                    z,
-                    document.getElementsByTagName('script')[0]
-                );
-            })('cwr', $MONITOR_ID_2, '1.0.0', $REGION, $CDN, {
-                sessionSampleRate: 1,
-                guestRoleArn: $GUEST_ARN_2,
-                identityPoolId: $IDENTITY_POOL_2,
-                endpoint: $ENDPOINT,
-                telemetries: ['performance', 'errors', 'http', 'interaction'],
-                allowCookies: true,
-                enableXRay: true,
-                cookieAttributes: {
-                    unique: true
-                }
-            });
-        </script>
-
         <link
             rel="icon"
             type="image/png"

--- a/app/smoke.html
+++ b/app/smoke.html
@@ -33,7 +33,44 @@
                 endpoint: $ENDPOINT,
                 telemetries: ['performance', 'errors', 'http', 'interaction'],
                 allowCookies: true,
-                enableXRay: true
+                enableXRay: true,
+                cookieAttributes: {
+                    unique: true
+                }
+            });
+        </script>
+
+        <script>
+            (function (n, i, v, r, s, c, x, z) {
+                x = window.AwsRumClient = {
+                    q: [],
+                    n: n,
+                    i: i,
+                    v: v,
+                    r: r,
+                    c: c
+                };
+                window[n] = function (c, p) {
+                    x.q.push({ c: c, p: p });
+                };
+                z = document.createElement('script');
+                z.async = true;
+                z.src = s;
+                document.head.insertBefore(
+                    z,
+                    document.getElementsByTagName('script')[0]
+                );
+            })('cwr', $MONITOR_ID_2, '1.0.0', $REGION, $CDN, {
+                sessionSampleRate: 1,
+                guestRoleArn: $GUEST_ARN_2,
+                identityPoolId: $IDENTITY_POOL_2,
+                endpoint: $ENDPOINT,
+                telemetries: ['performance', 'errors', 'http', 'interaction'],
+                allowCookies: true,
+                enableXRay: true,
+                cookieAttributes: {
+                    unique: true
+                }
             });
         </script>
 

--- a/app/smoke.html
+++ b/app/smoke.html
@@ -33,10 +33,7 @@
                 endpoint: $ENDPOINT,
                 telemetries: ['performance', 'errors', 'http', 'interaction'],
                 allowCookies: true,
-                enableXRay: true,
-                cookieAttributes: {
-                    unique: true
-                }
+                enableXRay: true
             });
         </script>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ For example, the config object may look similar to the following:
 | path | String | `/` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
 | sameSite | Boolean | `true` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
 | secure | Boolean | `true` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
-| unique | Boolean | `false` | When this field is `false`, the session cookie name is `cwr_s`. When this field is `true`, the session cookie name is `cwr_s_[AppMonitor Id]`.<br/><br/>Set this field to `true` when multiple AppMonitors will monitor the same page. For example, this might be the case if one AppMonitor is used for logged-in users, and a second AppMonitor is used for guest users.  |
+| unique | Boolean | `false` | When this field is `false`, the session cookie name is `cwr_s` and the credential cookie name is `cwr_c`. When this field is `true`, the session cookie name is `cwr_s_[AppMonitor Id]` and the credential cookie name is `cwr_c_[AppMonitor Id]`.<br/><br/>Set this field to `true` when multiple AppMonitors will monitor the same page. For example, this might be the case if one AppMonitor is used for logged-in users, and a second AppMonitor is used for guest users.  |
 
 ## MetadataAttributes
 You may add up to 10 custom attributes per event. Custom attributes are

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ For example, the config object may look similar to the following:
 | path | String | `/` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
 | sameSite | Boolean | `true` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
 | secure | Boolean | `true` | See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent |
-| unique | Boolean | `false` | When this field is `false`, the session cookie name is `cwr_s` and the credential cookie name is `cwr_c`. When this field is `true`, the session cookie name is `cwr_s_[AppMonitor Id]` and the credential cookie name is `cwr_c_[AppMonitor Id]`.<br/><br/>Set this field to `true` when multiple AppMonitors will monitor the same page. For example, this might be the case if one AppMonitor is used for logged-in users, and a second AppMonitor is used for guest users.  |
+| unique | Boolean | `false` | When this field is `false`, the session cookie name is `cwr_s` and the credential cookie name is `cwr_c`. When this field is `true`, the session cookie name is `cwr_s_[AppMonitor Id]` and the credential cookie name is `cwr_c_[AppMonitor Id]`.<br/><br/>Set this field to `true` when multiple AppMonitors will monitor the same page. For example, this might be the case if one AppMonitor is used for logged-in users, and a second AppMonitor is used for guest users. |
 
 ## MetadataAttributes
 

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
         "preinteg:local:nightwatch:firefox": "http-server ./build/dev -s &",
         "integ:local:nightwatch:firefox": "nightwatch -e firefox",
         "postinteg:local:nightwatch:firefox": "kill $(lsof -t -i:8080)",
-        "smoke:local:headless": "cross-env URL=$URL MONITOR_ID=$MONITOR ENDPOINT=$ENDPOINT NAME=$NAME VERSION=$npm_package_version npx playwright test --config=playwright.local.config.ts",
-        "smoke:local": "cross-env URL=$URL MONITOR_ID=$MONITOR ENDPOINT=$ENDPOINT NAME=$NAME VERSION=$npm_package_version npx playwright test --config=playwright.local.config.ts --headed",
-        "smoke:headless": "cross-env URL=$URL MONITOR_ID=$MONITOR ENDPOINT=$ENDPOINT NAME=$NAME VERSION=$npm_package_version INSTALL_METHOD=$INSTALL_METHOD npx playwright test --config=playwright.config.ts",
+        "smoke:local:headless": "cross-env URL=$URL MONITOR_ID=$MONITOR ENDPOINT=$ENDPOINT NAME=$NAME VERSION=$npm_package_version MONITOR_ID_2=$MONITOR_ID_2 npx playwright test --config=playwright.local.config.ts",
+        "smoke:local": "cross-env URL=$URL MONITOR_ID=$MONITOR ENDPOINT=$ENDPOINT NAME=$NAME VERSION=$npm_package_version MONITOR_ID_2=$MONITOR_ID_2 npx playwright test --config=playwright.local.config.ts --headed",
+        "smoke:headless": "cross-env URL=$URL MONITOR_ID=$MONITOR ENDPOINT=$ENDPOINT NAME=$NAME VERSION=$npm_package_version INSTALL_METHOD=$INSTALL_METHOD MONITOR_ID_2=$MONITOR_ID_2 npx playwright test --config=playwright.config.ts",
         "prepare": "husky install"
     },
     "devDependencies": {

--- a/smoke/smoke-test-application-NPM-CJS/app/smoke.html
+++ b/smoke/smoke-test-application-NPM-CJS/app/smoke.html
@@ -8,6 +8,19 @@
         <title>RUM Smoke Test</title>
 
         <script type="text/javascript" src="./loader_npm_rum_tmp.js"></script>
+        <script>
+            function loadScriptWithDelay() {
+                setTimeout(function () {
+                    var script = document.createElement('script');
+                    script.type = 'text/javascript';
+                    script.src = './loader_npm_rum_tmp_2.js';
+                    document.head.appendChild(script);
+                }, 10000); // 10 seconds
+            }
+
+            // Call the function to load the script with a delay
+            loadScriptWithDelay();
+        </script>
 
         <link
             rel="icon"

--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-2.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-2.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
-import { AwsRum, AwsRumConfig } from 'aws-rum-web';
+const { AwsRum, AwsRumConfig } = require('aws-rum-web');
 
 let awsRum;
 
 try {
     const config: AwsRumConfig = {
         sessionSampleRate: 1,
-        identityPoolId: $IDENTITY_POOL,
+        identityPoolId: $IDENTITY_POOL_2,
         endpoint: $ENDPOINT,
         telemetries: ['performance', 'errors', 'http', 'interaction'],
         allowCookies: true,
@@ -16,7 +16,7 @@ try {
         }
     };
 
-    const APPLICATION_ID: string = $MONITOR_ID;
+    const APPLICATION_ID: string = $MONITOR_ID_2;
     const APPLICATION_VERSION: string = '1.0.0';
     const APPLICATION_REGION: string = $REGION;
 

--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
@@ -10,7 +10,10 @@ try {
         endpoint: $ENDPOINT,
         telemetries: ['performance', 'errors', 'http', 'interaction'],
         allowCookies: true,
-        enableXRay: true
+        enableXRay: true,
+        cookieAttributes: {
+            unique: true
+        }
     };
 
     const APPLICATION_ID: string = $MONITOR_ID;

--- a/smoke/smoke-test-application-NPM-CJS/webpack/webpack.dev.js
+++ b/smoke/smoke-test-application-NPM-CJS/webpack/webpack.dev.js
@@ -22,7 +22,8 @@ module.exports = {
     devtool: 'inline-source-map',
     target: ['web', 'es5'],
     entry: {
-        loader_npm_rum_tmp: './src/loader-npm-rum-tmp.ts'
+        loader_npm_rum_tmp: './src/loader-npm-rum-tmp.ts',
+        loader_npm_rum_tmp_2: './src/loader-npm-rum-tmp-2.ts'
     },
     resolve: {
         extensions: ['.ts', '.js', '.json'],

--- a/smoke/smoke-test-application-NPM-ES/app/smoke.html
+++ b/smoke/smoke-test-application-NPM-ES/app/smoke.html
@@ -8,6 +8,19 @@
         <title>RUM Smoke Test</title>
 
         <script type="text/javascript" src="./loader_npm_rum_tmp.js"></script>
+        <script>
+            function loadScriptWithDelay() {
+                setTimeout(function () {
+                    var script = document.createElement('script');
+                    script.type = 'text/javascript';
+                    script.src = './loader_npm_rum_tmp_2.js';
+                    document.head.appendChild(script);
+                }, 10000); // 10 seconds
+            }
+
+            // Call the function to load the script with a delay
+            loadScriptWithDelay();
+        </script>
 
         <link
             rel="icon"

--- a/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-2.ts
+++ b/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-2.ts
@@ -6,7 +6,7 @@ let awsRum;
 try {
     const config: AwsRumConfig = {
         sessionSampleRate: 1,
-        identityPoolId: $IDENTITY_POOL,
+        identityPoolId: $IDENTITY_POOL_2,
         endpoint: $ENDPOINT,
         telemetries: ['performance', 'errors', 'http', 'interaction'],
         allowCookies: true,
@@ -16,7 +16,7 @@ try {
         }
     };
 
-    const APPLICATION_ID: string = $MONITOR_ID;
+    const APPLICATION_ID: string = $MONITOR_ID_2;
     const APPLICATION_VERSION: string = '1.0.0';
     const APPLICATION_REGION: string = $REGION;
 

--- a/smoke/smoke-test-application-NPM-ES/webpack/webpack.dev.js
+++ b/smoke/smoke-test-application-NPM-ES/webpack/webpack.dev.js
@@ -22,7 +22,8 @@ module.exports = {
     devtool: 'inline-source-map',
     target: ['web', 'es5'],
     entry: {
-        loader_npm_rum_tmp: './src/loader-npm-rum-tmp.ts'
+        loader_npm_rum_tmp: './src/loader-npm-rum-tmp.ts',
+        loader_npm_rum_tmp_2: './src/loader-npm-rum-tmp-2.ts'
     },
     resolve: {
         extensions: ['.ts', '.js', '.json']

--- a/src/__smoke-test-npm__/dataplane-integ.spec.ts
+++ b/src/__smoke-test-npm__/dataplane-integ.spec.ts
@@ -14,12 +14,14 @@ import {
 // Environment variables set through CLI command
 const ENDPOINT = process.env.ENDPOINT;
 const MONITOR_ID = process.env.MONITOR;
+const MONITOR_ID_2 = process.env.MONITOR_ID_2;
 const TEST_URL = getUrl(
     process.env.URL,
     process.env.VERSION,
     process.env.INSTALL_METHOD
 );
 const TARGET_URL = ENDPOINT + MONITOR_ID;
+const TARGET_URL_2 = ENDPOINT + MONITOR_ID_2;
 
 test('when web client calls PutRumEvents then the response code is 200', async ({
     page
@@ -30,6 +32,18 @@ test('when web client calls PutRumEvents then the response code is 200', async (
     // Test will timeout if no successful dataplane request is found
     await page.waitForResponse(async (response) =>
         isDataPlaneRequest(response, TARGET_URL)
+    );
+});
+
+test('when cookies are unique and web client calls PutRumEvents then the response code for second app monitor is 200', async ({
+    page
+}) => {
+    // Open page
+    await page.goto(TEST_URL);
+
+    // Test will timeout if no successful dataplane request is found
+    await page.waitForResponse(async (response) =>
+        isDataPlaneRequest(response, TARGET_URL_2)
     );
 });
 

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -13,10 +13,14 @@ export abstract class Authentication {
     constructor(config: Config, applicationId: string) {
         const region: string = config.identityPoolId!.split(':')[0];
         this.config = config;
-        this.cognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region
-        });
+        this.cognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region,
+                uniqueCookies: this.config.cookieAttributes.unique
+            },
+            applicationId
+        );
         this.credentialStorageKey = this.config.cookieAttributes.unique
             ? `${CRED_KEY}_${applicationId}`
             : CRED_KEY;

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -87,11 +87,7 @@ export abstract class Authentication {
                 try {
                     credentials = JSON.parse(
                         localStorage.getItem(
-                            getCookieName(
-                                this.config.cookieAttributes.unique,
-                                CRED_KEY,
-                                this.applicationId
-                            )
+                            this.credentialStorageKey
                         )!
                     );
                 } catch (e) {

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -18,7 +18,9 @@ export abstract class Authentication {
             fetchRequestHandler: new FetchHttpHandler(),
             region
         });
-        this.applicationId = applicationId;
+        this.credentialStorageKey = this.config.cookieAttributes.unique
+            ? `${CRED_KEY}_${this.applicationId}`
+            : CRED_KEY;
     }
 
     /**

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -13,14 +13,12 @@ export abstract class Authentication {
     constructor(config: Config, applicationId: string) {
         const region: string = config.identityPoolId!.split(':')[0];
         this.config = config;
-        this.cognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region
-            },
-            this.config.cookieAttributes.unique,
+        this.cognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region,
+            clientConfig: config,
             applicationId
-        );
+        });
         this.credentialStorageKey = this.config.cookieAttributes.unique
             ? `${CRED_KEY}_${applicationId}`
             : CRED_KEY;

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -3,13 +3,12 @@ import { Config } from '../orchestration/Orchestration';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { CRED_KEY, CRED_RENEW_MS } from '../utils/constants';
-import { getCookieName } from '../utils/cookies-utils';
 
 export abstract class Authentication {
-    protected applicationId: string;
     protected cognitoIdentityClient: CognitoIdentityClient;
     protected config: Config;
     protected credentials: AwsCredentialIdentity | undefined;
+    protected credentialStorageKey: string;
 
     constructor(config: Config, applicationId: string) {
         const region: string = config.identityPoolId!.split(':')[0];
@@ -19,7 +18,7 @@ export abstract class Authentication {
             region
         });
         this.credentialStorageKey = this.config.cookieAttributes.unique
-            ? `${CRED_KEY}_${this.applicationId}`
+            ? `${CRED_KEY}_${applicationId}`
             : CRED_KEY;
     }
 
@@ -86,9 +85,7 @@ export abstract class Authentication {
                 let credentials: AwsCredentialIdentity;
                 try {
                     credentials = JSON.parse(
-                        localStorage.getItem(
-                            this.credentialStorageKey
-                        )!
+                        localStorage.getItem(this.credentialStorageKey)!
                     );
                 } catch (e) {
                     // Error retrieving, decoding or parsing the cred string -- abort

--- a/src/dispatch/Authentication.ts
+++ b/src/dispatch/Authentication.ts
@@ -16,9 +16,9 @@ export abstract class Authentication {
         this.cognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region,
-                uniqueCookies: this.config.cookieAttributes.unique
+                region
             },
+            this.config.cookieAttributes.unique,
             applicationId
         );
         this.credentialStorageKey = this.config.cookieAttributes.unique

--- a/src/dispatch/BasicAuthentication.ts
+++ b/src/dispatch/BasicAuthentication.ts
@@ -2,9 +2,7 @@ import { Config } from '../orchestration/Orchestration';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { StsClient } from './StsClient';
-import { CRED_KEY } from '../utils/constants';
 import { Authentication } from './Authentication';
-import { getCookieName } from '../utils/cookies-utils';
 
 export class BasicAuthentication extends Authentication {
     private stsClient: StsClient;
@@ -52,11 +50,7 @@ export class BasicAuthentication extends Authentication {
                     this.credentials = credentials;
                     try {
                         localStorage.setItem(
-                            getCookieName(
-                                this.config.cookieAttributes.unique,
-                                CRED_KEY,
-                                this.applicationId
-                            ),
+                            this.credentialStorageKey,
                             JSON.stringify(credentials)
                         );
                     } catch (e) {

--- a/src/dispatch/BasicAuthentication.ts
+++ b/src/dispatch/BasicAuthentication.ts
@@ -4,12 +4,13 @@ import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { StsClient } from './StsClient';
 import { CRED_KEY } from '../utils/constants';
 import { Authentication } from './Authentication';
+import { getCookieName } from '../utils/cookies-utils';
 
 export class BasicAuthentication extends Authentication {
     private stsClient: StsClient;
 
-    constructor(config: Config) {
-        super(config);
+    constructor(config: Config, applicationId: string) {
+        super(config, applicationId);
         const region: string = config.identityPoolId!.split(':')[0];
         this.stsClient = new StsClient({
             fetchRequestHandler: new FetchHttpHandler(),
@@ -51,7 +52,11 @@ export class BasicAuthentication extends Authentication {
                     this.credentials = credentials;
                     try {
                         localStorage.setItem(
-                            CRED_KEY,
+                            getCookieName(
+                                this.config.cookieAttributes.unique,
+                                CRED_KEY,
+                                this.applicationId
+                            ),
                             JSON.stringify(credentials)
                         );
                     } catch (e) {

--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -3,6 +3,7 @@ import { HttpHandler, HttpRequest } from '@aws-sdk/protocol-http';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { responseToJson } from './utils';
 import { IDENTITY_KEY } from '../utils/constants';
+import { Config } from 'orchestration/Orchestration';
 
 const METHOD = 'POST';
 const CONTENT_TYPE = 'application/x-amz-json-1.1';
@@ -39,6 +40,8 @@ interface GetIdResponse {
 export declare type CognitoIdentityClientConfig = {
     fetchRequestHandler: HttpHandler;
     region?: string;
+    clientConfig?: Config;
+    applicationId?: string;
 };
 
 export class CognitoIdentityClient {
@@ -46,15 +49,11 @@ export class CognitoIdentityClient {
     private hostname: string;
     private identityStorageKey: string;
 
-    constructor(
-        config: CognitoIdentityClientConfig,
-        uniqueCookies: boolean,
-        applicationId: string
-    ) {
+    constructor(config: CognitoIdentityClientConfig) {
         this.hostname = `cognito-identity.${config.region}.amazonaws.com`;
         this.fetchRequestHandler = config.fetchRequestHandler;
-        this.identityStorageKey = uniqueCookies
-            ? `${IDENTITY_KEY}_${applicationId}`
+        this.identityStorageKey = config.clientConfig?.cookieAttributes.unique
+            ? `${IDENTITY_KEY}_${config.applicationId}`
             : IDENTITY_KEY;
     }
 

--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -3,7 +3,7 @@ import { HttpHandler, HttpRequest } from '@aws-sdk/protocol-http';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { responseToJson } from './utils';
 import { IDENTITY_KEY } from '../utils/constants';
-import { Config } from 'orchestration/Orchestration';
+import { Config } from '../orchestration/Orchestration';
 
 const METHOD = 'POST';
 const CONTENT_TYPE = 'application/x-amz-json-1.1';

--- a/src/dispatch/CognitoIdentityClient.ts
+++ b/src/dispatch/CognitoIdentityClient.ts
@@ -39,7 +39,6 @@ interface GetIdResponse {
 export declare type CognitoIdentityClientConfig = {
     fetchRequestHandler: HttpHandler;
     region?: string;
-    uniqueCookies?: boolean;
 };
 
 export class CognitoIdentityClient {
@@ -47,10 +46,14 @@ export class CognitoIdentityClient {
     private hostname: string;
     private identityStorageKey: string;
 
-    constructor(config: CognitoIdentityClientConfig, applicationId: string) {
+    constructor(
+        config: CognitoIdentityClientConfig,
+        uniqueCookies: boolean,
+        applicationId: string
+    ) {
         this.hostname = `cognito-identity.${config.region}.amazonaws.com`;
         this.fetchRequestHandler = config.fetchRequestHandler;
-        this.identityStorageKey = config.uniqueCookies
+        this.identityStorageKey = uniqueCookies
             ? `${IDENTITY_KEY}_${applicationId}`
             : IDENTITY_KEY;
     }

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -2,7 +2,6 @@ import { Config } from '../orchestration/Orchestration';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { CRED_KEY } from '../utils/constants';
 import { Authentication } from './Authentication';
-import { getCookieName } from '../utils/cookies-utils';
 
 export class EnhancedAuthentication extends Authentication {
     constructor(config: Config, applicationId: string) {
@@ -35,11 +34,7 @@ export class EnhancedAuthentication extends Authentication {
                     this.credentials = credentials;
                     try {
                         localStorage.setItem(
-                            getCookieName(
-                                this.config.cookieAttributes.unique,
-                                CRED_KEY,
-                                this.applicationId
-                            ),
+                            this.credentialStorageKey,
                             JSON.stringify(credentials)
                         );
                     } catch (e) {

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -2,10 +2,11 @@ import { Config } from '../orchestration/Orchestration';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { CRED_KEY } from '../utils/constants';
 import { Authentication } from './Authentication';
+import { getCookieName } from '../utils/cookies-utils';
 
 export class EnhancedAuthentication extends Authentication {
-    constructor(config: Config) {
-        super(config);
+    constructor(config: Config, applicationId: string) {
+        super(config, applicationId);
     }
     /**
      * Provides credentials for an anonymous (guest) user. These credentials are retrieved from Cognito's enhanced
@@ -34,7 +35,11 @@ export class EnhancedAuthentication extends Authentication {
                     this.credentials = credentials;
                     try {
                         localStorage.setItem(
-                            CRED_KEY,
+                            getCookieName(
+                                this.config.cookieAttributes.unique,
+                                CRED_KEY,
+                                this.applicationId
+                            ),
                             JSON.stringify(credentials)
                         );
                     } catch (e) {

--- a/src/dispatch/EnhancedAuthentication.ts
+++ b/src/dispatch/EnhancedAuthentication.ts
@@ -1,6 +1,5 @@
 import { Config } from '../orchestration/Orchestration';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
-import { CRED_KEY } from '../utils/constants';
 import { Authentication } from './Authentication';
 
 export class EnhancedAuthentication extends Authentication {

--- a/src/dispatch/__tests__/BasicAuthentication.test.ts
+++ b/src/dispatch/__tests__/BasicAuthentication.test.ts
@@ -42,6 +42,7 @@ describe('BasicAuthentication tests', () => {
             expiration: new Date(new Date().getTime() + 60 * 60 * 1000)
         });
         localStorage.removeItem(CRED_KEY);
+        localStorage.removeItem(`${CRED_KEY}_${APPLICATION_ID}`);
     });
 
     test('when credential is in localStorage then authentication chain retrieves credential from localStorage', async () => {

--- a/src/dispatch/__tests__/BasicAuthentication.test.ts
+++ b/src/dispatch/__tests__/BasicAuthentication.test.ts
@@ -1,6 +1,6 @@
 import { BasicAuthentication } from '../BasicAuthentication';
 import { CRED_KEY } from '../../utils/constants';
-import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
+import { APPLICATION_ID, DEFAULT_CONFIG } from '../../test-utils/test-utils';
 
 const assumeRole = jest.fn();
 const mockGetId = jest.fn();
@@ -54,7 +54,7 @@ describe('BasicAuthentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new BasicAuthentication(config);
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
 
         localStorage.setItem(
             CRED_KEY,
@@ -88,7 +88,7 @@ describe('BasicAuthentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new BasicAuthentication(config);
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
 
         localStorage.setItem(CRED_KEY, 'corrupt');
 
@@ -107,13 +107,16 @@ describe('BasicAuthentication tests', () => {
 
     test('when credential is not in localStorage then authentication chain retrieves credential from basic authflow', async () => {
         // Init
-        const auth = new BasicAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
-            }
-        });
+        const auth = new BasicAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();
@@ -139,7 +142,7 @@ describe('BasicAuthentication tests', () => {
             }
         };
 
-        const auth = new BasicAuthentication(config);
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
 
         localStorage.setItem(
             CRED_KEY,
@@ -181,13 +184,16 @@ describe('BasicAuthentication tests', () => {
                 sessionToken: 'z'
             });
 
-        const auth = new BasicAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
-            }
-        });
+        const auth = new BasicAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -210,13 +216,16 @@ describe('BasicAuthentication tests', () => {
             throw e;
         });
         // Init
-        const auth = new BasicAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
-            }
-        });
+        const auth = new BasicAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         return expect(auth.ChainAnonymousCredentialsProvider()).rejects.toEqual(
@@ -230,13 +239,16 @@ describe('BasicAuthentication tests', () => {
             throw e;
         });
         // Init
-        const auth = new BasicAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
-            }
-        });
+        const auth = new BasicAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         return expect(auth.ChainAnonymousCredentialsProvider()).rejects.toEqual(
@@ -250,13 +262,16 @@ describe('BasicAuthentication tests', () => {
             throw e;
         });
         // Init
-        const auth = new BasicAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
-            }
-        });
+        const auth = new BasicAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         expect(auth.ChainAnonymousCredentialsProvider()).rejects.toEqual(e);
@@ -272,7 +287,7 @@ describe('BasicAuthentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new BasicAuthentication(config);
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -321,7 +336,7 @@ describe('BasicAuthentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new BasicAuthentication(config);
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -358,7 +373,7 @@ describe('BasicAuthentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new BasicAuthentication(config);
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();
@@ -396,7 +411,7 @@ describe('BasicAuthentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new BasicAuthentication(config);
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -414,13 +429,77 @@ describe('BasicAuthentication tests', () => {
             throw e;
         });
         // Init
-        const auth = new BasicAuthentication({
+        const auth = new BasicAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
+
+        // Run
+        const credentials = await auth.ChainAnonymousCredentialsProvider();
+
+        // Assert
+        expect(credentials).toEqual(
+            expect.objectContaining({
+                accessKeyId: 'x',
+                secretAccessKey: 'y',
+                sessionToken: 'z'
+            })
+        );
+    });
+
+    test('when unique cookie names are used then cookie name with application id appended is stored', async () => {
+        // Init
+        const config = {
             ...DEFAULT_CONFIG,
             ...{
                 identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
+                guestRoleArn: GUEST_ROLE_ARN,
+                allowCookies: true,
+                cookieAttributes: {
+                    ...DEFAULT_CONFIG.cookieAttributes,
+                    ...{ unique: true }
+                }
             }
-        });
+        };
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
+
+        // Run
+        await auth.ChainAnonymousCredentialsProvider();
+        const credentials = JSON.parse(
+            localStorage.getItem(`${CRED_KEY}_${APPLICATION_ID}`)!
+        );
+
+        // Assert
+        expect(credentials).toEqual(
+            expect.objectContaining({
+                accessKeyId: 'x',
+                secretAccessKey: 'y',
+                sessionToken: 'z'
+            })
+        );
+    });
+
+    test('when unique cookie names are used then cookie name with application id appended is retrieved', async () => {
+        // Init
+        const config = {
+            ...DEFAULT_CONFIG,
+            ...{
+                identityPoolId: IDENTITY_POOL_ID,
+                guestRoleArn: GUEST_ROLE_ARN,
+                allowCookies: true,
+                cookieAttributes: {
+                    ...DEFAULT_CONFIG.cookieAttributes,
+                    ...{ unique: true }
+                }
+            }
+        };
+        const auth = new BasicAuthentication(config, APPLICATION_ID);
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -3,7 +3,11 @@ import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { advanceTo } from 'jest-date-mock';
 import { CognitoIdentityClient } from '../CognitoIdentityClient';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
-import { APPLICATION_ID, getReadableStream } from '../../test-utils/test-utils';
+import {
+    APPLICATION_ID,
+    getReadableStream,
+    DEFAULT_CONFIG
+} from '../../test-utils/test-utils';
 import { IDENTITY_KEY } from '../../utils/constants';
 
 const mockCredentials =
@@ -43,14 +47,17 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         const creds: AwsCredentialIdentity =
@@ -75,14 +82,17 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Assert
         await expect(
@@ -98,14 +108,17 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         const tokenCommand = await client.getOpenIdToken({
@@ -130,14 +143,17 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Assert
         expect(
@@ -155,14 +171,17 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         const idCommand = await client.getId({
@@ -186,14 +205,17 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Assert
         return expect(
@@ -211,14 +233,17 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         await client.getId({ IdentityPoolId: 'my-fake-identity-pool-id' });
@@ -246,14 +271,17 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Assert
         await expect(
@@ -274,14 +302,17 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Assert
         await expect(
@@ -300,14 +331,17 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Assert
         await expect(
@@ -325,14 +359,17 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         try {
@@ -358,14 +395,17 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Assert
         await expect(
@@ -384,14 +424,17 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Assert
         await expect(
@@ -409,14 +452,17 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: false
+                }
             },
-            false,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         try {
@@ -437,14 +483,21 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: true,
+                    cookieAttributes: {
+                        ...DEFAULT_CONFIG.cookieAttributes,
+                        ...{ unique: true }
+                    }
+                }
             },
-            true,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         await client.getId({
@@ -471,14 +524,21 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: true,
+                    cookieAttributes: {
+                        ...DEFAULT_CONFIG.cookieAttributes,
+                        ...{ unique: true }
+                    }
+                }
             },
-            true,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         const idCommand = await client.getId({
@@ -502,14 +562,21 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: true,
+                    cookieAttributes: {
+                        ...DEFAULT_CONFIG.cookieAttributes,
+                        ...{ unique: true }
+                    }
+                }
             },
-            true,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         try {
@@ -532,14 +599,21 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient(
-            {
-                fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION
+        const client: CognitoIdentityClient = new CognitoIdentityClient({
+            fetchRequestHandler: new FetchHttpHandler(),
+            region: Utils.AWS_RUM_REGION,
+            clientConfig: {
+                ...DEFAULT_CONFIG,
+                ...{
+                    allowCookies: true,
+                    cookieAttributes: {
+                        ...DEFAULT_CONFIG.cookieAttributes,
+                        ...{ unique: true }
+                    }
+                }
             },
-            true,
-            APPLICATION_ID
-        );
+            applicationId: APPLICATION_ID
+        });
 
         // Run
         try {

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -3,13 +3,15 @@ import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { advanceTo } from 'jest-date-mock';
 import { CognitoIdentityClient } from '../CognitoIdentityClient';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
-import { getReadableStream } from '../../test-utils/test-utils';
+import { APPLICATION_ID, getReadableStream } from '../../test-utils/test-utils';
 import { IDENTITY_KEY } from '../../utils/constants';
 
 const mockCredentials =
     '{ "IdentityId": "a", "Credentials": { "AccessKeyId": "x", "SecretKey": "y", "SessionToken": "z" } }';
 const mockToken = '{"IdentityId": "mockId", "Token": "mockToken"}';
 const mockIdCommand = '{"IdentityId": "mockId"}';
+
+const uniqueIdentityCookie = `${IDENTITY_KEY}_${APPLICATION_ID}`;
 
 const fetchHandler = jest.fn();
 
@@ -41,10 +43,14 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Run
         const creds: AwsCredentialIdentity =
@@ -69,10 +75,14 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         await expect(
@@ -88,10 +98,14 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Run
         const tokenCommand = await client.getOpenIdToken({
@@ -116,10 +130,14 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         expect(
@@ -137,10 +155,14 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Run
         const idCommand = await client.getId({
@@ -164,10 +186,14 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         return expect(
@@ -185,10 +211,14 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Run
         await client.getId({ IdentityPoolId: 'my-fake-identity-pool-id' });
@@ -216,10 +246,14 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         await expect(
@@ -240,10 +274,14 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         await expect(
@@ -262,10 +300,14 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         await expect(
@@ -283,10 +325,14 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Run
         try {
@@ -312,10 +358,14 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         await expect(
@@ -334,10 +384,14 @@ describe('CognitoIdentityClient tests', () => {
         );
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         await expect(
@@ -355,10 +409,14 @@ describe('CognitoIdentityClient tests', () => {
         });
 
         // Init
-        const client: CognitoIdentityClient = new CognitoIdentityClient({
-            fetchRequestHandler: new FetchHttpHandler(),
-            region: Utils.AWS_RUM_REGION
-        });
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
 
         // Run
         try {
@@ -369,5 +427,128 @@ describe('CognitoIdentityClient tests', () => {
 
         // Assert
         expect(localStorage.getItem(IDENTITY_KEY)).toBe(null);
+    });
+
+    test('when unique cookie names are used then cookie name with application id appended is stored', async () => {
+        fetchHandler.mockResolvedValueOnce({
+            response: {
+                body: getReadableStream(mockIdCommand)
+            }
+        });
+
+        // Init
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: true
+            },
+            APPLICATION_ID
+        );
+
+        // Run
+        await client.getId({
+            IdentityPoolId: 'my-fake-identity-pool-id'
+        });
+
+        // Assert
+        const credentials = JSON.parse(
+            localStorage.getItem(uniqueIdentityCookie)!
+        );
+
+        expect(credentials).toEqual(
+            expect.objectContaining({
+                IdentityId: 'mockId'
+            })
+        );
+    });
+
+    test('when unique cookie names are used then cookie name with application id appended is retrieved', async () => {
+        fetchHandler.mockResolvedValueOnce({
+            response: {
+                body: getReadableStream(mockIdCommand)
+            }
+        });
+
+        // Init
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: true
+            },
+            APPLICATION_ID
+        );
+
+        // Run
+        const idCommand = await client.getId({
+            IdentityPoolId: 'my-fake-identity-pool-id'
+        });
+
+        // Assert
+        expect(fetchHandler).toHaveBeenCalledTimes(1);
+        expect(idCommand).toMatchObject({
+            IdentityId: 'mockId'
+        });
+    });
+
+    test('when unique cookie names and getOpenIdToken returns a bad response then identity id is removed from localStorage', async () => {
+        localStorage.setItem(IDENTITY_KEY, 'my-fake-identity-id');
+
+        fetchHandler.mockResolvedValueOnce({
+            response: {
+                body: getReadableStream('not-json')
+            }
+        });
+
+        // Init
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: true
+            },
+            APPLICATION_ID
+        );
+
+        // Run
+        try {
+            await client.getOpenIdToken({ IdentityId: 'my-fake-identity-id' });
+        } catch (e) {
+            // Ignore
+        }
+
+        // Assert
+        expect(localStorage.getItem(uniqueIdentityCookie)).toBe(null);
+    });
+
+    test('when unique cookie names and getCredentialsForIdentity returns bad response then identity id is removed from localStorage ', async () => {
+        localStorage.setItem(IDENTITY_KEY, 'my-fake-identity-id');
+
+        fetchHandler.mockResolvedValueOnce({
+            response: {
+                body: getReadableStream('not-json')
+            }
+        });
+
+        // Init
+        const client: CognitoIdentityClient = new CognitoIdentityClient(
+            {
+                fetchRequestHandler: new FetchHttpHandler(),
+                region: Utils.AWS_RUM_REGION,
+                uniqueCookies: false
+            },
+            APPLICATION_ID
+        );
+
+        // Run
+        try {
+            await client.getCredentialsForIdentity('my-fake-identity-id');
+        } catch (e) {
+            // Ignore
+        }
+
+        // Assert
+        expect(localStorage.getItem(uniqueIdentityCookie)).toBe(null);
     });
 });

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -493,7 +493,7 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when unique cookie names and getOpenIdToken returns a bad response then identity id is removed from localStorage', async () => {
-        localStorage.setItem(IDENTITY_KEY, 'my-fake-identity-id');
+        localStorage.setItem(uniqueIdentityCookie, 'my-fake-identity-id');
 
         fetchHandler.mockResolvedValueOnce({
             response: {
@@ -523,7 +523,7 @@ describe('CognitoIdentityClient tests', () => {
     });
 
     test('when unique cookie names and getCredentialsForIdentity returns bad response then identity id is removed from localStorage ', async () => {
-        localStorage.setItem(IDENTITY_KEY, 'my-fake-identity-id');
+        localStorage.setItem(uniqueIdentityCookie, 'my-fake-identity-id');
 
         fetchHandler.mockResolvedValueOnce({
             response: {

--- a/src/dispatch/__tests__/CognitoIdentityClient.test.ts
+++ b/src/dispatch/__tests__/CognitoIdentityClient.test.ts
@@ -46,9 +46,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -78,9 +78,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -101,9 +101,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -133,9 +133,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -158,9 +158,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -189,9 +189,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -214,9 +214,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -249,9 +249,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -277,9 +277,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -303,9 +303,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -328,9 +328,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -361,9 +361,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -387,9 +387,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -412,9 +412,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            false,
             APPLICATION_ID
         );
 
@@ -440,9 +440,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: true
+                region: Utils.AWS_RUM_REGION
             },
+            true,
             APPLICATION_ID
         );
 
@@ -474,9 +474,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: true
+                region: Utils.AWS_RUM_REGION
             },
+            true,
             APPLICATION_ID
         );
 
@@ -505,9 +505,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: true
+                region: Utils.AWS_RUM_REGION
             },
+            true,
             APPLICATION_ID
         );
 
@@ -535,9 +535,9 @@ describe('CognitoIdentityClient tests', () => {
         const client: CognitoIdentityClient = new CognitoIdentityClient(
             {
                 fetchRequestHandler: new FetchHttpHandler(),
-                region: Utils.AWS_RUM_REGION,
-                uniqueCookies: false
+                region: Utils.AWS_RUM_REGION
             },
+            true,
             APPLICATION_ID
         );
 

--- a/src/dispatch/__tests__/EnhancedAuthentication.test.ts
+++ b/src/dispatch/__tests__/EnhancedAuthentication.test.ts
@@ -1,6 +1,7 @@
 import { CRED_KEY } from '../../utils/constants';
 import { EnhancedAuthentication } from '../EnhancedAuthentication';
-import { DEFAULT_CONFIG } from '../../test-utils/test-utils';
+import { APPLICATION_ID, DEFAULT_CONFIG } from '../../test-utils/test-utils';
+import { getCookieName } from '../../utils/cookies-utils';
 
 const mockGetId = jest.fn();
 const getCredentials = jest.fn();
@@ -41,7 +42,7 @@ describe('EnhancedAuthentication tests', () => {
             }
         };
 
-        const auth = new EnhancedAuthentication(config);
+        const auth = new EnhancedAuthentication(config, APPLICATION_ID);
 
         localStorage.setItem(
             CRED_KEY,
@@ -76,7 +77,7 @@ describe('EnhancedAuthentication tests', () => {
             }
         };
 
-        const auth = new EnhancedAuthentication(config);
+        const auth = new EnhancedAuthentication(config, APPLICATION_ID);
 
         localStorage.setItem(CRED_KEY, 'corrupt');
 
@@ -95,12 +96,15 @@ describe('EnhancedAuthentication tests', () => {
 
     test('when credential is not in the store authentication chain retrieves credential from basic authflow', async () => {
         // Init
-        const auth = new EnhancedAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID
-            }
-        });
+        const auth = new EnhancedAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();
@@ -126,7 +130,7 @@ describe('EnhancedAuthentication tests', () => {
             }
         };
 
-        const auth = new EnhancedAuthentication(config);
+        const auth = new EnhancedAuthentication(config, APPLICATION_ID);
 
         localStorage.setItem(
             CRED_KEY,
@@ -168,13 +172,16 @@ describe('EnhancedAuthentication tests', () => {
                 sessionToken: 'z'
             });
 
-        const auth = new EnhancedAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
-            }
-        });
+        const auth = new EnhancedAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -197,13 +204,16 @@ describe('EnhancedAuthentication tests', () => {
             throw new Error('mockGetId error');
         });
 
-        const auth = new EnhancedAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
-            }
-        });
+        const auth = new EnhancedAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         expect((auth: EnhancedAuthentication) => {
@@ -217,13 +227,16 @@ describe('EnhancedAuthentication tests', () => {
             throw new Error('mockGetId error');
         });
 
-        const auth = new EnhancedAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
-            }
-        });
+        const auth = new EnhancedAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Assert
         expect((auth: EnhancedAuthentication) => {
@@ -241,7 +254,7 @@ describe('EnhancedAuthentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new EnhancedAuthentication(config);
+        const auth = new EnhancedAuthentication(config, APPLICATION_ID);
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -290,7 +303,7 @@ describe('EnhancedAuthentication tests', () => {
                 guestRoleArn: GUEST_ROLE_ARN
             }
         };
-        const auth = new EnhancedAuthentication(config);
+        const auth = new EnhancedAuthentication(config, APPLICATION_ID);
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -327,12 +340,15 @@ describe('EnhancedAuthentication tests', () => {
             })
         );
 
-        const auth = new EnhancedAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID
-            }
-        });
+        const auth = new EnhancedAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();
@@ -364,12 +380,15 @@ describe('EnhancedAuthentication tests', () => {
             })
         );
 
-        const auth = new EnhancedAuthentication({
-            ...DEFAULT_CONFIG,
-            ...{
-                identityPoolId: IDENTITY_POOL_ID
-            }
-        });
+        const auth = new EnhancedAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID
+                }
+            },
+            APPLICATION_ID
+        );
 
         // Run
         await auth.ChainAnonymousCredentialsProvider();
@@ -387,13 +406,76 @@ describe('EnhancedAuthentication tests', () => {
             throw new Error('mockGetId error');
         });
 
-        const auth = new EnhancedAuthentication({
+        const auth = new EnhancedAuthentication(
+            {
+                ...DEFAULT_CONFIG,
+                ...{
+                    identityPoolId: IDENTITY_POOL_ID,
+                    guestRoleArn: GUEST_ROLE_ARN
+                }
+            },
+            APPLICATION_ID
+        );
+
+        // Run
+        const credentials = await auth.ChainAnonymousCredentialsProvider();
+
+        // Assert
+        expect(credentials).toEqual(
+            expect.objectContaining({
+                accessKeyId: 'x',
+                secretAccessKey: 'y',
+                sessionToken: 'z'
+            })
+        );
+    });
+
+    test('when unique cookie names are used then cookie name with application id appended is stored', async () => {
+        // Init
+        const config = {
             ...DEFAULT_CONFIG,
             ...{
                 identityPoolId: IDENTITY_POOL_ID,
-                guestRoleArn: GUEST_ROLE_ARN
+                allowCookies: true,
+                cookieAttributes: {
+                    ...DEFAULT_CONFIG.cookieAttributes,
+                    ...{ unique: true }
+                }
             }
-        });
+        };
+
+        const auth = new EnhancedAuthentication(config, APPLICATION_ID);
+
+        // Run
+        await auth.ChainAnonymousCredentialsProvider();
+        const credentials = JSON.parse(
+            localStorage.getItem(`${CRED_KEY}_${APPLICATION_ID}`)!
+        );
+
+        // Assert
+        expect(credentials).toEqual(
+            expect.objectContaining({
+                accessKeyId: 'x',
+                secretAccessKey: 'y',
+                sessionToken: 'z'
+            })
+        );
+    });
+    test('when unique cookie names are used then cookie name with application id appended is retrieved', async () => {
+        // Init
+        const config = {
+            ...DEFAULT_CONFIG,
+            ...{
+                identityPoolId: IDENTITY_POOL_ID,
+                allowCookies: true,
+                cookieAttributes: {
+                    ...DEFAULT_CONFIG.cookieAttributes,
+                    ...{ unique: true }
+                }
+            }
+        };
+
+        const auth = new EnhancedAuthentication(config, APPLICATION_ID);
 
         // Run
         const credentials = await auth.ChainAnonymousCredentialsProvider();

--- a/src/dispatch/__tests__/EnhancedAuthentication.test.ts
+++ b/src/dispatch/__tests__/EnhancedAuthentication.test.ts
@@ -29,6 +29,7 @@ describe('EnhancedAuthentication tests', () => {
             expiration: new Date(Date.now() + 3600 * 1000)
         });
         localStorage.removeItem(CRED_KEY);
+        localStorage.removeItem(`${CRED_KEY}_${APPLICATION_ID}`);
     });
 
     test('when credential is in localStorage then authentication chain retrieves credential from localStorage', async () => {

--- a/src/dispatch/__tests__/EnhancedAuthentication.test.ts
+++ b/src/dispatch/__tests__/EnhancedAuthentication.test.ts
@@ -1,7 +1,6 @@
 import { CRED_KEY } from '../../utils/constants';
 import { EnhancedAuthentication } from '../EnhancedAuthentication';
 import { APPLICATION_ID, DEFAULT_CONFIG } from '../../test-utils/test-utils';
-import { getCookieName } from '../../utils/cookies-utils';
 
 const mockGetId = jest.fn();
 const getCredentials = jest.fn();

--- a/src/orchestration/Orchestration.ts
+++ b/src/orchestration/Orchestration.ts
@@ -238,7 +238,7 @@ export class Orchestration {
             applicationVersion
         );
 
-        this.dispatchManager = this.initDispatch(region);
+        this.dispatchManager = this.initDispatch(region, applicationId);
         this.pluginManager = this.initPluginManager(
             applicationId,
             applicationVersion
@@ -378,7 +378,7 @@ export class Orchestration {
         );
     }
 
-    private initDispatch(region: string) {
+    private initDispatch(region: string, applicationId: string) {
         const dispatch: Dispatch = new Dispatch(
             region,
             this.config.endpointUrl,
@@ -395,12 +395,12 @@ export class Orchestration {
 
         if (this.config.identityPoolId && this.config.guestRoleArn) {
             dispatch.setAwsCredentials(
-                new BasicAuthentication(this.config)
+                new BasicAuthentication(this.config, applicationId)
                     .ChainAnonymousCredentialsProvider
             );
         } else if (this.config.identityPoolId) {
             dispatch.setAwsCredentials(
-                new EnhancedAuthentication(this.config)
+                new EnhancedAuthentication(this.config, applicationId)
                     .ChainAnonymousCredentialsProvider
             );
         }

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -176,11 +176,7 @@ export class SessionManager {
     private createOrRenewSessionCookie(session: Session, expires: Date) {
         if (btoa) {
             storeCookie(
-                getCookieName(
-                    this.config.cookieAttributes.unique,
-                    SESSION_COOKIE_NAME,
-                    this.appMonitorDetails.id!
-                ),
+                this.sessionCookieName,
                 btoa(JSON.stringify(session)),
                 this.config.cookieAttributes,
                 undefined,

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -1,4 +1,4 @@
-import { storeCookie, getCookie, getCookieName } from '../utils/cookies-utils';
+import { storeCookie, getCookie } from '../utils/cookies-utils';
 
 import { v4 } from 'uuid';
 import { Config } from '../orchestration/Orchestration';
@@ -69,6 +69,7 @@ export class SessionManager {
     private config: Config;
     private record: RecordSessionInitEvent;
     private attributes!: Attributes;
+    private sessionCookieName: string;
 
     constructor(
         appMonitorDetails: AppMonitorDetails,
@@ -80,6 +81,10 @@ export class SessionManager {
         this.config = config;
         this.record = record;
         this.pageManager = pageManager;
+
+        this.sessionCookieName = this.config.cookieAttributes.unique
+            ? `${SESSION_COOKIE_NAME}_${this.appMonitorDetails.id}`
+            : SESSION_COOKIE_NAME;
 
         // Initialize the session to the nil session
         this.session = {
@@ -201,14 +206,7 @@ export class SessionManager {
 
     private getSessionFromCookie() {
         if (this.useCookies()) {
-            const cookie: string = getCookie(
-                getCookieName(
-                    this.config.cookieAttributes.unique,
-                    SESSION_COOKIE_NAME,
-                    this.appMonitorDetails.id!
-                )
-            );
-
+            const cookie: string = getCookie(this.sessionCookieName);
             if (cookie && atob) {
                 try {
                     this.session = JSON.parse(atob(cookie)) as Session;

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -1,4 +1,4 @@
-import { storeCookie, getCookie } from '../utils/cookies-utils';
+import { storeCookie, getCookie, getCookieName } from '../utils/cookies-utils';
 
 import { v4 } from 'uuid';
 import { Config } from '../orchestration/Orchestration';
@@ -176,7 +176,11 @@ export class SessionManager {
     private createOrRenewSessionCookie(session: Session, expires: Date) {
         if (btoa) {
             storeCookie(
-                this.sessionCookieName(),
+                getCookieName(
+                    this.config.cookieAttributes.unique,
+                    SESSION_COOKIE_NAME,
+                    this.appMonitorDetails.id!
+                ),
                 btoa(JSON.stringify(session)),
                 this.config.cookieAttributes,
                 undefined,
@@ -201,7 +205,13 @@ export class SessionManager {
 
     private getSessionFromCookie() {
         if (this.useCookies()) {
-            const cookie: string = getCookie(this.sessionCookieName());
+            const cookie: string = getCookie(
+                getCookieName(
+                    this.config.cookieAttributes.unique,
+                    SESSION_COOKIE_NAME,
+                    this.appMonitorDetails.id!
+                )
+            );
 
             if (cookie && atob) {
                 try {
@@ -285,12 +295,5 @@ export class SessionManager {
      */
     private sample(): boolean {
         return Math.random() < this.config.sessionSampleRate;
-    }
-
-    private sessionCookieName(): string {
-        if (this.config.cookieAttributes.unique) {
-            return `${SESSION_COOKIE_NAME}_${this.appMonitorDetails.id}`;
-        }
-        return SESSION_COOKIE_NAME;
     }
 }

--- a/src/utils/cookies-utils.ts
+++ b/src/utils/cookies-utils.ts
@@ -69,14 +69,3 @@ export const getCookie = (name: string): string => {
     }
     return '';
 };
-
-export const getCookieName = (
-    isUnique: boolean,
-    cookiePrefix: string,
-    appMonitorId: string
-): string => {
-    if (isUnique) {
-        return `${cookiePrefix}_${appMonitorId}`;
-    }
-    return cookiePrefix;
-};

--- a/src/utils/cookies-utils.ts
+++ b/src/utils/cookies-utils.ts
@@ -69,3 +69,14 @@ export const getCookie = (name: string): string => {
     }
     return '';
 };
+
+export const getCookieName = (
+    isUnique: boolean,
+    cookiePrefix: string,
+    appMonitorId: string
+): string => {
+    if (isUnique) {
+        return `${cookiePrefix}_${appMonitorId}`;
+    }
+    return cookiePrefix;
+};


### PR DESCRIPTION
Multiple AppMonitors from different AWS accounts cannot currently be used on the same page. Because the credential cookie name `cwr_c` is not unique to an AppMonitor, multiple web clients running on the same page attempt to read and store credential info to the same cookie, which would produce incorrect data.

This change uses the existing `cookieAttributes.unique` configuration to add the AppMonitorID as a postfix to the credential cookie `cwr_c`. When used, the credential cookie name will have the format `cwr_c_[AppMonitor Id]`, and multiple web clients sending data to app monitors in different accounts can run on the same page. 

Related FR: https://github.com/aws-observability/aws-rum-web/issues/557

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
