### PR TITLE
chore: Update smoke tests to send requests with custom headers

### DIFF
--- a/smoke/smoke-test-application-CDN/smoke.html
+++ b/smoke/smoke-test-application-CDN/smoke.html
@@ -33,7 +33,12 @@
                 endpoint: $ENDPOINT,
                 telemetries: ['performance', 'errors', 'http', 'interaction'],
                 allowCookies: true,
-                enableXRay: true
+                enableXRay: true,
+                headers: {
+                    Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`,
+                    'x-api-key': 'a1b2c3d4e5f6',
+                    'content-type': 'application/json'
+                }
             });
         </script>
 

--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
@@ -2,6 +2,8 @@
 const { AwsRum, AwsRumConfig } = require('aws-rum-web');
 
 let awsRum;
+const token =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
 
 try {
     const config: AwsRumConfig = {
@@ -13,6 +15,11 @@ try {
         enableXRay: true,
         cookieAttributes: {
             unique: true
+        },
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'x-api-key': 'a1b2c3d4e5f6',
+            'content-type': 'application/json'
         }
     };
 

--- a/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
@@ -2,6 +2,8 @@
 import { AwsRum, AwsRumConfig } from 'aws-rum-web';
 
 let awsRum;
+const token =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
 
 try {
     const config: AwsRumConfig = {
@@ -13,6 +15,11 @@ try {
         enableXRay: true,
         cookieAttributes: {
             unique: true
+        },
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'x-api-key': 'a1b2c3d4e5f6',
+            'content-type': 'application/json'
         }
     };
 


### PR DESCRIPTION
This PR updates smoke tests to send requests with custom headers and increases test coverage to changes made in https://github.com/aws-observability/aws-rum-web/pull/610. 

Ran smoke tests in forked branch and most tests are passing with the exception of the one that verifies ingestion of navigation events: https://github.com/limhjgrace/aws-rum-web/actions/runs/14112183767/job/39533498647

I verified that this test also fails with latest mainline changes so it is most likely that the failing test is not caused by the custom headers change: https://github.com/limhjgrace/aws-rum-web/actions/runs/14097032216. Will be investigating failing smoke test outside the scope of the custom headers PR.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
