### PR TITLE
chore: add more smoke tests for w3c trace format

### DIFF
--- a/src/__smoke-test-npm__/ingestion-integ.spec.ts
+++ b/src/__smoke-test-npm__/ingestion-integ.spec.ts
@@ -409,3 +409,38 @@ test('when xray event is sent with w3c format enabled then the event is ingested
     );
     expect(isIngestionCompleted).toEqual(true);
 });
+
+test('when http events are sent with w3c format enabled then the events are ingested', async ({
+    page
+}) => {
+    const timestamp = Date.now() - 30000;
+
+    // Open page
+    await page.goto(W3C_TEST_URL);
+    const fetch500 = page.locator('[id=httpStatFetch500]');
+    const xhr500 = page.locator('[id=httpStatXhr500]');
+    await fetch500.click();
+    await xhr500.click();
+
+    // Test will timeout if no successful dataplane request is found
+    const response = await page.waitForResponse(async (response) =>
+        isDataPlaneRequest(response, TARGET_URL)
+    );
+
+    // Parse payload to verify event count
+    const requestBody = JSON.parse(response.request().postData());
+
+    const httpEvents = getEventsByType(requestBody, HTTP_EVENT_TYPE);
+    const eventIds = getEventIds(httpEvents);
+
+    // Expect two http events
+    expect(eventIds.length).toEqual(2);
+    const isIngestionCompleted = await verifyIngestionWithRetry(
+        rumClient,
+        eventIds,
+        timestamp,
+        MONITOR_NAME,
+        5
+    );
+    expect(isIngestionCompleted).toEqual(true);
+});

--- a/src/__smoke-test__/ingestion-integ.spec.ts
+++ b/src/__smoke-test__/ingestion-integ.spec.ts
@@ -530,3 +530,38 @@ test('when INP event is sent then event is ingested', async ({ page }) => {
     );
     expect(isIngestionCompleted).toEqual(true);
 });
+
+test('when http events are sent with w3c format enabled then the events are ingested', async ({
+    page
+}) => {
+    const timestamp = Date.now() - 30000;
+
+    // Open page
+    await page.goto(W3C_TEST_URL);
+    const fetch500 = page.locator('[id=httpStatFetch500]');
+    const xhr500 = page.locator('[id=httpStatXhr500]');
+    await fetch500.click();
+    await xhr500.click();
+
+    // Test will timeout if no successful dataplane request is found
+    const response = await page.waitForResponse(async (response) =>
+        isDataPlaneRequest(response, TARGET_URL)
+    );
+
+    // Parse payload to verify event count
+    const requestBody = JSON.parse(response.request().postData());
+
+    const httpEvents = getEventsByType(requestBody, HTTP_EVENT_TYPE);
+    const eventIds = getEventIds(httpEvents);
+
+    // Expect two http events
+    expect(eventIds.length).toEqual(2);
+    const isIngestionCompleted = await verifyIngestionWithRetry(
+        rumClient,
+        eventIds,
+        timestamp,
+        MONITOR_NAME,
+        5
+    );
+    expect(isIngestionCompleted).toEqual(true);
+});


### PR DESCRIPTION
Add two smoke tests which were removed because the backend changes were not deployed yet
Since the changes are deployed now we are adding back these tests


Smoke test results: https://github.com/ishajos/aws-rum-web/actions/runs/16451816656/job/46498743808

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
