### PR TITLE
chore: migrate npm release to oidc

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,12 +3,15 @@ name: AWS RUM Web Client Release
 on:
     workflow_dispatch:
 
+permissions:
+    id-token: write
+    contents: read
+
 jobs:
     publish_to_cdn:
         name: Publish New Release
         runs-on: ubuntu-latest
         environment: cdn-prod-release
-        permissions: write-all
         steps:
             - name: Checkout AWS RUM Web Client Repository
               uses: actions/checkout@v4
@@ -29,6 +32,7 @@ jobs:
 
             - name: Build Release
               run: |
+                  npm install -g npm@latest
                   npm ci
                   npm run release
 
@@ -189,9 +193,7 @@ jobs:
               run: npm run smoke:headless
 
             - name: Publish to NPM
-              run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: npm publish --provenance
 
             - name: Build Smoke Test Application - NPM/ES (Post NPM Release)
               id: build-npm-es-application-post-release


### PR DESCRIPTION
## Summary

Permanent hardcoded npm credentials are deprecated in favor of OIDC

https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/

## Implementation

Update aws-rum-web publishing permissions to 

1. aws-observability/aws-rum-web, cd.yaml, cdn-prod-release environment
2. Require two-factor authentication and disallow tokens (recommended)

<img width="749" height="763" alt="Screenshot 2025-12-12 at 12 14 29 AM" src="https://github.com/user-attachments/assets/e0a650e9-8559-4042-8230-024f3d7b757d" />

## Future

I would also like to migrate cd.yaml to re-use smoke.yml from #725, but that requires some more testing and I didn't get to it. 

## Testing

Updated aws-rum-web-experimental publishing permissions to 

1. williazz/aws-rum-web, cd.yaml, cdn-prod-release environment
4. Require two-factor authentication and disallow tokens (recommended)


<img width="721" height="500" alt="Screenshot 2025-12-12 at 12 09 43 AM" src="https://github.com/user-attachments/assets/dc5fa2cf-22bf-4b27-83a3-a2adc89d13f0" />

Published from williazz/aws-rum-web - https://github.com/williazz/aws-rum-web/actions/runs/20160035414

See final artifact - https://www.npmjs.com/package/aws-rum-web-experimental/v/1.25.0

---



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
