### PR TITLE
feat: add core-js polyfills to CDN by usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@aws-sdk/signature-v4": "^3.36.0",
                 "@aws-sdk/util-hex-encoding": "^3.36.0",
                 "@babel/runtime": "^7.16.0",
+                "core-js": "^2.6.12",
                 "shimmer": "^1.2.1",
                 "ua-parser-js": "^1.0.33",
                 "uuid": "^9.0.0",
@@ -8468,6 +8469,14 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/core-js": {
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+            "hasInstallScript": true,
+            "license": "MIT"
         },
         "node_modules/core-js-compat": {
             "version": "3.25.5",
@@ -28552,6 +28561,11 @@
                     "dev": true
                 }
             }
+        },
+        "core-js": {
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "core-js-compat": {
             "version": "3.25.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
             },
             "devDependencies": {
                 "@aws-sdk/client-rum": "^3.76.0",
-                "@babel/plugin-transform-modules-commonjs": "^7.21.2",
                 "@babel/plugin-transform-runtime": "^7.16.0",
                 "@babel/preset-env": "~7.20.2",
                 "@playwright/test": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     },
     "devDependencies": {
         "@aws-sdk/client-rum": "^3.76.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
         "@babel/plugin-transform-runtime": "^7.16.0",
         "@babel/preset-env": "~7.20.2",
         "@playwright/test": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
         ]
     },
     "browserslist": [
-        "defaults",
-        "ie 11"
+        "defaults"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
         "@aws-sdk/signature-v4": "^3.36.0",
         "@aws-sdk/util-hex-encoding": "^3.36.0",
         "@babel/runtime": "^7.16.0",
+        "core-js": "^2.6.12",
         "shimmer": "^1.2.1",
         "ua-parser-js": "^1.0.33",
         "uuid": "^9.0.0",

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,7 +1,16 @@
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 const babelLoaderOptions = {
-    presets: [['@babel/preset-env']]
+    presets: [
+        [
+            '@babel/preset-env',
+            {
+                modules: false,
+                useBuiltIns: 'usage',
+                corejs: 2
+            }
+        ]
+    ]
 };
 
 module.exports = {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,16 +1,18 @@
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 const babelLoaderOptions = {
-    presets: [['@babel/preset-env', {}]],
-    plugins: [
-        '@babel/plugin-transform-modules-commonjs',
+    presets: [
         [
-            '@babel/plugin-transform-runtime',
+            '@babel/preset-env',
             {
-                absoluteRuntime: false,
-                corejs: false,
-                helpers: true,
-                regenerator: true
+                targets: {
+                    edge: '17',
+                    firefox: '60',
+                    chrome: '67',
+                    safari: '11.1'
+                }
+                // useBuiltIns: 'usage',
+                // corejs: '3.6.5'
             }
         ]
     ]

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -11,8 +11,6 @@ const babelLoaderOptions = {
                     chrome: '67',
                     safari: '11.1'
                 }
-                // useBuiltIns: 'usage',
-                // corejs: '3.6.5'
             }
         ]
     ]

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,19 +1,7 @@
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 const babelLoaderOptions = {
-    presets: [
-        [
-            '@babel/preset-env',
-            {
-                targets: {
-                    edge: '17',
-                    firefox: '60',
-                    chrome: '67',
-                    safari: '11.1'
-                }
-            }
-        ]
-    ]
+    presets: [['@babel/preset-env']]
 };
 
 module.exports = {


### PR DESCRIPTION
### Summary

The configuration in https://github.com/aws-observability/aws-rum-web/pull/563 only targets default browser targets (https://browsersl.ist/#q=defaults). This may not be enough because that only targets the last 2 versions of non-dead browsers that are used by more than 0.5% of users. This PR dynamically adds polyfills by usage to close the gap. 

<img width="317" alt="Screenshot 2024-06-25 at 7 06 17 PM" src="https://github.com/aws-observability/aws-rum-web/assets/43121212/ac95962c-301e-461d-9fd5-83dec6285557">

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
