### PR TITLE
test: publish to gamma and run smoke test on merge 

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,6 +3,14 @@ name: AWS RUM Web Client Smoke Tests
 on:
     push:
         branches: [main, release/*.*.*]
+    workflow_call:
+    workflow_dispatch:
+
+concurrency:
+    # Only run one at a time, in case there are multiple triggers (e.g. multiple merges to main)
+    group: smoke-tests
+    # This workflow also uploads to gamma, so we do not want to cancel ongoing work.
+    cancel-in-progress: false
 
 jobs:
     smoke-test:


### PR DESCRIPTION
## Summary

We are only running smoke tests during release, which is too late. Instead, we should be running this test more frequently on merges to main to proactively detect regressions. In addition, this will also keep Gamma CDN release up to date for manual testing.

## Implementation

Created `smoke.yml`, which uses secrets from new environment `smoke-test`. 

## Future

I would like the release workflow `cd.yml` to re-use `smoke.yml`, but I need to do some more testing for that change by doing a test release to `aws-rum-web-experimental`

## Tests

https://github.com/aws-observability/aws-rum-web/actions/runs/20116775237

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
