### PR TITLE
fix: resolve smoke tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4539,10 +4539,52 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@rrweb/record": {
+            "version": "2.0.0-alpha.20",
+            "resolved": "https://registry.npmjs.org/@rrweb/record/-/record-2.0.0-alpha.20.tgz",
+            "integrity": "sha512-marVOU3Lc285mwLCp+vI6M/eJ+wZ6lcTa7fX0zcdmBsM+j5loXmMQjkmIvkji5+lAbkq5/w2cwto3GS0TaCjtg==",
+            "license": "MIT",
+            "dependencies": {
+                "@rrweb/types": "^2.0.0-alpha.20",
+                "@rrweb/utils": "^2.0.0-alpha.20",
+                "rrweb": "^2.0.0-alpha.20"
+            }
+        },
+        "node_modules/@rrweb/record/node_modules/rrdom": {
+            "version": "2.0.0-alpha.20",
+            "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.20.tgz",
+            "integrity": "sha512-hoqjS4662LtBp82qEz9GrqU36UpEmCvTA2Hns3qdF7cklLFFy3G+0Th8hLytJENleHHWxsB5nWJ3eXz5mSRxdQ==",
+            "license": "MIT",
+            "dependencies": {
+                "rrweb-snapshot": "^2.0.0-alpha.20"
+            }
+        },
+        "node_modules/@rrweb/record/node_modules/rrweb": {
+            "version": "2.0.0-alpha.20",
+            "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.20.tgz",
+            "integrity": "sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==",
+            "license": "MIT",
+            "dependencies": {
+                "@rrweb/types": "^2.0.0-alpha.20",
+                "@rrweb/utils": "^2.0.0-alpha.20",
+                "@types/css-font-loading-module": "0.0.7",
+                "@xstate/fsm": "^1.4.0",
+                "base64-arraybuffer": "^1.0.1",
+                "mitt": "^3.0.0",
+                "rrdom": "^2.0.0-alpha.20",
+                "rrweb-snapshot": "^2.0.0-alpha.20"
+            }
+        },
         "node_modules/@rrweb/types": {
             "version": "2.0.0-alpha.20",
             "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.20.tgz",
             "integrity": "sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==",
+            "license": "MIT"
+        },
+        "node_modules/@rrweb/utils": {
+            "version": "2.0.0-alpha.20",
+            "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.20.tgz",
+            "integrity": "sha512-MTQOmhPRe39C0fYaCnnVYOufQsyGzwNXpUStKiyFSfGLUJrzuwhbRoUAKR5w6W2j5XuA0bIz3ZDIBztkquOhLw==",
             "license": "MIT"
         },
         "node_modules/@rtsao/scc": {
@@ -19304,7 +19346,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -19511,6 +19552,34 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/postcss": {
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
         "node_modules/postcss-selector-parser": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
@@ -19523,6 +19592,24 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/postcss/node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
         "node_modules/prelude-ls": {
@@ -20501,10 +20588,13 @@
             "license": "MIT"
         },
         "node_modules/rrweb-snapshot": {
-            "version": "2.0.0-alpha.4",
-            "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.4.tgz",
-            "integrity": "sha512-KQ2OtPpXO5jLYqg1OnXS/Hf+EzqnZyP5A+XPqBCjYpj3XIje/Od4gdUwjbFo3cVuWq5Cw5Y1d3/xwgIS7/XpQQ==",
-            "license": "MIT"
+            "version": "2.0.0-alpha.20",
+            "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.20.tgz",
+            "integrity": "sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==",
+            "license": "MIT",
+            "dependencies": {
+                "postcss": "^8.4.38"
+            }
         },
         "node_modules/run-applescript": {
             "version": "7.1.0",
@@ -21271,7 +21361,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -24179,6 +24268,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^5.2.0",
+                "@rrweb/record": "2.0.0-alpha.20",
                 "@smithy/fetch-http-handler": "^5.0.0",
                 "@smithy/protocol-http": "^5.0.0",
                 "@smithy/querystring-builder": "^4.0.0",

--- a/packages/core/__tests__/plugins/event-plugins/RRWebPlugin.test.ts
+++ b/packages/core/__tests__/plugins/event-plugins/RRWebPlugin.test.ts
@@ -13,9 +13,9 @@ import {
 } from '@aws-rum/web-core/test-utils/test-utils';
 import { RRWEB_EVENT_TYPE } from '@aws-rum/web-core/plugins/utils/constant';
 import type { RRWebEvent } from '@aws-rum/web-core/events/rrweb-event';
-import { record as rrwebRecord } from 'rrweb';
+import { record as rrwebRecord } from '@rrweb/record';
 
-jest.mock('rrweb', () => ({
+jest.mock('@rrweb/record', () => ({
     record: jest.fn()
 }));
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
         "@smithy/protocol-http": "^5.0.0",
         "@smithy/signature-v4": "^5.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
+        "@rrweb/record": "2.0.0-alpha.20",
         "rrweb": "2.0.0-alpha.4",
         "shimmer": "^1.2.1",
         "uuid": "^9.0.0",

--- a/packages/core/src/__smoke-test__/dataplane-integ.spec.ts
+++ b/packages/core/src/__smoke-test__/dataplane-integ.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from '@playwright/test';
 import {
     getEventsByType,
     getUrl,
-    isDataPlaneRequest
+    isDataPlaneRequest,
+    parseRequestBody
 } from 'test-utils/smoke-test-utils';
 import {
     PERFORMANCE_NAVIGATION_EVENT_TYPE,
@@ -65,7 +66,7 @@ test('when web client calls PutRumEvents then the payload contains all events', 
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const session = getEventsByType(requestBody, SESSION_START_EVENT_TYPE);
     const navigation = getEventsByType(

--- a/packages/core/src/__smoke-test__/ingestion-integ.spec.ts
+++ b/packages/core/src/__smoke-test__/ingestion-integ.spec.ts
@@ -19,6 +19,7 @@ import {
     getEventsByType,
     getUrl,
     isDataPlaneRequest,
+    parseRequestBody,
     verifyIngestionWithRetry
 } from 'test-utils/smoke-test-utils';
 
@@ -60,7 +61,7 @@ test('when session start event is sent then event is ingested', async ({
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const session = getEventsByType(requestBody, SESSION_START_EVENT_TYPE);
     const eventIds = getEventIds(session);
@@ -86,7 +87,7 @@ test('when resource event is sent then event is ingested', async ({ page }) => {
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const resource = getEventsByType(
         requestBody,
@@ -117,7 +118,7 @@ test('when LCP event is sent then event is ingested', async ({ page }) => {
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const lcp = getEventsByType(requestBody, LCP_EVENT_TYPE);
     const eventIds = getEventIds(lcp);
@@ -146,7 +147,7 @@ test('when FID event is sent then event is ingested', async ({ page }) => {
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const fid = getEventsByType(requestBody, FID_EVENT_TYPE);
     const eventIds = getEventIds(fid);
@@ -177,7 +178,7 @@ test('when navigation events are sent then events are ingested', async ({
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const navigation = getEventsByType(
         requestBody,
@@ -212,7 +213,7 @@ test('when page view event is sent then the event is ingested', async ({
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const pageViews = getEventsByType(requestBody, PAGE_VIEW_EVENT_TYPE);
     const eventIds = getEventIds(pageViews);
@@ -248,7 +249,7 @@ test('when error events are sent then the events are ingested', async ({
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const errors = getEventsByType(requestBody, JS_ERROR_EVENT_TYPE);
     const eventIds = getEventIds(errors);
@@ -282,7 +283,7 @@ test('when http events are sent then the events are ingested', async ({
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const httpEvents = getEventsByType(requestBody, HTTP_EVENT_TYPE);
     const eventIds = getEventIds(httpEvents);
@@ -317,7 +318,7 @@ test('when CLS event is sent then the event is ingested', async ({ page }) => {
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const clsEvents = getEventsByType(requestBody, CLS_EVENT_TYPE);
     const eventIds = getEventIds(clsEvents);
@@ -349,7 +350,7 @@ test('when dom event is sent then the event is ingested', async ({ page }) => {
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const domEvent = getEventsByType(requestBody, DOM_EVENT_TYPE);
     const eventIds = getEventIds(domEvent);
@@ -379,7 +380,7 @@ test('when xray event is sent then the event is ingested', async ({ page }) => {
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const xrayEvent = getEventsByType(requestBody, XRAY_TRACE_EVENT_TYPE);
     const eventIds = getEventIds(xrayEvent);
@@ -411,7 +412,7 @@ test('when xray event is sent with w3c trace id then the event is ingested', asy
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const xrayEvent = getEventsByType(requestBody, XRAY_TRACE_EVENT_TYPE);
     const eventIds = getEventIds(xrayEvent);
@@ -446,7 +447,7 @@ test('when event with custom attributes is sent then the event is ingested', asy
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const pageViews = getEventsByType(requestBody, PAGE_VIEW_EVENT_TYPE);
     const eventIds = getEventIds(pageViews);
@@ -501,7 +502,7 @@ test('when INP event is sent then event is ingested', async ({ page }) => {
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const inp = getEventsByType(requestBody, INP_EVENT_TYPE);
     const eventIds = getEventIds(inp);
@@ -536,7 +537,7 @@ test('when http events are sent with w3c format enabled then the events are inge
     );
 
     // Parse payload to verify event count
-    const requestBody = JSON.parse(response.request().postData());
+    const requestBody = parseRequestBody(response);
 
     const httpEvents = getEventsByType(requestBody, HTTP_EVENT_TYPE);
     const eventIds = getEventIds(httpEvents);

--- a/packages/core/src/__smoke-test__/ingestion-integ.spec.ts
+++ b/packages/core/src/__smoke-test__/ingestion-integ.spec.ts
@@ -169,8 +169,6 @@ test('when navigation events are sent then events are ingested', async ({
 
     // Open page
     await page.goto(TEST_URL);
-    const clearButton = page.locator('[id=pushStateOneToHistory]');
-    await clearButton.click();
 
     // Test will timeout if no successful dataplane request is found
     const response = await page.waitForResponse(async (response) =>
@@ -186,8 +184,8 @@ test('when navigation events are sent then events are ingested', async ({
     );
     const eventIds = getEventIds(navigation);
 
-    // One initial load, one route change
-    expect(eventIds.length).toEqual(2);
+    // Initial page load
+    expect(eventIds.length).toEqual(1);
     const isIngestionCompleted = await verifyIngestionWithRetry(
         rumClient,
         eventIds,

--- a/packages/core/src/dispatch/DataPlaneClient.ts
+++ b/packages/core/src/dispatch/DataPlaneClient.ts
@@ -39,7 +39,7 @@ declare type SerializedPutRumEventsRequest = {
     BatchId: string;
     AppMonitorDetails: AppMonitorDetails;
     UserDetails: UserDetails;
-    Metadata?: string;
+    SessionMetadata?: string;
     RumEvents: SerializedRumEvent[];
     Alias?: string;
 };
@@ -193,10 +193,10 @@ export const serializeRequest = (
         UserDetails: request.UserDetails,
         RumEvents: serializedRumEvents
     };
-    if (request.Metadata) {
+    if (request.SessionMetadata) {
         serializedRequest = {
             ...serializedRequest,
-            Metadata: request.Metadata
+            SessionMetadata: request.SessionMetadata
         };
     }
     if (request.Alias) {

--- a/packages/core/src/dispatch/Dispatch.ts
+++ b/packages/core/src/dispatch/Dispatch.ts
@@ -328,7 +328,9 @@ export class Dispatch {
             BatchId: v4(),
             AppMonitorDetails: this.eventCache.getAppMonitorDetails(),
             UserDetails: this.eventCache.getUserDetails(),
-            Metadata: JSON.stringify(this.eventCache.getCommonMetadata()),
+            SessionMetadata: JSON.stringify(
+                this.eventCache.getCommonMetadata()
+            ),
             RumEvents: this.eventCache.getEventBatch(flush),
             Alias: this.config.alias
         };

--- a/packages/core/src/dispatch/dataplane.ts
+++ b/packages/core/src/dispatch/dataplane.ts
@@ -11,7 +11,7 @@ export interface PutRumEventsRequest {
     BatchId: string;
     AppMonitorDetails: AppMonitorDetails;
     UserDetails: UserDetails;
-    Metadata?: string;
+    SessionMetadata?: string;
     RumEvents: RumEvent[];
     Alias?: string;
 }

--- a/packages/core/src/event-cache/EventCache.ts
+++ b/packages/core/src/event-cache/EventCache.ts
@@ -366,7 +366,7 @@ export class EventCache {
         // As of 3.0, session-level attributes (browser, OS, domain, etc.) are
         // sent once in the payload-level Metadata field. Event-level metadata
         // contains only per-event (page) attributes. Consumers merge:
-        //   { ...request.Metadata, ...event.metadata }
+        //   { ...request.SessionMetadata, ...event.metadata }
         const eventMetadata = {
             ...this.pageManager.getAttributes()
         };

--- a/packages/core/src/plugins/event-plugins/RRWebPlugin.ts
+++ b/packages/core/src/plugins/event-plugins/RRWebPlugin.ts
@@ -20,7 +20,13 @@
 import { InternalPlugin } from '../InternalPlugin';
 import { RRWEB_EVENT_TYPE } from '../utils/constant';
 import { InternalLogger } from '../../utils/InternalLogger';
-import { record } from 'rrweb';
+// Use @rrweb/record instead of rrweb directly. rrweb@2.0.0-alpha.4 ships a
+// broken package.json (type:module with a CJS main), which makes consumer
+// bundlers throw `ReferenceError: exports is not defined` at runtime.
+// @rrweb/record has a proper exports map with separate import/require
+// conditions and bundles all rrweb code inline, so CJS and ESM consumers
+// both work.
+import { record } from '@rrweb/record';
 import type { recordOptions } from 'rrweb/typings/types';
 import type { RRWebEvent as RRWebEventPayload } from '../../events/rrweb-event';
 

--- a/packages/core/src/sessions/__integ__/SessionManager.spec.ts
+++ b/packages/core/src/sessions/__integ__/SessionManager.spec.ts
@@ -82,7 +82,7 @@ test.describe('Session Handler usage', () => {
 
         // Session-level attributes are in the top-level Metadata field
         const requestBody = JSON.parse(requestBodyText || '{}');
-        const metadata = JSON.parse(requestBody.Metadata || '{}');
+        const metadata = JSON.parse(requestBody.SessionMetadata || '{}');
 
         expect(metadata.browserLanguage).toBeDefined();
         expect(metadata.platformType).toBeDefined();
@@ -126,7 +126,7 @@ test.describe('Session Handler usage', () => {
 
         // Session attributes are in the top-level Metadata field
         const requestBody = JSON.parse(requestBodyText || '{}');
-        const metadata = JSON.parse(requestBody.Metadata || '{}');
+        const metadata = JSON.parse(requestBody.SessionMetadata || '{}');
 
         expect(metadata.customAttributeAtInit).toBe(
             'customAttributeAtInitValue'
@@ -155,7 +155,7 @@ test.describe('Session Handler usage', () => {
 
         // Runtime session attributes are in the top-level Metadata field
         const requestBody = JSON.parse(requestBodyText || '{}');
-        const metadata = JSON.parse(requestBody.Metadata || '{}');
+        const metadata = JSON.parse(requestBody.SessionMetadata || '{}');
 
         expect(metadata.customPageAttributeAtRuntimeString).toBe(
             'stringCustomAttributeAtRunTimeValue'

--- a/packages/core/src/test-utils/smoke-test-utils.ts
+++ b/packages/core/src/test-utils/smoke-test-utils.ts
@@ -4,6 +4,7 @@ import {
     RUMClient
 } from '@aws-sdk/client-rum';
 import { expect, Response } from '@playwright/test';
+import { ungzip } from 'pako';
 
 const INGESTION_READ_ATTEMPTS = 15;
 const INGESTION_POLL_INTERVAL_MS = 10000;
@@ -40,6 +41,20 @@ export const getEventsByType = (
     eventType: string
 ) => {
     return requestBody.RumEvents.filter((e) => e.type === eventType);
+};
+
+/**
+ * Parses the request body from a dataplane response, asserting it was sent
+ * gzipped (compression is enabled by default) and decompressing before JSON parse.
+ */
+export const parseRequestBody = (response: Response): { RumEvents: any[] } => {
+    const request = response.request();
+    expect(request.headers()['content-encoding']).toEqual('gzip');
+    const buffer = request.postDataBuffer();
+    if (!buffer) {
+        throw new Error('Request has no post data');
+    }
+    return JSON.parse(ungzip(buffer, { to: 'string' }));
 };
 
 /** Returns an array of eventIds */

--- a/packages/slim/webpack/webpack.common.js
+++ b/packages/slim/webpack/webpack.common.js
@@ -7,7 +7,9 @@ module.exports = {
     resolve: {
         extensions: ['.ts', '.js', '.json'],
         alias: {
-            '@aws-rum/web-core': path.resolve(__dirname, '../../core/src')
+            '@aws-rum/web-core': path.resolve(__dirname, '../../core/src'),
+            // See packages/web/webpack/webpack.common.js for rationale.
+            '@rrweb/record$': 'rrweb/es/rrweb/packages/rrweb/src/index.js'
         }
     },
     plugins: [new CaseSensitivePathsPlugin()],

--- a/packages/web/webpack/webpack.common.js
+++ b/packages/web/webpack/webpack.common.js
@@ -8,7 +8,13 @@ module.exports = {
         extensions: ['.ts', '.js', '.json'],
         alias: {
             '@aws-rum/web-core': path.resolve(__dirname, '../../core/src'),
-            '@aws-rum/web-slim': path.resolve(__dirname, '../../slim/src')
+            '@aws-rum/web-slim': path.resolve(__dirname, '../../slim/src'),
+            // @rrweb/record is pre-bundled (377 KB) and not tree-shakable. Alias
+            // to rrweb's ESM source so webpack can tree-shake unused rrweb
+            // subsystems out of the CDN bundle. NPM consumers bypass this
+            // alias and get @rrweb/record directly (which fixes the CJS
+            // `exports is not defined` bug from rrweb's broken package.json).
+            '@rrweb/record$': 'rrweb/es/rrweb/packages/rrweb/src/index.js'
         }
     },
     plugins: [new CaseSensitivePathsPlugin()],

--- a/smoke/smoke-test-application-CDN/smoke.html
+++ b/smoke/smoke-test-application-CDN/smoke.html
@@ -40,8 +40,7 @@
                     'content-type': 'application/json'
                 },
                 useBeacon: false,
-                releaseId: '2.1.7',
-                legacySPASupport: true
+                releaseId: '2.1.7'
             });
         </script>
 

--- a/smoke/smoke-test-application-CDN/smoke_w3c_format_enabled.html
+++ b/smoke/smoke-test-application-CDN/smoke_w3c_format_enabled.html
@@ -41,8 +41,7 @@
                 },
                 useBeacon: false,
                 releaseId: '2.1.7',
-                enableW3CTraceId: true,
-                legacySPASupport: true
+                enableW3CTraceId: true
             });
         </script>
 

--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-2.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-2.ts
@@ -14,8 +14,7 @@ try {
         cookieAttributes: {
             unique: true
         },
-        useBeacon: false,
-        legacySPASupport: true
+        useBeacon: false
     };
 
     const APPLICATION_ID: string = $MONITOR_ID_2;

--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-w3c-format-enabled.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum-w3c-format-enabled.ts
@@ -22,8 +22,7 @@ try {
             'content-type': 'application/json'
         },
         useBeacon: false,
-        enableW3CTraceId: true,
-        legacySPASupport: true
+        enableW3CTraceId: true
     };
 
     const APPLICATION_ID: string = $MONITOR_ID;

--- a/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-CJS/src/loader-npm-rum.ts
@@ -22,8 +22,7 @@ try {
             'content-type': 'application/json'
         },
         useBeacon: false,
-        releaseId: '2.1.7',
-        legacySPASupport: true
+        releaseId: '2.1.7'
     };
 
     const APPLICATION_ID: string = $MONITOR_ID;

--- a/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-2.ts
+++ b/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-2.ts
@@ -15,8 +15,7 @@ try {
             unique: true
         },
         useBeacon: false,
-        releaseId: '2.1.7',
-        legacySPASupport: true
+        releaseId: '2.1.7'
     };
 
     const APPLICATION_ID: string = $MONITOR_ID_2;

--- a/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-w3c-format-enabled.ts
+++ b/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum-w3c-format-enabled.ts
@@ -22,8 +22,7 @@ try {
             'content-type': 'application/json'
         },
         useBeacon: false,
-        enableW3CTraceId: true,
-        legacySPASupport: true
+        enableW3CTraceId: true
     };
 
     const APPLICATION_ID: string = $MONITOR_ID;

--- a/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
+++ b/smoke/smoke-test-application-NPM-ES/src/loader-npm-rum.ts
@@ -22,8 +22,7 @@ try {
             'content-type': 'application/json'
         },
         useBeacon: false,
-        releaseId: '2.1.7',
-        legacySPASupport: true
+        releaseId: '2.1.7'
     };
 
     const APPLICATION_ID: string = $MONITOR_ID;


### PR DESCRIPTION
## Summary
Two main fixes that were blocking smoke tests
1. Dispatch had the wrong metadata field, rename from `Metadata` to `SessionMetadata`
2. Fix CJS bug that was broken by an RRWeb bug
3. Small test-related fixes (remove legacySPASuport, parse gzipped request body)

## Tests

Ran here - https://github.com/aws-observability/aws-rum-web/actions/runs/24917652078/job/72972946648

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
