### PR TITLE
fix: point source maps to TS files

### DIFF
--- a/tsconfig.webpack.json
+++ b/tsconfig.webpack.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "module": "es2020",
-        "outDir": "./dist/webpack"
+        "outDir": "./dist/webpack",
+        "sourceMap": true
     },
     "include": ["src/index-browser.ts"],
     "extends": "./tsconfig"

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -5,7 +5,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = merge(common, {
     mode: 'production',
-    devtool: 'hidden-source-map',
+    devtool: 'source-map',
     optimization: {
         minimizer: [
             new TerserPlugin({

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -5,7 +5,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = merge(common, {
     mode: 'production',
-    devtool: 'source-map',
+    devtool: 'hidden-source-map',
     optimization: {
         minimizer: [
             new TerserPlugin({


### PR DESCRIPTION
Without this change, the row and column numbers will be wrong when JSErrors are applied to source maps, because they will mapped to the compiled JS files, not the original TS files. 

TypeScript is supposed to output inline source maps for the JS files that they ultimately create. These TS->JS source maps are necessary so that the line number is actually correct when we debug our TS files. Webpack also needs this information so it knows what to include in the final CDN distro. Currently, we are vending the bad source maps to https://client.rum.us-east-1.amazonaws.com/1.x/cwr.js.map; however, the source map distributions are not advertised. 

Documentation for TS -> JS -> Webpack source maps
https://webpack.js.org/guides/typescript/#source-maps

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
