### PR TITLE
docs: Fix nested array in telemetries example in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,17 +199,15 @@ For example, the following telemetry config array causes the web client to ignor
 
 ```javascript
 telemetries: [
+    'errors',
+    'http',
     [
-        'errors',
-        'http',
-        [
-            'performance',
-            {
-                ignore: (entry: PerformanceEntry) => {
-                    return entry.entryType === 'resource';
-                }
+        'performance',
+        {
+            ignore: (entry: PerformanceEntry) => {
+                return entry.entryType === 'resource';
             }
-        ]
+        }
     ]
 ];
 ```


### PR DESCRIPTION
## Fix incorrect nested array in `telemetries` example in `configuration.md`

This PR corrects an inconsistency in the `telemetries` configuration example in `configuration.md`.

The current example:

```ts
telemetries: [
    [
        'errors',
        'http',
        [
            'performance',
            {
                ignore: (entry: PerformanceEntry) => {
                    return entry.entryType === 'resource';
                }
            }
        ]
    ]
];
```
is wrapped in an unnecessary nested array, which may mislead users into thinking that all telemetry types need to be grouped inside a single array element.

Why this change is needed
Other valid examples in the same document use a flat array of telemetry definitions. For example:
```ts
telemetries: ['errors', 'performance', 'http'];
```
Or:

```ts
telemetries: [
    ['errors', { stackTraceLength: 500 }],
    'performance',
    ['http', { stackTraceLength: 500, addXRayTraceIdHeader: true }]
];
```
Or:

```ts
telemetries: [
    [
        'errors',
        {
            stackTraceLength: 500,
            ignore: (errorEvent) => {
                return (
                    errorEvent &&
                    errorEvent.message &&
                    /^Warning:/.test(errorEvent.message)
                );
            }
        }
    ],
    'performance',
    'http'
];
```
To stay consistent with the examples above, the updated version should be:

```ts
telemetries: [
    'errors',
    'http',
    [
        'performance',
        {
            ignore: (entry: PerformanceEntry) => {
                return entry.entryType === 'resource';
            }
        }
    ]
];
```
This change helps avoid confusion and ensures consistency across the documentation.