### PR TITLE
chore: Upgrade ubantu version to replace deprecating version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
     unit-test:
         name: Check Format and Run Unit Tests
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         permissions: read-all
         steps:
             - name: Checkout AWS RUM Web Client Repository
@@ -52,7 +52,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-20.04, windows-latest]
+                os: [ubuntu-latest, windows-latest]
 
         steps:
             - name: Checkout AWS RUM Web Client Repository
@@ -73,8 +73,8 @@ jobs:
 
             - run: npm ci
 
-            - name: Run Integ Tests on ubuntu-20.04
-              if: matrix.os == 'ubuntu-20.04'
+            - name: Run Integ Tests on ubuntu-latest
+              if: matrix.os == 'ubuntu-latest'
               run: |
                   npm run integ:headless-linux
 


### PR DESCRIPTION
The Ubantu version we are using for our Github workflows will stop working on 2025-04-01. 
This PR changes the workflow to use latest version automatically. 

Ref: https://github.com/actions/runner-images/issues/11101

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
