### PR TITLE
fix: reduce CDN size by tree shaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
             },
             "devDependencies": {
                 "@aws-sdk/client-rum": "^3.76.0",
-                "@babel/plugin-transform-modules-commonjs": "^7.21.2",
                 "@babel/plugin-transform-runtime": "^7.16.0",
                 "@babel/preset-env": "~7.20.2",
                 "@playwright/test": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     },
     "devDependencies": {
         "@aws-sdk/client-rum": "^3.76.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
         "@babel/plugin-transform-runtime": "^7.16.0",
         "@babel/preset-env": "~7.20.2",
         "@playwright/test": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
         ]
     },
     "browserslist": [
-        "defaults",
-        "ie 11"
+        "defaults"
     ]
 }

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,16 +1,18 @@
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 const babelLoaderOptions = {
-    presets: [['@babel/preset-env', {}]],
-    plugins: [
-        '@babel/plugin-transform-modules-commonjs',
+    presets: [
         [
-            '@babel/plugin-transform-runtime',
+            '@babel/preset-env',
             {
-                absoluteRuntime: false,
-                corejs: false,
-                helpers: true,
-                regenerator: true
+                targets: {
+                    edge: '17',
+                    firefox: '60',
+                    chrome: '67',
+                    safari: '11.1'
+                }
+                // useBuiltIns: 'usage',
+                // corejs: '3.6.5'
             }
         ]
     ]

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -11,8 +11,6 @@ const babelLoaderOptions = {
                     chrome: '67',
                     safari: '11.1'
                 }
-                // useBuiltIns: 'usage',
-                // corejs: '3.6.5'
             }
         ]
     ]

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,19 +1,7 @@
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 const babelLoaderOptions = {
-    presets: [
-        [
-            '@babel/preset-env',
-            {
-                targets: {
-                    edge: '17',
-                    firefox: '60',
-                    chrome: '67',
-                    safari: '11.1'
-                }
-            }
-        ]
-    ]
+    presets: [['@babel/preset-env']]
 };
 
 module.exports = {


### PR DESCRIPTION
## Summary

These changes reduce the size of `cwr.js` from ~230KB to 141KB. The problem is that we are including unused dependencies because our tree shaking is broken. From webpack documentation: https://webpack.js.org/guides/tree-shaking/

> Ensure no compilers transform your ES2015 module syntax into CommonJS modules (this is the default behavior of the popular Babel preset @babel/preset-env - see the [documentation](https://babeljs.io/docs/en/babel-preset-env#modules) for more details).

This PR restores treeshaking by compiling to native ES5 modules instead of CommonJS. 

![Screenshot 2024-06-21 at 11 45 04 AM](https://github.com/aws-observability/aws-rum-web/assets/43121212/439db8db-bb5e-4bda-a5d3-2bf6fd7d4d65)

However, this only fixes the CDN build and does not impact the NPM build in any way. While the CDN build is compiled by webpack and outputs to `build/assets/cwr.js`, the NPM build is managed by `tsc` and outputs to the `dist` directory. 

## Example

We have a dependency on UUID's `v4` function that is currently taking 15 kb. However, nearly all of that is stuff that we do not need, such as v1, md5, etc. 

![Screenshot 2024-06-22 at 12 19 31 PM](https://github.com/aws-observability/aws-rum-web/assets/43121212/50afd4ce-43c7-4fcb-b762-673283486c13)

After tree shaking, we now only import `v4` and drop everything else, reducing the stat size from 24 kb to 3 kb, and the parsed size is much lower. 

![Screenshot 2024-06-22 at 12 20 17 PM](https://github.com/aws-observability/aws-rum-web/assets/43121212/e07b56b1-3bfb-47d3-b85f-14291918fe59)


## Backwards compatibility

We can reduce package size even further by specifying browser targets. I've used the default targets from documentation, which look good against a quick check of which browsers people actually use.

* https://babeljs.io/docs/options#targets
* https://www.stetic.com/market-share/browser/

In general, we can trade backwards compatibility for package size by setting browser targets to earlier versions. By default, the TerserPlugin for Webpack attempts to provide the broadest support possible. 

## Risk

Before deploying, we should do some manual testing and run the smoke tests for backward compatibility since we are switching the CDN build from CommonJS to ES15. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
