### PR TITLE
fix: Add quotes around message to fix npm deprecate command

### DIFF
--- a/.github/workflows/npm_deprecate.yaml
+++ b/.github/workflows/npm_deprecate.yaml
@@ -24,6 +24,6 @@ jobs:
                   node-version: '20.x'
                   registry-url: 'https://registry.npmjs.org'
             - name: Deprecate Version
-              run: npm deprecate aws-rum-web@${{ github.event.inputs.version }} ${{ github.event.inputs.message }}
+              run: npm deprecate aws-rum-web@${{ github.event.inputs.version }} "${{ github.event.inputs.message }}"
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The current NPM deprecate workflow does not format the deprecating message correctly and so, only recognizes the first word of the message. For example: https://www.npmjs.com/package/aws-rum-web/v/1.22.0.

This PR will add quotes around the message so that the full message is included. Tested in forked repo that the `npm deprecate` command is formatted correctly: https://github.com/limhjgrace/aws-rum-web/actions/runs/14543965537/job/40806747504

Command now correctly wraps message in quotes:
```
npm deprecate aws-rum-web-experimental@1.9.0-alpha.1 "Testing deprecate command fix"
```

Workflow failed due to NPM token issues. Manually ran the command above and verified it worked: https://www.npmjs.com/package/aws-rum-web-experimental/v/1.9.0-alpha.1

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
