### PR TITLE
feat: add configuration option to normalize URLs on HTTP events (Fetch and XHR plugins)

### DIFF
--- a/src/plugins/event-plugins/FetchPlugin.ts
+++ b/src/plugins/event-plugins/FetchPlugin.ts
@@ -224,10 +224,16 @@ export class FetchPlugin extends MonkeyPatched<Window, 'fetch'> {
         init?: RequestInit
     ): HttpEvent => {
         const request = input as Request;
+        const url = resourceToUrlString(input);
+        const normalizedUrl =
+            typeof this.config.eventURLNormalizer === 'function'
+                ? this.config.eventURLNormalizer(url)
+                : url;
+
         return {
             version: '1.0.0',
             request: {
-                url: resourceToUrlString(input),
+                url: normalizedUrl,
                 method: init?.method
                     ? init.method
                     : request.method

--- a/src/plugins/event-plugins/XhrPlugin.ts
+++ b/src/plugins/event-plugins/XhrPlugin.ts
@@ -250,14 +250,27 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
         return status >= 200 && status < 300;
     }
 
+    private createHttpEvent(xhrDetails: XhrDetails): HttpEvent {
+        const url = xhrDetails.url;
+
+        const normalizedUrl =
+            typeof this.config.eventURLNormalizer === 'function'
+                ? this.config.eventURLNormalizer(url)
+                : url;
+
+        return {
+            version: '1.0.0',
+            request: { method: xhrDetails.method, url: normalizedUrl }
+        };
+    }
+
     private recordHttpEventWithResponse(
         xhrDetails: XhrDetails,
         xhr: XMLHttpRequest
     ) {
         this.xhrMap.delete(xhr);
         const httpEvent: HttpEvent = {
-            version: '1.0.0',
-            request: { method: xhrDetails.method, url: xhrDetails.url },
+            ...this.createHttpEvent(xhrDetails),
             response: { status: xhr.status, statusText: xhr.statusText }
         };
         if (this.isTracingEnabled()) {
@@ -276,8 +289,7 @@ export class XhrPlugin extends MonkeyPatched<XMLHttpRequest, 'send' | 'open'> {
     ) {
         this.xhrMap.delete(xhr);
         const httpEvent: HttpEvent = {
-            version: '1.0.0',
-            request: { method: xhrDetails.method, url: xhrDetails.url },
+            ...this.createHttpEvent(xhrDetails),
             error: errorEventToJsErrorEvent(
                 {
                     type: 'error',

--- a/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/FetchPlugin.test.ts
@@ -1094,4 +1094,37 @@ describe('FetchPlugin tests', () => {
         expect(record).toHaveBeenCalledTimes(1);
         expect(record.mock.calls[0][0]).toEqual(XRAY_TRACE_EVENT_TYPE);
     });
+
+    test('when eventURLNormalizer is present then HTTP event URL is modified by it', async () => {
+        // Init
+        const URL_NORMALIZED = 'example.com';
+        const config: Partial<HttpPluginConfig> = {
+            recordAllRequests: true,
+            eventURLNormalizer: () => {
+                return URL_NORMALIZED;
+            }
+        };
+
+        const plugin: FetchPlugin = new FetchPlugin(config);
+        plugin.load(xRayOffContext);
+
+        // Run
+        await fetch(URL);
+        plugin.disable();
+
+        // Assert
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(record).toHaveBeenCalledTimes(1);
+        expect(record.mock.calls[0][0]).toEqual(HTTP_EVENT_TYPE);
+        expect(record.mock.calls[0][1]).toMatchObject({
+            request: {
+                method: 'GET',
+                url: URL_NORMALIZED
+            },
+            response: {
+                status: 200,
+                statusText: 'OK'
+            }
+        });
+    });
 });

--- a/src/plugins/utils/http-utils.ts
+++ b/src/plugins/utils/http-utils.ts
@@ -28,6 +28,24 @@ export type HttpPluginConfig = {
     // the X-Amzn-Trace-Id header should test their applications before enabling
     // it in a production environment.
     addXRayTraceIdHeader: boolean | RegExp[];
+    /**
+     * Use this function to normalize URLs before recording the HTTP Event in RUM.
+     * This is useful when you want to obfuscate sensitive information in the URL or group URLs with similar patterns together (i.e. path parameters)
+     * Or even, to have a clearer naming for known services.
+     *
+     * Example use cases:
+     *
+     * @example normalizing path params
+     *  /users/1234
+     *  /users/5678
+     * can be normalized to
+     *  /users/{userId}
+     * @example
+     *  /users/1234
+     * can be normalized to
+     *  GetUsersById
+     */
+    eventURLNormalizer?: (url: string) => string;
 };
 
 export const isTraceIdHeaderEnabled = (


### PR DESCRIPTION
# Feature proposal

This PR adds a new configuration option to the HTTP telemetry.

```ts
eventURLNormalizer?: (url: string) => string;
```

> PS: Nomenclature is up to debate

This function will be invoked before recording the HTTP event in RUM. And is useful for scenarios like the following:

1. HTTP requests done for a single endpoint that contains Path Parameters:
```
/users/1234
/users/5678

Can be normalized to, e.g.:
/users/{userId}
```

This helps avoiding noise in the RUM monitor by aggregating data (request count, sessions, etc) about same endpoints in a single "row".

2. HTTP requests that contain possibly sensitive information in the URL 

```
/users/<some-sensitive-info-here>
```

3. For normalizing known services, to help finding information in the code faster

```
/users/1234

Can be normalized to, e.g.:
"My Service Name - GetUserById"
```

## Considerations

- I have been running this in a patched version in my project and did not experience any regression issues.

- I have considered not exposing this configuration as a function! 
Instead it would be receiving URL patterns and what to replace it with. (a similar configuration to `urlsToInclude`) to avoid shifting complexity to consumers. 
But that would be more complexity to be maintained here, and could not be predicting all scenarios. So I followed the idea of the `ignore` function (from JSError plugin)

- I have NOT changed all files (documentation, integration tests, etc) because I want to collect feedback for the proposal first.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
