### PR TITLE
[bug-fix] Make it possible to grant xray traces with an http request in Nuxt3

### DIFF
--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -168,10 +168,17 @@ export const addAmznTraceIdHeaderToInit = (
     if (!init.headers) {
         init.headers = {};
     }
-    (init.headers as any)[X_AMZN_TRACE_ID] = getAmznTraceIdHeaderValue(
-        traceId,
-        segmentId
-    );
+    if ((init.headers as any).set) {
+        (init.headers as any).set(
+            X_AMZN_TRACE_ID,
+            getAmznTraceIdHeaderValue(traceId, segmentId)
+        );
+    } else {
+        (init.headers as any)[X_AMZN_TRACE_ID] = getAmznTraceIdHeaderValue(
+            traceId,
+            segmentId
+        );
+    }
 };
 
 export const addAmznTraceIdHeaderToHeaders = (


### PR DESCRIPTION
…
issue #615 

Resolves an issue where X_AMZN_TRACE_ID is not assigned to the http request header in nuxt3 (ofetch).
The cause is that in AddamznTraceIdHeaderToInit, a trace has been added as a property like init.headers [X_AMZN_TRACE_ID], but it is actually a Header object, so it doesn't work properly.
In contrast to this, in the case of an object that has a set method, set is used to assign a trace ID.

Before fix
![Image](https://github.com/user-attachments/assets/df690a9b-d1b7-4b2b-8a8d-113c2d18b678)

After fix
![image](https://github.com/user-attachments/assets/b3d5fa98-9301-42ab-9ba0-c5a266d2b2ca)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
