### PR TITLE
Revert "feat: fetch with keepalive (#618)"

### DIFF
--- a/src/dispatch/FetchHttpHandler.ts
+++ b/src/dispatch/FetchHttpHandler.ts
@@ -88,38 +88,37 @@ export class FetchHttpHandler implements HttpHandler {
 
         const fetchRequest = new Request(url, requestOptions);
         const raceOfPromises = [
-            this.fetchFunction!.apply(window, [
-                fetchRequest,
-                { keepalive: true }
-            ]).then((response) => {
-                const fetchHeaders: any = response.headers;
-                const transformedHeaders: HeaderBag = {};
+            this.fetchFunction!.apply(window, [fetchRequest]).then(
+                (response) => {
+                    const fetchHeaders: any = response.headers;
+                    const transformedHeaders: HeaderBag = {};
 
-                for (const pair of fetchHeaders.entries() as string[][]) {
-                    transformedHeaders[pair[0]] = pair[1];
-                }
+                    for (const pair of fetchHeaders.entries() as string[][]) {
+                        transformedHeaders[pair[0]] = pair[1];
+                    }
 
-                const hasReadableStream = response.body !== undefined;
+                    const hasReadableStream = response.body !== undefined;
 
-                // Return the response with buffered body
-                if (!hasReadableStream) {
-                    return response.blob().then((body) => ({
+                    // Return the response with buffered body
+                    if (!hasReadableStream) {
+                        return response.blob().then((body) => ({
+                            response: new HttpResponse({
+                                headers: transformedHeaders,
+                                statusCode: response.status,
+                                body
+                            })
+                        }));
+                    }
+                    // Return the response with streaming body
+                    return {
                         response: new HttpResponse({
                             headers: transformedHeaders,
                             statusCode: response.status,
-                            body
+                            body: response.body
                         })
-                    }));
+                    };
                 }
-                // Return the response with streaming body
-                return {
-                    response: new HttpResponse({
-                        headers: transformedHeaders,
-                        statusCode: response.status,
-                        body: response.body
-                    })
-                };
-            }),
+            ),
             requestTimeout(requestTimeoutInMs)
         ];
         if (abortSignal) {


### PR DESCRIPTION
Chromium based browsers enforce a 65 kb limit when keepalive is enabled. This should not be enabled by default. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
