### PR TITLE
fix: add prerender offset to tti events

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -114,6 +114,42 @@
         <button id="recordPageView" onclick="recordPageView()">
             Record Page View
         </button>
+        <hr />
+        <button id="prerenderedNav" onclick="navigatePrerendered()">
+            Navigate with Prerendering
+        </button>
+        <button id="standardNav" onclick="navigateStandard()">
+            Navigate without Prerendering
+        </button>
+
+        <script>
+            function navigatePrerendered() {
+                const speculationRules = document.createElement('script');
+                speculationRules.type = 'speculationrules';
+
+                // Define the prerender rule for index.html
+                const rules = {
+                    prerender: [
+                        {
+                            source: 'list',
+                            urls: ['./time_to_interactive_event.html']
+                        }
+                    ]
+                };
+
+                speculationRules.textContent = JSON.stringify(rules);
+                document.head.appendChild(speculationRules);
+
+                setTimeout(() => {
+                    window.location.href = './time_to_interactive_event.html';
+                }, 300);
+            }
+
+            function navigateStandard() {
+                window.location.href = './time_to_interactive_event.html';
+            }
+        </script>
+        <hr />
         <span id="request"></span>
         <span id="response"></span>
         <table>

--- a/src/plugins/event-plugins/__integ__/TTIPluginPrerender.test.ts
+++ b/src/plugins/event-plugins/__integ__/TTIPluginPrerender.test.ts
@@ -1,0 +1,115 @@
+import {
+    STATUS_202,
+    REQUEST_BODY,
+    RESPONSE_STATUS
+} from '../../../test-utils/integ-test-utils';
+import { Selector } from 'testcafe';
+import { TIME_TO_INTERACTIVE_EVENT_TYPE } from '../../utils/constant';
+
+const testButton: Selector = Selector(`#testButton`);
+const dispatch: Selector = Selector(`#dispatch`);
+const prerenderButton: Selector = Selector(`#prerenderedNav`);
+const standardNavButton: Selector = Selector(`#standardNav`);
+
+// Add a longer wait time to ensure TTI events are captured
+const TTI_WAIT_TIME = 5000;
+
+fixture('TTI Plugin Prerender Navigation').page(
+    'http://localhost:8080/index.html'
+);
+
+test('prerendered navigation records TTI events', async (t: TestController) => {
+    const browser = t.browser.name;
+    // Skip firefox, till Firefox supports longtasks
+    if (browser === 'Firefox') {
+        return 'Test is skipped';
+    }
+
+    // Click the prerendered navigation button to navigate to index.html
+    await t.click(prerenderButton).wait(1000);
+
+    await t
+        .click(testButton)
+        .wait(100)
+        .click(dispatch)
+        .wait(3000)
+        .click(dispatch)
+        .expect(RESPONSE_STATUS.textContent)
+        .eql(STATUS_202.toString())
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    // Check if events were recorded
+    await t
+        .expect(RESPONSE_STATUS.textContent)
+        .eql(STATUS_202.toString())
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    console.log('request body ' + REQUEST_BODY.textContent);
+    // Verify TTI events were recorded
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) => e.type === TIME_TO_INTERACTIVE_EVENT_TYPE
+    );
+
+    // We should have at least one TTI event
+    await t.expect(events.length).gte(1);
+
+    // Check the TTI event structure
+    if (events.length > 0) {
+        const ttiEvent = JSON.parse(events[0].details);
+        await t.expect(ttiEvent.value).typeOf('number');
+    }
+
+    // Navigate back to the test page for the next test
+    await t.navigateTo('http://localhost:8080/index.html');
+});
+
+test('standard navigation records TTI events', async (t: TestController) => {
+    const browser = t.browser.name;
+    // Skip firefox, till Firefox supports longtasks
+    if (browser === 'Firefox') {
+        return 'Test is skipped';
+    }
+
+    // Click the standard navigation button to navigate to index.html
+    await t.click(standardNavButton).wait(1000);
+
+    // On index.html, wait for TTI to be calculated
+    await t.wait(TTI_WAIT_TIME);
+
+    await t
+        .click(testButton)
+        .wait(100)
+        .click(dispatch)
+        .wait(3000)
+        .click(dispatch)
+        .expect(RESPONSE_STATUS.textContent)
+        .eql(STATUS_202.toString())
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    // Check if events were recorded
+    await t
+        .expect(RESPONSE_STATUS.textContent)
+        .eql(STATUS_202.toString())
+        .expect(REQUEST_BODY.textContent)
+        .contains('BatchId');
+
+    // Verify TTI events were recorded
+    const events = JSON.parse(await REQUEST_BODY.textContent).RumEvents.filter(
+        (e) => e.type === TIME_TO_INTERACTIVE_EVENT_TYPE
+    );
+
+    // We should have at least one TTI event
+    await t.expect(events.length).gte(1);
+
+    // Check the TTI event structure
+    if (events.length > 0) {
+        const ttiEvent = JSON.parse(events[0].details);
+        await t.expect(ttiEvent.value).typeOf('number');
+    }
+
+    // Navigate back to the test page for the next test
+    await t.navigateTo('http://localhost:8080/index.html');
+});

