### PR TITLE
feat: add optional eventDetails parameter to recordError

### DIFF
--- a/packages/core/src/plugins/event-plugins/JsErrorPlugin.ts
+++ b/packages/core/src/plugins/event-plugins/JsErrorPlugin.ts
@@ -1,8 +1,15 @@
 import { InternalPlugin } from '../InternalPlugin';
 import { JS_ERROR_EVENT_TYPE } from '../utils/constant';
 import { errorEventToJsErrorEvent } from '../utils/js-error-utils';
+import { JSErrorEvent } from '../../events/js-error-event';
 
 export const JS_ERROR_EVENT_PLUGIN_ID = 'js-error';
+
+export type ErrorEventDetails = {
+    [key: string]: unknown;
+} & {
+    [K in keyof JSErrorEvent]?: never;
+};
 
 export type PartialJsErrorPluginConfig = {
     stackTraceLength?: number;
@@ -43,11 +50,16 @@ export class JsErrorPlugin extends InternalPlugin {
         this.enabled = false;
     }
 
-    record(error: any): void {
+    record(data: any): void {
+        const error = data?.error !== undefined ? data.error : data;
+        const eventDetails: ErrorEventDetails | undefined = data?.eventDetails;
         if (error instanceof ErrorEvent) {
-            this.recordJsErrorEvent(error);
+            this.recordJsErrorEvent(error, eventDetails);
         } else {
-            this.recordJsErrorEvent({ type: 'error', error } as ErrorEvent);
+            this.recordJsErrorEvent(
+                { type: 'error', error } as ErrorEvent,
+                eventDetails
+            );
         }
     }
 
@@ -70,10 +82,17 @@ export class JsErrorPlugin extends InternalPlugin {
         }
     };
 
-    private recordJsErrorEvent(error: ErrorEvent) {
+    private recordJsErrorEvent(
+        error: ErrorEvent,
+        eventDetails?: ErrorEventDetails
+    ) {
+        const eventData = errorEventToJsErrorEvent(
+            error,
+            this.config.stackTraceLength
+        );
         this.context?.record(
             JS_ERROR_EVENT_TYPE,
-            errorEventToJsErrorEvent(error, this.config.stackTraceLength)
+            eventDetails ? { ...eventData, ...eventDetails } : eventData
         );
     }
 

--- a/packages/slim/src/orchestration/Orchestration.ts
+++ b/packages/slim/src/orchestration/Orchestration.ts
@@ -13,7 +13,8 @@ import {
     INSTALL_MODULE,
     EventBus,
     Topic,
-    InternalLogger
+    InternalLogger,
+    type ErrorEventDetails
 } from '@aws-rum/web-core';
 import {
     AwsCredentialIdentityProvider,
@@ -212,8 +213,11 @@ export class Orchestration {
         this.eventCache.recordPageView(payload);
     }
 
-    public recordError(error: any) {
-        this.pluginManager.record('com.amazonaws.rum.js-error', error);
+    public recordError(error: any, eventDetails?: ErrorEventDetails) {
+        this.pluginManager.record('com.amazonaws.rum.js-error', {
+            error,
+            eventDetails
+        });
     }
 
     public registerDomEvents(events: any[]) {

--- a/packages/web/src/orchestration/Orchestration.ts
+++ b/packages/web/src/orchestration/Orchestration.ts
@@ -9,6 +9,7 @@ import {
     TargetDomEvent,
     JsErrorPlugin,
     JS_ERROR_EVENT_PLUGIN_ID,
+    type ErrorEventDetails,
     NavigationPlugin,
     ResourcePlugin,
     WebVitalsPlugin,
@@ -127,9 +128,15 @@ export class Orchestration extends SlimOrchestration {
 
     /**
      * Record an error using the JS error plugin.
+     *
+     * @param error An ErrorEvent, Error or primitive.
+     * @param eventDetails Optional additional details to include in the error event.
      */
-    public recordError(error: any) {
-        this.pluginManager.record(JS_ERROR_EVENT_PLUGIN_ID, error);
+    public recordError(error: any, eventDetails?: ErrorEventDetails) {
+        this.pluginManager.record(JS_ERROR_EVENT_PLUGIN_ID, {
+            error,
+            eventDetails
+        });
     }
 
     /**


### PR DESCRIPTION
Allow callers to pass additional event details when recording errors via recordError(error, eventDetails). The details are merged into the event details at the top level, consistent with how recordEvent stores eventData.

The ErrorEventDetails type prevents reserved JSErrorEvent keys (version, type, message, filename, lineno, colno, stack) from being overwritten.

Backward compatible - existing callers passing a raw error still work.

```ts
// Before: recordError only accepts an error
awsRum.recordError(error);

// After: optionally pass additional event details
awsRum.recordError(error, {
    traceId: '550e8400-e29b-41d4-a716-446655440000',
    component: 'PaymentForm',
});
```