### PR TITLE
fix: resolve off by one error in session expiration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aws-rum-web",
-    "version": "1.21.0",
+    "version": "1.22.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-rum-web",
-            "version": "1.21.0",
+            "version": "1.22.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^3.0.0",

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -124,7 +124,7 @@ export class SessionManager {
             this.createSession();
         } else if (
             this.session.sessionId !== NIL_UUID &&
-            new Date() > this.sessionExpiry
+            new Date() >= this.sessionExpiry
         ) {
             // The session has expired. Create a new one.
             this.createSession();

--- a/src/sessions/__tests__/SessionManager.test.ts
+++ b/src/sessions/__tests__/SessionManager.test.ts
@@ -86,7 +86,7 @@ describe('SessionManager tests', () => {
         navigatorCookieEnabled = true;
         removeCookie(SESSION_COOKIE_NAME, DEFAULT_CONFIG.cookieAttributes);
         removeCookie(USER_COOKIE_NAME, DEFAULT_CONFIG.cookieAttributes);
-        jest.useRealTimers();
+        jest.useRealTimers(); // This avoids stack overflow to document.location.toString() in jest's mock browser environment
         mockRecord.mockClear();
     });
 


### PR DESCRIPTION
## Summary

I was deflaking the session manager tests, and realized the root cause was an off by one error in the session expiration logic. 

These three unit tests were flaky because sessionExpirationTime is set to 0, and sometimes the sessions did not expire because 0 ms elapsed in between calls to getSession(). 

1. when cookies are disabled during runtime and session expires then getSession returns new session
2. when cookies are enabled during runtime and session expires then getSession returns new session
3. when the sessionId cookie expires then a new sessionId is created

## Implementation

Just change the `>` to `>=`

## Tests

Removed manual time advancements which were being used to force expire the sessions. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
