### PR TITLE
fix: replace uuid dependency with native crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3258,21 +3258,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@noble/hashes": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
         "@types/pako": "^2.0.4",
         "@types/shimmer": "^1.0.2",
         "@types/ua-parser-js": "^0.7.35",
-        "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
         "@webpack-cli/serve": "^3.0.1",

--- a/packages/core/__tests__/sessions/SessionManager.test.ts
+++ b/packages/core/__tests__/sessions/SessionManager.test.ts
@@ -9,7 +9,6 @@ import {
     removeCookie,
     storeCookie
 } from '@aws-rum/web-core/utils/cookies-utils';
-import * as uuid from 'uuid';
 import { navigationEvent } from '@aws-rum/web-core/test-utils/mock-data';
 import { Config } from '@aws-rum/web-core/orchestration/config';
 import * as configModule from '@aws-rum/web-core/orchestration/config';
@@ -112,7 +111,7 @@ describe('SessionManager tests', () => {
             ...{ allowCookies: true }
         };
 
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(JSON.stringify({ sessionId, record: true })),
@@ -223,7 +222,7 @@ describe('SessionManager tests', () => {
 
     test('when sessionId cookie is corrupt then getSession returns a new sessionId', async () => {
         // Init
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         const config = {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true }
@@ -275,7 +274,7 @@ describe('SessionManager tests', () => {
             ...{ allowCookies: true }
         };
 
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(JSON.stringify({ sessionId, record: true })),
@@ -314,7 +313,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true, userIdRetentionDays: 90 }
         };
-        const userId = uuid.v4();
+        const userId = crypto.randomUUID();
         storeCookie(
             USER_COOKIE_NAME,
             userId,
@@ -359,7 +358,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true, userIdRetentionDays: 90 }
         };
-        const userId = uuid.v4();
+        const userId = crypto.randomUUID();
         storeCookie(
             USER_COOKIE_NAME,
             userId,
@@ -434,7 +433,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true }
         };
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(
@@ -594,7 +593,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true }
         };
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(JSON.stringify({ sessionId, record: true, eventCount: 1 })),
@@ -748,7 +747,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true, userIdRetentionDays: 0 }
         };
-        const userId = uuid.v4();
+        const userId = crypto.randomUUID();
         storeCookie(
             USER_COOKIE_NAME,
             userId,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,6 @@
         "@smithy/util-hex-encoding": "^3.0.0",
         "rrweb": "2.0.0-alpha.4",
         "shimmer": "^1.2.1",
-        "uuid": "^9.0.0",
         "web-vitals": "^4.0.0"
     }
 }

--- a/packages/core/src/dispatch/Dispatch.ts
+++ b/packages/core/src/dispatch/Dispatch.ts
@@ -9,10 +9,10 @@ import { BeaconHttpHandler } from './BeaconHttpHandler';
 import { FetchHttpHandler } from './FetchHttpHandler';
 import { PutRumEventsRequest } from './dataplane';
 import { Config } from '../orchestration/config';
-import { v4 } from 'uuid';
 import { RetryHttpHandler } from './RetryHttpHandler';
 import { InternalLogger } from '../utils/InternalLogger';
 import { CRED_KEY, IDENTITY_KEY } from '../utils/constants';
