### PR TITLE
Use port from endpoint url to create HttpRequestOptions: fix for 594

### DIFF
--- a/src/dispatch/DataPlaneClient.ts
+++ b/src/dispatch/DataPlaneClient.ts
@@ -114,7 +114,11 @@ export class DataPlaneClient {
         const options = {
             method: METHOD,
             protocol: this.config.endpoint.protocol,
-            port: this.config.endpoint.port,
+            port:
+                !this.config.endpoint.port ||
+                isNaN(parseInt(this.config.endpoint.port, 10))
+                    ? undefined
+                    : parseInt(this.config.endpoint.port, 10),
             headers: {
                 'content-type': contentType,
                 host: this.config.endpoint.host

--- a/src/dispatch/DataPlaneClient.ts
+++ b/src/dispatch/DataPlaneClient.ts
@@ -114,6 +114,7 @@ export class DataPlaneClient {
         const options = {
             method: METHOD,
             protocol: this.config.endpoint.protocol,
+            port: this.config.endpoint.port,
             headers: {
                 'content-type': contentType,
                 host: this.config.endpoint.host

--- a/src/dispatch/DataPlaneClient.ts
+++ b/src/dispatch/DataPlaneClient.ts
@@ -114,11 +114,7 @@ export class DataPlaneClient {
         const options = {
             method: METHOD,
             protocol: this.config.endpoint.protocol,
-            port:
-                !this.config.endpoint.port ||
-                isNaN(parseInt(this.config.endpoint.port, 10))
-                    ? undefined
-                    : parseInt(this.config.endpoint.port, 10),
+            port: Number(this.config.endpoint.port) || undefined,
             headers: {
                 'content-type': contentType,
                 host: this.config.endpoint.host

--- a/src/dispatch/__tests__/DataPlaneClient.test.ts
+++ b/src/dispatch/__tests__/DataPlaneClient.test.ts
@@ -193,6 +193,28 @@ describe('DataPlaneClient tests', () => {
         );
     });
 
+    test('when the endpoint does not contain port then the fetch request url also contains no  port', async () => {
+        // Init
+        const endpoint = Utils.AWS_RUM_ENDPOINT;
+        const client: DataPlaneClient = createDataPlaneClient({
+            ...defaultConfig,
+            endpoint
+        });
+
+        // Run
+        await client.sendFetch(Utils.PUT_RUM_EVENTS_REQUEST);
+
+        // Assert
+        const signedRequest: HttpRequest = (
+            fetchHandler.mock.calls[0] as any
+        )[0];
+        expect(signedRequest.port).toBeUndefined();
+        expect(signedRequest.hostname).toEqual(Utils.AWS_RUM_ENDPOINT.hostname);
+        expect(signedRequest.path).toEqual(
+            `${endpoint.pathname.replace(/\/$/, '')}/appmonitors/application123`
+        );
+    });
+
     test('when the endpoint contains a path then the beacon request url contains the path prefix', async () => {
         // Init
         const endpoint = new URL(`${Utils.AWS_RUM_ENDPOINT}${'prod'}`);
@@ -253,6 +275,29 @@ describe('DataPlaneClient tests', () => {
 
         expect(signedRequest.port).toEqual(8080);
         expect(signedRequest.hostname).toEqual('localhost');
+        expect(signedRequest.path).toEqual(
+            `${endpoint.pathname.replace(/\/$/, '')}/appmonitors/application123`
+        );
+    });
+
+    test('when the endpoint does not contain port then the beacon request url also does not contains  port', async () => {
+        // Init
+        const endpoint = Utils.AWS_RUM_ENDPOINT;
+        const client: DataPlaneClient = createDataPlaneClient({
+            ...defaultConfig,
+            endpoint
+        });
+
+        // Run
+        await client.sendBeacon(Utils.PUT_RUM_EVENTS_REQUEST);
+
+        // Assert
+        const signedRequest: HttpRequest = (
+            beaconHandler.mock.calls[0] as any
+        )[0];
+
+        expect(signedRequest.port).toBeUndefined();
+        expect(signedRequest.hostname).toEqual(Utils.AWS_RUM_ENDPOINT.hostname);
         expect(signedRequest.path).toEqual(
             `${endpoint.pathname.replace(/\/$/, '')}/appmonitors/application123`
         );

--- a/src/dispatch/__tests__/DataPlaneClient.test.ts
+++ b/src/dispatch/__tests__/DataPlaneClient.test.ts
@@ -171,6 +171,28 @@ describe('DataPlaneClient tests', () => {
         );
     });
 
+    test('when the endpoint contains port then the fetch request url also contains the same port', async () => {
+        // Init
+        const endpoint = new URL('https://localhost:8080');
+        const client: DataPlaneClient = createDataPlaneClient({
+            ...defaultConfig,
+            endpoint
+        });
+
+        // Run
+        await client.sendFetch(Utils.PUT_RUM_EVENTS_REQUEST);
+
+        // Assert
+        const signedRequest: HttpRequest = (
+            fetchHandler.mock.calls[0] as any
+        )[0];
+        expect(signedRequest.port).toEqual(8080);
+        expect(signedRequest.hostname).toEqual('localhost');
+        expect(signedRequest.path).toEqual(
+            `${endpoint.pathname.replace(/\/$/, '')}/appmonitors/application123`
+        );
+    });
+
     test('when the endpoint contains a path then the beacon request url contains the path prefix', async () => {
         // Init
         const endpoint = new URL(`${Utils.AWS_RUM_ENDPOINT}${'prod'}`);
@@ -208,6 +230,29 @@ describe('DataPlaneClient tests', () => {
             beaconHandler.mock.calls[0] as any
         )[0];
         expect(signedRequest.hostname).toEqual(Utils.AWS_RUM_ENDPOINT.hostname);
+        expect(signedRequest.path).toEqual(
+            `${endpoint.pathname.replace(/\/$/, '')}/appmonitors/application123`
+        );
+    });
+
+    test('when the endpoint contains port then the beacon request url also contains the same port', async () => {
+        // Init
+        const endpoint = new URL('https://localhost:8080');
+        const client: DataPlaneClient = createDataPlaneClient({
+            ...defaultConfig,
+            endpoint
+        });
+
+        // Run
+        await client.sendBeacon(Utils.PUT_RUM_EVENTS_REQUEST);
+
+        // Assert
+        const signedRequest: HttpRequest = (
+            beaconHandler.mock.calls[0] as any
+        )[0];
+
+        expect(signedRequest.port).toEqual(8080);
+        expect(signedRequest.hostname).toEqual('localhost');
         expect(signedRequest.path).toEqual(
             `${endpoint.pathname.replace(/\/$/, '')}/appmonitors/application123`
         );


### PR DESCRIPTION
---

This is fix for https://github.com/aws-observability/aws-rum-web/issues/594 . 

These options are used to create HttpRequest (https://github.com/aws-observability/aws-rum-web/blob/032a9f5561fea8a9789ad934009d46a9d3d7c388/src/dispatch/DataPlaneClient.ts#L76) , which is then used to create the rum URL ( https://github.com/aws-observability/aws-rum-web/blob/032a9f5561fea8a9789ad934009d46a9d3d7c388/src/dispatch/FetchHttpHandler.ts#L70) 
