### PR TITLE
refactor: migrate from deep to barrel imports

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -36,7 +36,9 @@ module.exports = {
         '**/packages/slim/__tests__/**/*.test.ts'
     ],
     moduleNameMapper: {
+        '^@aws-rum/web-core$': '<rootDir>/packages/core/src',
         '^@aws-rum/web-core/(.*)$': '<rootDir>/packages/core/src/$1',
+        '^@aws-rum/web-slim$': '<rootDir>/packages/slim/src',
         '^@aws-rum/web-slim/(.*)$': '<rootDir>/packages/slim/src/$1'
     },
     transform: {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/es/index';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",
-    "types": "dist/es/index.d.ts",
+    "types": "index.d.ts",
     "sideEffects": false,
     "exports": {
         ".": {
@@ -27,7 +27,8 @@
         }
     },
     "files": [
-        "dist/"
+        "dist/",
+        "index.d.ts"
     ],
     "scripts": {
         "pretest": "npm run build:schemas",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,13 +7,27 @@ export {
     type Telemetry,
     type PageIdFormat
 } from './orchestration/config';
-export { type ClientBuilder } from './dispatch/Dispatch';
-export { type CognitoCredentialProviderFactory } from './dispatch/Dispatch';
-export { type SigningConfigFactory } from './dispatch/Dispatch';
+export {
+    type ClientBuilder,
+    type CognitoCredentialProviderFactory,
+    type SigningConfigFactory,
+    Dispatch
+} from './dispatch/Dispatch';
 export { type SigningConfig } from './dispatch/DataPlaneClient';
+export { BasicAuthentication } from './dispatch/BasicAuthentication';
+export { EnhancedAuthentication } from './dispatch/EnhancedAuthentication';
 export { type PageAttributes } from './sessions/PageManager';
 export { type Plugin } from './plugins/Plugin';
-export { type PluginContext } from './plugins/types';
+export { InternalPlugin } from './plugins/InternalPlugin';
+export {
+    type PluginContext,
+    type InternalPluginContext
+} from './plugins/types';
+export { PluginManager } from './plugins/PluginManager';
+export { EventCache } from './event-cache/EventCache';
+export { default as EventBus, Topic } from './event-bus/EventBus';
+export { InternalLogger } from './utils/InternalLogger';
+export { INSTALL_SCRIPT, INSTALL_MODULE } from './utils/constants';
 export { TTIPlugin } from './plugins/event-plugins/TTIPlugin';
 export * from './plugins/event-plugins/DomEventPlugin';
 export * from './plugins/event-plugins/JsErrorPlugin';

--- a/packages/slim/index.d.ts
+++ b/packages/slim/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/es/index';

--- a/packages/slim/package.json
+++ b/packages/slim/package.json
@@ -6,7 +6,7 @@
     "author": "Amazon CloudWatch RUM Staff <nobody@amazon.com>",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",
-    "types": "dist/es/index.d.ts",
+    "types": "index.d.ts",
     "exports": {
         ".": {
             "import": "./dist/es/index.js",
@@ -29,6 +29,7 @@
     "sideEffects": false,
     "files": [
         "dist/",
+        "index.d.ts",
         "CHANGELOG.md",
         "NOTICE",
         "LICENSE-THIRD-PARTY"

--- a/packages/slim/src/CommandQueue.ts
+++ b/packages/slim/src/CommandQueue.ts
@@ -2,7 +2,7 @@ import {
     AwsCredentialIdentity,
     AwsCredentialIdentityProvider
 } from '@aws-sdk/types';
-import { INSTALL_SCRIPT } from '@aws-rum/web-core/utils/constants';
+import { INSTALL_SCRIPT } from '@aws-rum/web-core';
 import { PartialConfig, Orchestration } from './orchestration/Orchestration';
 
 export type CommandFunction = (payload?: any) => void;

--- a/packages/slim/src/index.ts
+++ b/packages/slim/src/index.ts
@@ -1,15 +1,27 @@
 export {
     type PartialConfig as AwsRumConfig,
+    Orchestration,
     Orchestration as AwsRum,
     type PartialCookieAttributes,
     type PageIdFormat,
-    PageIdFormatEnum
+    PageIdFormatEnum,
+    defaultConfig,
+    defaultCookieAttributes
 } from './orchestration/Orchestration';
-export type { ClientBuilder } from '@aws-rum/web-core/dispatch/Dispatch';
-export type { PageAttributes } from '@aws-rum/web-core/sessions/PageManager';
-export type { Plugin } from '@aws-rum/web-core/plugins/Plugin';
-export type { PluginContext } from '@aws-rum/web-core/plugins/types';
-export { TTIPlugin } from '@aws-rum/web-core/plugins/event-plugins/TTIPlugin';
+export {
+    CommandQueue,
+    type Command,
+    type CommandFunction,
+    type CommandFunctions,
+    type AwsRumClientInit
+} from './CommandQueue';
+export {
+    type ClientBuilder,
+    type PageAttributes,
+    type Plugin,
+    type PluginContext,
+    TTIPlugin
+} from '@aws-rum/web-core';
 export * from '@aws-rum/web-core/plugins/event-plugins/DomEventPlugin';
 export * from '@aws-rum/web-core/plugins/event-plugins/JsErrorPlugin';
 export * from '@aws-rum/web-core/plugins/event-plugins/NavigationPlugin';

--- a/packages/slim/src/orchestration/Orchestration.ts
+++ b/packages/slim/src/orchestration/Orchestration.ts
@@ -1,21 +1,20 @@
-import { InternalPluginContext } from '@aws-rum/web-core/plugins/types';
-import { PluginManager } from '@aws-rum/web-core/plugins/PluginManager';
-import { EventCache } from '@aws-rum/web-core/event-cache/EventCache';
 import {
+    type InternalPluginContext,
+    PluginManager,
+    EventCache,
     Dispatch,
-    SigningConfigFactory
-} from '@aws-rum/web-core/dispatch/Dispatch';
-import { PageViewPlugin } from '@aws-rum/web-core/plugins/event-plugins/PageViewPlugin';
-import { PageAttributes } from '@aws-rum/web-core/sessions/PageManager';
-import { INSTALL_MODULE } from '@aws-rum/web-core/utils/constants';
-import EventBus, { Topic } from '@aws-rum/web-core/event-bus/EventBus';
-import { InternalLogger } from '@aws-rum/web-core/utils/InternalLogger';
-import { Plugin } from '@aws-rum/web-core/plugins/Plugin';
-import {
+    type SigningConfigFactory,
+    PageViewPlugin,
+    type PageAttributes,
+    type Plugin,
     type Config,
     type PartialConfig as CorePartialConfig,
-    type CookieAttributes
-} from '@aws-rum/web-core/orchestration/config';
+    type CookieAttributes,
+    INSTALL_MODULE,
+    EventBus,
+    Topic,
+    InternalLogger
+} from '@aws-rum/web-core';
 import {
     AwsCredentialIdentityProvider,
     AwsCredentialIdentity
@@ -25,7 +24,7 @@ export {
     type Config,
     type CookieAttributes,
     type PageIdFormat
-} from '@aws-rum/web-core/orchestration/config';
+} from '@aws-rum/web-core';
 
 /** Slim config — use `eventPluginsToLoad` for plugins. */
 export type PartialConfig = CorePartialConfig;

--- a/packages/web/__tests__/orchestration/Orchestration.test.ts
+++ b/packages/web/__tests__/orchestration/Orchestration.test.ts
@@ -4,13 +4,15 @@ import {
     defaultCookieAttributes
 } from '../../src/orchestration/Orchestration';
 import { TelemetryEnum } from '../../src/orchestration/config';
-import { Dispatch } from '@aws-rum/web-core/dispatch/Dispatch';
-import { EventCache } from '@aws-rum/web-core/event-cache/EventCache';
-import { DomEventPlugin } from '@aws-rum/web-core/plugins/event-plugins/DomEventPlugin';
-import { JsErrorPlugin } from '@aws-rum/web-core/plugins/event-plugins/JsErrorPlugin';
-import { PluginManager } from '@aws-rum/web-core/plugins/PluginManager';
-import { PageAttributes } from '@aws-rum/web-core/sessions/PageManager';
-import { INSTALL_SCRIPT } from '@aws-rum/web-core/utils/constants';
+import {
+    Dispatch,
+    EventCache,
+    DomEventPlugin,
+    JsErrorPlugin,
+    PluginManager,
+    type PageAttributes,
+    INSTALL_SCRIPT
+} from '@aws-rum/web-core';
 import { performanceEvent } from '@aws-rum/web-core/test-utils/mock-data';
 import { DEFAULT_CONFIG } from '@aws-rum/web-core/test-utils/test-utils';
 

--- a/packages/web/__tests__/plugins/event-plugins/FetchPlugin.integ.test.ts
+++ b/packages/web/__tests__/plugins/event-plugins/FetchPlugin.integ.test.ts
@@ -1,7 +1,7 @@
 import { Orchestration } from '../../../src/orchestration/Orchestration';
 import { createAwsCredentials } from '@aws-rum/web-core/test-utils/test-utils';
 import { HttpPluginConfig } from '@aws-rum/web-core/plugins/utils/http-utils';
-import { FetchPlugin } from '@aws-rum/web-core/plugins/event-plugins/FetchPlugin';
+import { FetchPlugin } from '@aws-rum/web-core';
 
 const mockFetch = jest.fn(
     (input: RequestInfo, init?: RequestInit) =>

--- a/packages/web/src/CommandQueue.ts
+++ b/packages/web/src/CommandQueue.ts
@@ -1,13 +1,13 @@
-import { INSTALL_SCRIPT } from '@aws-rum/web-core/utils/constants';
+import { INSTALL_SCRIPT } from '@aws-rum/web-core';
 import {
     CommandQueue as SlimCommandQueue,
     type AwsRumClientInit as SlimAwsRumClientInit
-} from '@aws-rum/web-slim/CommandQueue';
+} from '@aws-rum/web-slim';
 import { PartialConfig } from './orchestration/config';
 import { Orchestration } from './orchestration/Orchestration';
 import { getRemoteConfig } from './remote-config/remote-config';
 
-export type { Command, CommandFunction } from '@aws-rum/web-slim/CommandQueue';
+export type { Command, CommandFunction } from '@aws-rum/web-slim';
 
 /** Extends slim's init type to accept `telemetries` in the config. */
 export type AwsRumClientInit = Omit<SlimAwsRumClientInit, 'c'> & {

--- a/packages/web/src/dispatch/signing.ts
+++ b/packages/web/src/dispatch/signing.ts
@@ -7,7 +7,7 @@ import {
 } from '@aws-sdk/types';
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { HttpRequest } from '@smithy/protocol-http';
-import { SigningConfig } from '@aws-rum/web-core/dispatch/DataPlaneClient';
+import { type SigningConfig } from '@aws-rum/web-core';
 
 const SERVICE = 'rum';
 const REQUEST_PRESIGN_ARGS: RequestPresigningArguments = { expiresIn: 60 };

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -7,11 +7,13 @@ export {
     Telemetry,
     TelemetryEnum
 } from './orchestration/Orchestration';
-export { ClientBuilder } from '@aws-rum/web-core/dispatch/Dispatch';
-export { PageAttributes } from '@aws-rum/web-core/sessions/PageManager';
-export { Plugin } from '@aws-rum/web-core/plugins/Plugin';
-export { PluginContext } from '@aws-rum/web-core/plugins/types';
-export { TTIPlugin } from '@aws-rum/web-core/plugins/event-plugins/TTIPlugin';
+export {
+    type ClientBuilder,
+    type PageAttributes,
+    type Plugin,
+    type PluginContext,
+    TTIPlugin
+} from '@aws-rum/web-core';
 export * from '@aws-rum/web-core/plugins/event-plugins/DomEventPlugin';
 export * from '@aws-rum/web-core/plugins/event-plugins/JsErrorPlugin';
 export * from '@aws-rum/web-core/plugins/event-plugins/NavigationPlugin';

--- a/packages/web/src/orchestration/Orchestration.ts
+++ b/packages/web/src/orchestration/Orchestration.ts
@@ -1,26 +1,24 @@
-import { InternalPlugin } from '@aws-rum/web-core/plugins/InternalPlugin';
-import { BasicAuthentication } from '@aws-rum/web-core/dispatch/BasicAuthentication';
-import { EnhancedAuthentication } from '@aws-rum/web-core/dispatch/EnhancedAuthentication';
-import { PluginManager } from '@aws-rum/web-core/plugins/PluginManager';
-import { Dispatch } from '@aws-rum/web-core/dispatch/Dispatch';
 import {
+    InternalPlugin,
+    BasicAuthentication,
+    EnhancedAuthentication,
+    PluginManager,
+    Dispatch,
     DomEventPlugin,
     DOM_EVENT_PLUGIN_ID,
-    TargetDomEvent
-} from '@aws-rum/web-core/plugins/event-plugins/DomEventPlugin';
-import {
+    TargetDomEvent,
     JsErrorPlugin,
-    JS_ERROR_EVENT_PLUGIN_ID
-} from '@aws-rum/web-core/plugins/event-plugins/JsErrorPlugin';
-import { NavigationPlugin } from '@aws-rum/web-core/plugins/event-plugins/NavigationPlugin';
-import { ResourcePlugin } from '@aws-rum/web-core/plugins/event-plugins/ResourcePlugin';
-import { WebVitalsPlugin } from '@aws-rum/web-core/plugins/event-plugins/WebVitalsPlugin';
-import { XhrPlugin } from '@aws-rum/web-core/plugins/event-plugins/XhrPlugin';
-import { FetchPlugin } from '@aws-rum/web-core/plugins/event-plugins/FetchPlugin';
-import { RRWebPlugin } from '@aws-rum/web-core/plugins/event-plugins/RRWebPlugin';
-import { InternalLogger } from '@aws-rum/web-core/utils/InternalLogger';
+    JS_ERROR_EVENT_PLUGIN_ID,
+    NavigationPlugin,
+    ResourcePlugin,
+    WebVitalsPlugin,
+    XhrPlugin,
+    FetchPlugin,
+    RRWebPlugin,
+    InternalLogger
+} from '@aws-rum/web-core';
 import { createSigningConfig } from '../dispatch/signing';
-import { Orchestration as SlimOrchestration } from '@aws-rum/web-slim/orchestration/Orchestration';
+import { Orchestration as SlimOrchestration } from '@aws-rum/web-slim';
 import {
     TelemetryEnum,
     Config,

--- a/packages/web/src/orchestration/config.ts
+++ b/packages/web/src/orchestration/config.ts
@@ -1,18 +1,18 @@
 import {
-    Config as CoreConfig,
-    CookieAttributes,
-    Telemetry
-} from '@aws-rum/web-core/orchestration/config';
-import { defaultConfig as slimDefaultConfig } from '@aws-rum/web-slim/orchestration/Orchestration';
+    type Config as CoreConfig,
+    type CookieAttributes,
+    type Telemetry
+} from '@aws-rum/web-core';
+import { defaultConfig as slimDefaultConfig } from '@aws-rum/web-slim';
 
 // Re-export core types for backward compatibility
 export {
-    CookieAttributes,
-    PartialCookieAttributes,
-    CompressionStrategy,
-    Telemetry,
-    PageIdFormat
-} from '@aws-rum/web-core/orchestration/config';
+    type CookieAttributes,
+    type PartialCookieAttributes,
+    type CompressionStrategy,
+    type Telemetry,
+    type PageIdFormat
+} from '@aws-rum/web-core';
 
 export interface Config extends CoreConfig {
     guestRoleArn?: string;
@@ -39,7 +39,7 @@ export enum PageIdFormatEnum {
     PathAndHash = 'PATH_AND_HASH'
 }
 
-export { defaultCookieAttributes } from '@aws-rum/web-slim/orchestration/Orchestration';
+export { defaultCookieAttributes } from '@aws-rum/web-slim';
 
 export const defaultConfig = (cookieAttributes: CookieAttributes): Config => {
     return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "paths": {
             "@aws-rum/web-core": ["./packages/core/src"],
             "@aws-rum/web-core/*": ["./packages/core/src/*"],
+            "@aws-rum/web-slim": ["./packages/slim/src"],
             "@aws-rum/web-slim/*": ["./packages/slim/src/*"],
             "test-utils/*": ["./packages/core/src/test-utils/*"]
         }

--- a/tsconfig.unit.json
+++ b/tsconfig.unit.json
@@ -13,6 +13,7 @@
         "paths": {
             "@aws-rum/web-core": ["./packages/core/src"],
             "@aws-rum/web-core/*": ["./packages/core/src/*"],
+            "@aws-rum/web-slim": ["./packages/slim/src"],
             "@aws-rum/web-slim/*": ["./packages/slim/src/*"]
         }
     },


### PR DESCRIPTION
## Summary

Cleaning up the import statements so it's easier for users to find modules.

For example,

```typescript
import { type SigningConfig } from '@aws-rum/web-core';
```

instead of 
```typescript
import { SigningConfig } from '@aws-rum/web-core/dispatch/DataPlaneClient';
```

## Testing

approval workflow. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