+import { generateUUID } from '../utils/random';
 
 type SendFunction = (
     putRumEventsRequest: PutRumEventsRequest
@@ -325,7 +325,7 @@ export class Dispatch {
 
     private createRequest(flush = false): PutRumEventsRequest {
         return {
-            BatchId: v4(),
+            BatchId: generateUUID(),
             AppMonitorDetails: this.eventCache.getAppMonitorDetails(),
             UserDetails: this.eventCache.getUserDetails(),
             Metadata: JSON.stringify(this.eventCache.getCommonMetadata()),

--- a/packages/core/src/event-cache/EventCache.ts
+++ b/packages/core/src/event-cache/EventCache.ts
@@ -1,5 +1,4 @@
 import { Session, SessionManager } from '../sessions/SessionManager';
-import { v4 } from 'uuid';
 import { MetaData } from '../events/meta-data';
 import { Config } from '../orchestration/config';
 import { PageAttributes, PageManager } from '../sessions/PageManager';
@@ -13,6 +12,7 @@ import EventBus, { Topic } from '../event-bus/EventBus';
 import { RecordEvent } from '../plugins/types';
 import { SESSION_START_EVENT_TYPE } from '../plugins/utils/constant';
 import { InternalLogger } from '../utils/InternalLogger';
+import { generateUUID } from '../utils/random';
 
 import { WEB_CLIENT_VERSION } from '../utils/version';
 
@@ -372,7 +372,7 @@ export class EventCache {
         };
 
         const partialEvent = {
-            id: v4(),
+            id: generateUUID(),
             timestamp: new Date(),
             type
         };

--- a/packages/core/src/sessions/SessionManager.ts
+++ b/packages/core/src/sessions/SessionManager.ts
@@ -1,6 +1,5 @@
 import { storeCookie, getCookie } from '../utils/cookies-utils';
 
-import { v4 } from 'uuid';
 import { Config, userAgentDataProvider } from '../orchestration/config';
 import { Page, PageManager } from './PageManager';
 import { SESSION_COOKIE_NAME, USER_COOKIE_NAME } from '../utils/constants';
@@ -8,6 +7,7 @@ import { AppMonitorDetails } from '../dispatch/dataplane';
 import { RecordEvent } from '../plugins/types';
 import { SESSION_START_EVENT_TYPE } from '../plugins/utils/constant';
 import { InternalLogger } from '../utils/InternalLogger';
+import { generateUUID } from '../utils/random';
 
 export const NIL_UUID = '00000000-0000-0000-0000-000000000000';
 
@@ -176,10 +176,10 @@ export class SessionManager {
             this.userId = '00000000-0000-0000-0000-000000000000';
         } else if (this.useCookies()) {
             userId = this.getUserIdCookie();
-            this.userId = userId ? userId : v4();
+            this.userId = userId ? userId : generateUUID();
             this.createOrRenewUserCookie(userId, this.userExpiry);
         } else {
-            this.userId = v4();
+            this.userId = generateUUID();
         }
     }
 
@@ -244,7 +244,7 @@ export class SessionManager {
         // We ensure the nil session and new session created right after initialization have the same sampling decision.
         // Otherwise, we will always reevaluate the sample decision.
         this.session = {
-            sessionId: v4(),
+            sessionId: generateUUID(),
             record:
                 this.session.sessionId === NIL_UUID
                     ? this.session.record

--- a/packages/core/src/utils/random.ts
+++ b/packages/core/src/utils/random.ts
@@ -11,3 +11,21 @@ export const getRandomValues = (holder: Uint8Array): Uint8Array => {
         throw new Error('No crypto library found.');
     }
 };
+
+export const generateUUID = (): string => {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+        return crypto.randomUUID();
+    }
+    const bytes = getRandomValues(new Uint8Array(16));
+    // eslint-disable-next-line no-bitwise
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    // eslint-disable-next-line no-bitwise
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+        ''
+    );
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+        12,
+        16
+    )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};


### PR DESCRIPTION
## Summary
- Removes the `uuid` package to eliminate [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (moderate severity, uuid <14.0.0)
- Replaces `v4()` calls with a `generateUUID()` utility in `packages/core/src/utils/random.ts`
- Uses `crypto.randomUUID()` where available, with a fallback to `crypto.getRandomValues()` for older browsers (IE11+ via msCrypto)

## Motivation
Upgrading uuid to 14.0.0 (#815) breaks the Jest test suite because uuid@14 is ESM-only. Rather than fighting ESM compatibility, this removes the dependency entirely.

## Test plan
- All 45 test suites pass (668 tests)
- Webpack production build compiles successfully