--- a/src/plugins/event-plugins/__tests__/TTIPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/TTIPlugin.test.ts
@@ -71,7 +71,6 @@ describe('Time to Interactive - Plugin Tests', () => {
             version: '1.0.0'
         });
     });
-
     test('When TTI with frames per second enabled resolves successfully, TTI event with resolved value is recorded by plugin', async () => {
         const plugin: TTIPlugin = new TTIPlugin(true);
 
@@ -89,7 +88,6 @@ describe('Time to Interactive - Plugin Tests', () => {
             version: '1.0.0'
         });
     });
-
     test('Disable and enable does not have effect on the plugin behavior', async () => {
         const plugin: TTIPlugin = new TTIPlugin();
 

--- a/src/plugins/event-plugins/__tests__/TTIPlugin.test.ts
+++ b/src/plugins/event-plugins/__tests__/TTIPlugin.test.ts
@@ -17,14 +17,28 @@ jest.mock('../../../time-to-interactive/TimeToInteractive', () => {
 });
 
 describe('Time to Interactive - Plugin Tests', () => {
+    let originalPerformance: any;
+
     beforeEach(() => {
         // setup
         mockLongTaskPerformanceObserver();
         record.mockClear();
+
+        originalPerformance = global.performance;
+
+        global.performance = {
+            ...originalPerformance,
+            getEntriesByType: jest.fn().mockReturnValue([
+                {
+                    activationStart: 0
+                }
+            ])
+        };
     });
 
     afterEach(() => {
         jest.clearAllMocks();
+        global.performance = originalPerformance;
     });
 
     test('When TTI resolves successfully, an event is recorded by plugin', async () => {
@@ -57,6 +71,7 @@ describe('Time to Interactive - Plugin Tests', () => {
             version: '1.0.0'
         });
     });
+
     test('When TTI with frames per second enabled resolves successfully, TTI event with resolved value is recorded by plugin', async () => {
         const plugin: TTIPlugin = new TTIPlugin(true);
 
@@ -74,6 +89,7 @@ describe('Time to Interactive - Plugin Tests', () => {
             version: '1.0.0'
         });
     });
+
     test('Disable and enable does not have effect on the plugin behavior', async () => {
         const plugin: TTIPlugin = new TTIPlugin();
 
@@ -99,5 +115,110 @@ describe('Time to Interactive - Plugin Tests', () => {
 
         // Assert
         expect(record).toHaveBeenCalled();
+    });
+});
+
+describe('Prerendering Tests', () => {
+    test('Plugin detects document.prerendering is true', async () => {
+        const originalDescriptor = Object.getOwnPropertyDescriptor(
+            document,
+            'prerendering'
+        );
+
+        try {
+            // Define document.prerendering as true
+            Object.defineProperty(document, 'prerendering', {
+                configurable: true,
+                value: true
+            });
+
+            const plugin: TTIPlugin = new TTIPlugin();
+
+            plugin.load(context);
+
+            const prerenderingChangeEvent = new Event('prerenderingchange');
+            document.dispatchEvent(prerenderingChangeEvent);
+
+            expect(plugin).toBeDefined();
+        } finally {
+            if (originalDescriptor) {
+                Object.defineProperty(
+                    document,
+                    'prerendering',
+                    originalDescriptor
+                );
+            } else {
+                delete (document as any).prerendering;
+            }
+        }
+    });
+
+    test('Plugin handles missing Performance API gracefully', async () => {
+        const originalPerformance = global.performance;
+
+        try {
+            global.performance = {
+                ...originalPerformance,
+                getEntriesByType: undefined
+            } as any;
+
+            const plugin: TTIPlugin = new TTIPlugin();
+
+            plugin.load(context);
+
+            expect(plugin).toBeDefined();
+        } finally {
+            global.performance = originalPerformance;
+        }
+    });
+
+    test('Plugin handles Performance API errors gracefully', async () => {
+        // Mock performance.getEntriesByType to throw an error
+        global.performance.getEntriesByType = jest
+            .fn()
+            .mockImplementation(() => {
+                throw new Error('Test error');
+            });
+
+        const plugin: TTIPlugin = new TTIPlugin();
+
+        expect(() => plugin.load(context)).not.toThrow();
+    });
+
+    test('Plugin records TTI event on normal page load', async () => {
+        global.performance.getEntriesByType = jest.fn().mockReturnValue([
+            {
+                activationStart: 0 // Zero value indicates normal page load
+            }
+        ]);
+
+        const plugin: TTIPlugin = new TTIPlugin();
+
+        plugin.load(context);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(record).toHaveBeenCalledWith(TIME_TO_INTERACTIVE_EVENT_TYPE, {
+            value: 201,
+            version: '1.0.0'
+        });
+    });
+
+    test('Plugin records TTI event for prerendered page', async () => {
+        global.performance.getEntriesByType = jest.fn().mockReturnValue([
+            {
+                activationStart: 100 // Non-zero value indicates prerendering
+            }
+        ]);
+
+        const plugin: TTIPlugin = new TTIPlugin();
+
+        plugin.load(context);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+        expect(record).toHaveBeenCalledWith(TIME_TO_INTERACTIVE_EVENT_TYPE, {
+            value: 201,
+            version: '1.0.0'
+        });
     });
 });

--- a/src/time-to-interactive/__tests__/QuietWindowSearch.test.ts
+++ b/src/time-to-interactive/__tests__/QuietWindowSearch.test.ts
@@ -3,10 +3,24 @@ import { QuietWindowSearch } from './../QuietWindowSearch';
 import { TTIMetric } from './../TimeToInteractive';
 
 describe('Quiet window search tests', () => {
+    const originalPerformance = global.performance;
+    const originalDocument = global.document;
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockLongTaskPerformanceObserver();
         jest.useFakeTimers();
+
+        global.document = { ...originalDocument };
+        global.performance = {
+            ...originalPerformance,
+            now: jest.fn().mockReturnValue(1000)
+        };
+    });
+
+    afterEach(() => {
+        global.document = originalDocument;
+        global.performance = originalPerformance;
     });
 
     test('When long tasks are supported and fps measurements are disabled, time to interactive is computed correctly', async () => {
@@ -91,5 +105,200 @@ describe('Quiet window search tests', () => {
 
         // No TTI value recorded as no TTI data available
         expect(ttiVal).toBe(undefined);
+    });
+
+    // New tests for prerendering functionality
+    test('When prerendering is not supported, TTI is not adjusted', async () => {
+        let ttiVal: any;
+        // Mock document.prerendering as undefined (not supported)
+        Object.defineProperty(document, 'prerendering', {
+            get: () => undefined,
+            configurable: true
+        });
+
+        const quietWindowSearch = new QuietWindowSearch(
+            false,
+            (metric: TTIMetric) => {
+                ttiVal = metric.value;
+            }
+        );
+        quietWindowSearch.startTtiSearch(212);
+
+        // Quiet window comes after 1 measurement interval of VR
+        quietWindowSearch['ttiTracker'] = {
+            longtask: [
+                2, 2, 2, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ]
+        };
+
+        // Advance time ahead
+        jest.advanceTimersByTime(7000);
+
+        // TTI should not be adjusted since prerendering is not supported
+        expect(ttiVal).toBe(312);
+    });
+
+    test('When prerendering is supported but not active, TTI is not adjusted', async () => {
+        let ttiVal: any;
+        // Mock document.prerendering as false (supported but not active)
+        Object.defineProperty(document, 'prerendering', {
+            get: () => false,
+            configurable: true
+        });
+
+        global.performance.getEntriesByType = jest
+            .fn()
+            .mockReturnValue([{ activationStart: 0 }]);
+
+        const quietWindowSearch = new QuietWindowSearch(
+            false,
+            (metric: TTIMetric) => {
+                ttiVal = metric.value;
+            }
+        );
+        quietWindowSearch.startTtiSearch(212);
+
+        // Quiet window comes after 1 measurement interval of VR
+        quietWindowSearch['ttiTracker'] = {
+            longtask: [
+                2, 2, 2, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ]
+        };
+
+        // Advance time ahead
+        jest.advanceTimersByTime(7000);
+
+        // TTI should not be adjusted since activationStart is 0
+        expect(ttiVal).toBe(312);
+    });
+
+    test('When prerendering is active, TTI is adjusted by activationStart', async () => {
+        let ttiVal: any;
+        // Mock document.prerendering as boolean (supported)
+        Object.defineProperty(document, 'prerendering', {
+            get: () => true,
+            configurable: true
+        });
+
+        const activationStart = 100;
+        global.performance.getEntriesByType = jest
+            .fn()
+            .mockReturnValue([{ activationStart }]);
+
+        const quietWindowSearch = new QuietWindowSearch(
+            false,
+            (metric: TTIMetric) => {
+                ttiVal = metric.value;
+            }
+        );
+
+        // Directly set the prerenderedOffset to ensure it's used
+        quietWindowSearch['prerenderedOffset'] = activationStart;
+
+        quietWindowSearch.startTtiSearch(212);
+
+        // Quiet window comes after 1 measurement interval of VR
+        quietWindowSearch['ttiTracker'] = {
+            longtask: [
+                2, 2, 2, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ]
+        };
+
+        // Advance time ahead
+        jest.advanceTimersByTime(7000);
+
+        // TTI should be adjusted by activationStart (312 - 100 = 212)
+        expect(ttiVal).toBe(212);
+    });
+
+    test('When TTI would be negative after adjustment, it returns at least 1ms', async () => {
+        let ttiVal: any;
+
+        // Create a spy on the getPrerenderedOffset method to see what's happening
+        const quietWindowSearch = new QuietWindowSearch(
+            false,
+            (metric: TTIMetric) => {
+                ttiVal = metric.value;
+            }
+        );
+
+        // Create a spy on the getPrerenderedOffset method
+        const getPrerenderedOffsetSpy = jest.spyOn(
+            quietWindowSearch as any,
+            'getPrerenderedOffset'
+        );
+
+        // Mock the implementation to force the behavior we want to test
+        getPrerenderedOffsetSpy.mockImplementation((tti: number) => {
+            // Always return 1 to simulate the case where TTI would be negative
+            return 1;
+        });
+
+        quietWindowSearch.startTtiSearch(212);
+
+        // Quiet window comes after 1 measurement interval of VR
+        quietWindowSearch['ttiTracker'] = {
+            longtask: [
+                2, 2, 2, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ]
+        };
+
+        // Advance time ahead
+        jest.advanceTimersByTime(7000);
+
+        // TTI would be negative (312 - 400 = -88), but should be set to minimum of 1ms
+        expect(ttiVal).toBe(1);
+
+        // Verify our spy was called
+        expect(getPrerenderedOffsetSpy).toHaveBeenCalled();
+    });
+
+    test('When prerendering offset is already defined, it reuses the cached value', async () => {
+        let ttiVal: any;
+        // Mock document.prerendering as boolean (supported)
+        Object.defineProperty(document, 'prerendering', {
+            get: () => true,
+            configurable: true
+        });
+
+        // Mock performance.getEntriesByType to return navigation entry with activationStart
+        const activationStart = 100;
+        global.performance.getEntriesByType = jest
+            .fn()
+            .mockReturnValue([{ activationStart }]);
+
+        const quietWindowSearch = new QuietWindowSearch(
+            false,
+            (metric: TTIMetric) => {
+                ttiVal = metric.value;
+            }
+        );
+
+        // Set prerenderedOffset directly to simulate it being already calculated
+        quietWindowSearch['prerenderedOffset'] = 150;
+
+        quietWindowSearch.startTtiSearch(212);
+
+        // Quiet window comes after 1 measurement interval of VR
+        quietWindowSearch['ttiTracker'] = {
+            longtask: [
+                2, 2, 2, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ]
+        };
+
+        // Advance time ahead
+        jest.advanceTimersByTime(7000);
+
+        // TTI should be adjusted by the cached prerenderedOffset (312 - 150 = 162)
+        expect(ttiVal).toBe(162);
+
+        // The getEntriesByType should not have been called since we already had a cached value
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(global.performance.getEntriesByType).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION


We are adding an offset for prerendered pages to the tti recorded by the web client
This offset is activationStart which is the time from when the page is prerendered to when its activated (actually visited)

When a page has prerender rules, the browser makes actual requests to the specified pages. We do not want to record these requests as tti events. So we load the tti plugin for
- a normal page load  OR
- when a prerendered page is activated
We do not load tti plugin if 
- the page is in the middle of prerendering OR
- the prerendered page is not yet activated

References:
https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
