### PR TITLE
chore: use fetch() instead of sendBeacon() in smoke tests

### DIFF
--- a/app/smoke.html
+++ b/app/smoke.html
@@ -33,7 +33,8 @@
                 endpoint: $ENDPOINT,
                 telemetries: ['performance', 'errors', 'http', 'interaction'],
                 allowCookies: true,
-                enableXRay: true
+                enableXRay: true,
+                useBeacon: false
             });
         </script>
 

--- a/smoke/smoke-test-application-CDN/smoke.html
+++ b/smoke/smoke-test-application-CDN/smoke.html
@@ -38,7 +38,8 @@
                     Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`,
                     'x-api-key': 'a1b2c3d4e5f6',
                     'content-type': 'application/json'
-                }
+                },
+                useBeacon: false
             });
         </script>
 

--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-2.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-2.ts
@@ -13,7 +13,8 @@ try {
         enableXRay: true,
         cookieAttributes: {
             unique: true
-        }
+        },
+        useBeacon: false
     };
 
     const APPLICATION_ID: string = $MONITOR_ID_2;

--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
@@ -20,7 +20,8 @@ try {
             Authorization: `Bearer ${token}`,
             'x-api-key': 'a1b2c3d4e5f6',
             'content-type': 'application/json'
-        }
+        },
+        useBeacon: false
     };
 
     const APPLICATION_ID: string = $MONITOR_ID;

--- a/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-2.ts
+++ b/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-2.ts
@@ -13,7 +13,8 @@ try {
         enableXRay: true,
         cookieAttributes: {
             unique: true
-        }
+        },
+        useBeacon: false
     };
 
     const APPLICATION_ID: string = $MONITOR_ID_2;

--- a/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
@@ -20,7 +20,8 @@ try {
             Authorization: `Bearer ${token}`,
             'x-api-key': 'a1b2c3d4e5f6',
             'content-type': 'application/json'
-        }
+        },
+        useBeacon: false
     };
 
     const APPLICATION_ID: string = $MONITOR_ID;


### PR DESCRIPTION
## Why

Fix the smoke test for CLS. This does not have any impact on the prod behavior. 

https://github.com/williazz/aws-rum-web/actions/runs/14180465141/job/39725211063

## Root cause

Playwright's `waitForResponse` is unaware of sendBeacon API, which means it will never find the CLS event. Instead, we must use fetch. 

Previously, it seems likely that the smoke tests were using fetch instead of sendBeacon under the hood due to an unaddressed race condition. After #631 addressed the race condition, then playwright became completely blind. 

## Implementation

Set useBeacon=false in smoke tests. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
