### PR TITLE
feat: collect First Contentful Paint and Time to First Byte web vitals

### DIFF
--- a/packages/core/__tests__/plugins/event-plugins/WebVitalsPlugin.test.ts
+++ b/packages/core/__tests__/plugins/event-plugins/WebVitalsPlugin.test.ts
@@ -11,11 +11,13 @@ jest.mock('@aws-rum/web-core/utils/common-utils', () => {
 import { ResourceType } from '@aws-rum/web-core/utils/common-utils';
 import {
     CLS_EVENT_TYPE,
+    FCP_EVENT_TYPE,
     FID_EVENT_TYPE,
     INP_EVENT_TYPE,
     LCP_EVENT_TYPE,
     PERFORMANCE_NAVIGATION_EVENT_TYPE,
-    PERFORMANCE_RESOURCE_EVENT_TYPE
+    PERFORMANCE_RESOURCE_EVENT_TYPE,
+    TTFB_EVENT_TYPE
 } from '@aws-rum/web-core/plugins/utils/constant';
 import {
     context,
@@ -29,7 +31,9 @@ import {
     INPMetricWithAttribution,
     CLSMetricWithAttribution,
     FIDMetricWithAttribution,
-    LCPMetricWithAttribution
+    LCPMetricWithAttribution,
+    FCPMetricWithAttribution,
+    TTFBMetricWithAttribution
 } from 'web-vitals';
 
 const mockLCPData = {
@@ -87,6 +91,32 @@ const mockINPData = {
     }
 } as INPMetricWithAttribution;
 
+const mockFCPData = {
+    delta: 1200.5,
+    id: 'v1-1621403597703-1234567890123',
+    name: 'FCP',
+    value: 1200.5,
+    attribution: {
+        timeToFirstByte: 800,
+        firstByteToFCP: 400.5,
+        loadState: 'dom-interactive'
+    }
+} as FCPMetricWithAttribution;
+
+const mockTTFBData = {
+    delta: 800.25,
+    id: 'v1-1621403597704-9876543210987',
+    name: 'TTFB',
+    value: 800.25,
+    attribution: {
+        waitingDuration: 100,
+        cacheDuration: 50,
+        dnsDuration: 150,
+        connectionDuration: 200,
+        requestDuration: 300.25
+    }
+} as TTFBMetricWithAttribution;
+
 // only need hasLatency fields
 const imagePerformanceEntry = {
     duration: 50,
@@ -128,7 +158,15 @@ jest.mock('web-vitals/attribution', () => {
         onCLS: jest
             .fn()
             .mockImplementation((callback) => callback(mockCLSData)),
-        onINP: jest.fn().mockImplementation((callback) => callback(mockINPData))
+        onINP: jest
+            .fn()
+            .mockImplementation((callback) => callback(mockINPData)),
+        onFCP: jest
+            .fn()
+            .mockImplementation((callback) => callback(mockFCPData)),
+        onTTFB: jest
+            .fn()
+            .mockImplementation((callback) => callback(mockTTFBData))
     };
 });
 
@@ -189,6 +227,53 @@ describe('WebVitalsPlugin tests', () => {
         );
     });
 
+    test('When web vitals are present then FCP is recorded with attribution', async () => {
+        // Setup
+        const plugin: WebVitalsPlugin = new WebVitalsPlugin();
+
+        // Run
+        plugin.load(context);
+
+        // Assert
+        expect(record).toHaveBeenCalledWith(
+            FCP_EVENT_TYPE,
+            expect.objectContaining({
+                version: '1.0.0',
+                value: mockFCPData.value,
+                attribution: {
+                    timeToFirstByte: mockFCPData.attribution.timeToFirstByte,
+                    firstByteToFCP: mockFCPData.attribution.firstByteToFCP,
+                    loadState: mockFCPData.attribution.loadState
+                }
+            })
+        );
+    });
+
+    test('When web vitals are present then TTFB is recorded with attribution', async () => {
+        // Setup
+        const plugin: WebVitalsPlugin = new WebVitalsPlugin();
+
+        // Run
+        plugin.load(context);
+
+        // Assert
+        expect(record).toHaveBeenCalledWith(
+            TTFB_EVENT_TYPE,
+            expect.objectContaining({
+                version: '1.0.0',
+                value: mockTTFBData.value,
+                attribution: {
+                    waitingDuration: mockTTFBData.attribution.waitingDuration,
+                    cacheDuration: mockTTFBData.attribution.cacheDuration,
+                    dnsDuration: mockTTFBData.attribution.dnsDuration,
+                    connectionDuration:
+                        mockTTFBData.attribution.connectionDuration,
+                    requestDuration: mockTTFBData.attribution.requestDuration
+                }
+            })
+        );
+    });
+
     test('When web vitals are present with reportAllCLS=false then CLS is recorded with attribution as event candidate', async () => {
         // Setup
         const plugin: WebVitalsPlugin = new WebVitalsPlugin({
@@ -199,7 +284,8 @@ describe('WebVitalsPlugin tests', () => {
         plugin.load(context);
 
         // Assert
-        expect(record).toHaveBeenCalledTimes(2);
+        // LCP + FID + FCP + TTFB recorded; CLS is a candidate
+        expect(record).toHaveBeenCalledTimes(4);
         expect(recordCandidate).toHaveBeenCalledWith(
             CLS_EVENT_TYPE,
             expect.objectContaining({
@@ -231,7 +317,8 @@ describe('WebVitalsPlugin tests', () => {
         plugin.load(context);
 
         // Assert
-        expect(record).toHaveBeenCalledTimes(3);
+        // LCP + FID + FCP + TTFB + CLS (reported as a regular event)
+        expect(record).toHaveBeenCalledTimes(5);
 
         expect(record).toHaveBeenCalledWith(
             CLS_EVENT_TYPE,
@@ -392,7 +479,8 @@ describe('WebVitalsPlugin tests', () => {
         plugin.load(context);
 
         // Assert
-        expect(record).toHaveBeenCalledTimes(2);
+        // LCP + FID + FCP + TTFB recorded; INP is a candidate
+        expect(record).toHaveBeenCalledTimes(4);
         expect(recordCandidate).toHaveBeenCalledWith(
             INP_EVENT_TYPE,
             expect.objectContaining({
@@ -429,7 +517,8 @@ describe('WebVitalsPlugin tests', () => {
         plugin.load(context);
 
         // Assert
-        expect(record).toHaveBeenCalledTimes(3);
+        // LCP + FID + FCP + TTFB + INP (reported as a regular event)
+        expect(record).toHaveBeenCalledTimes(5);
         expect(record).toHaveBeenCalledWith(
             INP_EVENT_TYPE,
             expect.objectContaining({
@@ -478,6 +567,16 @@ describe('WebVitalsPlugin tests', () => {
         // Test INP with null attribution
         webVitals.onINP.mockImplementationOnce((callback) => {
             callback({ ...mockINPData, attribution: null });
+        });
+
+        // Test FCP with null attribution
+        webVitals.onFCP.mockImplementationOnce((callback) => {
+            callback({ ...mockFCPData, attribution: null });
+        });
+
+        // Test TTFB with null attribution
+        webVitals.onTTFB.mockImplementationOnce((callback) => {
+            callback({ ...mockTTFBData, attribution: null });
         });
 
         const plugin = new WebVitalsPlugin();
@@ -537,6 +636,32 @@ describe('WebVitalsPlugin tests', () => {
                     processingDuration: undefined,
                     presentationDelay: undefined,
                     loadState: undefined
+                })
+            })
+        );
+
+        // Verify FCP handles null attribution
+        expect(record).toHaveBeenCalledWith(
+            FCP_EVENT_TYPE,
+            expect.objectContaining({
+                attribution: expect.objectContaining({
+                    timeToFirstByte: undefined,
+                    firstByteToFCP: undefined,
+                    loadState: undefined
+                })
+            })
+        );
+
+        // Verify TTFB handles null attribution
+        expect(record).toHaveBeenCalledWith(
+            TTFB_EVENT_TYPE,
+            expect.objectContaining({
+                attribution: expect.objectContaining({
+                    waitingDuration: undefined,
+                    cacheDuration: undefined,
+                    dnsDuration: undefined,
+                    connectionDuration: undefined,
+                    requestDuration: undefined
                 })
             })
         );

--- a/packages/core/src/__smoke-test__/ingestion-integ.spec.ts
+++ b/packages/core/src/__smoke-test__/ingestion-integ.spec.ts
@@ -12,7 +12,9 @@ import {
     SESSION_START_EVENT_TYPE,
     DOM_EVENT_TYPE,
     XRAY_TRACE_EVENT_TYPE,
-    INP_EVENT_TYPE
+    INP_EVENT_TYPE,
+    FCP_EVENT_TYPE,
+    TTFB_EVENT_TYPE
 } from '../plugins/utils/constant';
 import {
     getEventIds,
@@ -151,6 +153,64 @@ test('when FID event is sent then event is ingested', async ({ page }) => {
 
     const fid = getEventsByType(requestBody, FID_EVENT_TYPE);
     const eventIds = getEventIds(fid);
+
+    expect(eventIds.length).not.toEqual(0);
+    const isIngestionCompleted = await verifyIngestionWithRetry(
+        rumClient,
+        eventIds,
+        timestamp,
+        MONITOR_NAME
+    );
+    expect(isIngestionCompleted).toEqual(true);
+});
+
+test('when FCP event is sent then event is ingested', async ({ page }) => {
+    const timestamp = Date.now() - 30000;
+
+    // Open page
+    await page.goto(TEST_URL);
+    const clearButton = page.locator('[id=dummyButton]');
+    await clearButton.click();
+
+    // Test will timeout if no successful dataplane request is found
+    const response = await page.waitForResponse(async (response) =>
+        isDataPlaneRequest(response, TARGET_URL)
+    );
+
+    // Parse payload to verify event count
+    const requestBody = parseRequestBody(response);
+
+    const fcp = getEventsByType(requestBody, FCP_EVENT_TYPE);
+    const eventIds = getEventIds(fcp);
+
+    expect(eventIds.length).not.toEqual(0);
+    const isIngestionCompleted = await verifyIngestionWithRetry(
+        rumClient,
+        eventIds,
+        timestamp,
+        MONITOR_NAME
+    );
+    expect(isIngestionCompleted).toEqual(true);
+});
+
+test('when TTFB event is sent then event is ingested', async ({ page }) => {
+    const timestamp = Date.now() - 30000;
+
+    // Open page
+    await page.goto(TEST_URL);
+    const clearButton = page.locator('[id=dummyButton]');
+    await clearButton.click();
+
+    // Test will timeout if no successful dataplane request is found
+    const response = await page.waitForResponse(async (response) =>
+        isDataPlaneRequest(response, TARGET_URL)
+    );
+
+    // Parse payload to verify event count
+    const requestBody = parseRequestBody(response);
+
+    const ttfb = getEventsByType(requestBody, TTFB_EVENT_TYPE);
+    const eventIds = getEventIds(ttfb);
 
     expect(eventIds.length).not.toEqual(0);
     const isIngestionCompleted = await verifyIngestionWithRetry(

--- a/packages/core/src/event-schemas/first-contentful-paint-event.json
+++ b/packages/core/src/event-schemas/first-contentful-paint-event.json
@@ -1,0 +1,45 @@
+{
+    "$id": "com.amazon.rum.first_contentful_paint_event",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "FirstContentfulPaintEvent",
+    "type": "object",
+    "properties": {
+        "version": {
+            "const": "1.0.0",
+            "type": "string",
+            "description": "Schema version."
+        },
+        "value": {
+            "type": "number",
+            "description": "Time until the first contentful paint in milliseconds"
+        },
+        "attribution": {
+            "type": "object",
+            "description": "Attributions for FCP",
+            "properties": {
+                "timeToFirstByte": {
+                    "type": "number",
+                    "description": "Time from navigation start until the first response byte"
+                },
+                "firstByteToFCP": {
+                    "type": "number",
+                    "description": "Delta between TTFB and FCP"
+                },
+                "loadState": {
+                    "type": "string",
+                    "enum": [
+                        "loading",
+                        "dom-interactive",
+                        "dom-content-loaded",
+                        "complete"
+                    ],
+                    "description": "Document loading state when FCP occurred"
+                }
+            },
+            "required": ["timeToFirstByte", "firstByteToFCP", "loadState"],
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false,
+    "required": ["version", "value"]
+}

--- a/packages/core/src/event-schemas/time-to-first-byte-event.json
+++ b/packages/core/src/event-schemas/time-to-first-byte-event.json
@@ -1,0 +1,53 @@
+{
+    "$id": "com.amazon.rum.time_to_first_byte_event",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "TimeToFirstByteEvent",
+    "type": "object",
+    "properties": {
+        "version": {
+            "const": "1.0.0",
+            "type": "string",
+            "description": "Schema version."
+        },
+        "value": {
+            "type": "number",
+            "description": "Time until the first byte of the response in milliseconds"
+        },
+        "attribution": {
+            "type": "object",
+            "description": "Attributions for TTFB",
+            "properties": {
+                "waitingDuration": {
+                    "type": "number",
+                    "description": "Time from user navigation until request handling begins"
+                },
+                "cacheDuration": {
+                    "type": "number",
+                    "description": "Time spent checking the HTTP cache"
+                },
+                "dnsDuration": {
+                    "type": "number",
+                    "description": "Time to resolve DNS for the requested domain"
+                },
+                "connectionDuration": {
+                    "type": "number",
+                    "description": "Time to create the connection to the requested domain"
+                },
+                "requestDuration": {
+                    "type": "number",
+                    "description": "Time from request sent until first byte received"
+                }
+            },
+            "required": [
+                "waitingDuration",
+                "cacheDuration",
+                "dnsDuration",
+                "connectionDuration",
+                "requestDuration"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false,
+    "required": ["version", "value"]
+}

--- a/packages/core/src/plugins/event-plugins/WebVitalsPlugin.ts
+++ b/packages/core/src/plugins/event-plugins/WebVitalsPlugin.ts
@@ -3,22 +3,30 @@ import { LargestContentfulPaintEvent } from '../../events/largest-contentful-pai
 import { CumulativeLayoutShiftEvent } from '../../events/cumulative-layout-shift-event';
 import { FirstInputDelayEvent } from '../../events/first-input-delay-event';
 import { InteractionToNextPaintEvent } from '../../events/interaction-to-next-paint';
+import { FirstContentfulPaintEvent } from '../../events/first-contentful-paint-event';
+import { TimeToFirstByteEvent } from '../../events/time-to-first-byte-event';
 import {
     CLSMetricWithAttribution,
+    FCPMetricWithAttribution,
     FIDMetricWithAttribution,
     INPMetricWithAttribution,
     LCPMetricWithAttribution,
+    TTFBMetricWithAttribution,
     Metric,
     onCLS,
+    onFCP,
     onFID,
     onLCP,
-    onINP
+    onINP,
+    onTTFB
 } from 'web-vitals/attribution';
 import {
     CLS_EVENT_TYPE,
+    FCP_EVENT_TYPE,
     FID_EVENT_TYPE,
     INP_EVENT_TYPE,
     LCP_EVENT_TYPE,
+    TTFB_EVENT_TYPE,
     PERFORMANCE_NAVIGATION_EVENT_TYPE,
     PERFORMANCE_RESOURCE_EVENT_TYPE
 } from '../utils/constant';
@@ -65,6 +73,8 @@ export class WebVitalsPlugin extends InternalPlugin {
             reportAllChanges: true
         });
         onINP((metric) => this.handleINP(metric), { reportAllChanges: true });
+        onFCP((metric) => this.handleFCP(metric));
+        onTTFB((metric) => this.handleTTFB(metric));
     }
 
     private handleEvent = (event: ParsedRumEvent) => {
@@ -170,5 +180,33 @@ export class WebVitalsPlugin extends InternalPlugin {
                 loadState: a?.loadState
             }
         } as InteractionToNextPaintEvent);
+    }
+
+    private handleFCP(metric: FCPMetricWithAttribution | Metric) {
+        const a = (metric as FCPMetricWithAttribution).attribution;
+        this.context?.record(FCP_EVENT_TYPE, {
+            version: '1.0.0',
+            value: metric.value,
+            attribution: {
+                timeToFirstByte: a?.timeToFirstByte,
+                firstByteToFCP: a?.firstByteToFCP,
+                loadState: a?.loadState
+            }
+        } as FirstContentfulPaintEvent);
+    }
+
+    private handleTTFB(metric: TTFBMetricWithAttribution | Metric) {
+        const a = (metric as TTFBMetricWithAttribution).attribution;
+        this.context?.record(TTFB_EVENT_TYPE, {
+            version: '1.0.0',
+            value: metric.value,
+            attribution: {
+                waitingDuration: a?.waitingDuration,
+                cacheDuration: a?.cacheDuration,
+                dnsDuration: a?.dnsDuration,
+                connectionDuration: a?.connectionDuration,
+                requestDuration: a?.requestDuration
+            }
+        } as TimeToFirstByteEvent);
     }
 }

--- a/packages/core/src/plugins/event-plugins/__integ__/WebVitalsPlugin.spec.ts
+++ b/packages/core/src/plugins/event-plugins/__integ__/WebVitalsPlugin.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from '@playwright/test';
 import {
     CLS_EVENT_TYPE,
+    FCP_EVENT_TYPE,
     INP_EVENT_TYPE,
     LCP_EVENT_TYPE,
     PERFORMANCE_NAVIGATION_EVENT_TYPE,
-    PERFORMANCE_RESOURCE_EVENT_TYPE
+    PERFORMANCE_RESOURCE_EVENT_TYPE,
+    TTFB_EVENT_TYPE
 } from '../../utils/constant';
 
 test.describe('WebVitalEvent Plugin', () => {
@@ -100,6 +102,53 @@ test.describe('WebVitalEvent Plugin', () => {
             expect(typeof inpEventDetails.value).toBe('number');
             expect(typeof inpEventDetails.attribution).toBe('object');
         }
+    });
+
+    test('WebVitalEvent records fcp and ttfb events on chrome', async ({
+        page,
+        browserName
+    }) => {
+        test.skip(
+            browserName === 'webkit' || browserName === 'firefox',
+            'Test is skipped for Safari and Firefox'
+        );
+
+        await page.goto('/web_vital_event.html');
+
+        await page.waitForTimeout(300);
+        // FCP and TTFB are reported on initial load; flush on page hide.
+        await page.click('#testButton');
+        await page.click('#makePageHidden');
+
+        const responseStatus = await page
+            .locator('#response_status')
+            .textContent();
+        const requestBodyText = await page
+            .locator('#request_body')
+            .textContent();
+
+        expect(responseStatus).toBe('202');
+        expect(requestBodyText).toContain('BatchId');
+
+        const content = requestBodyText || '{}';
+
+        const fcpEvents = JSON.parse(content).RumEvents.filter(
+            (e: any) => e.type === FCP_EVENT_TYPE
+        );
+        const ttfbEvents = JSON.parse(content).RumEvents.filter(
+            (e: any) => e.type === TTFB_EVENT_TYPE
+        );
+
+        expect(fcpEvents.length).toBeGreaterThan(0);
+        expect(ttfbEvents.length).toBeGreaterThan(0);
+
+        const fcpEventDetails = JSON.parse(fcpEvents[0].details);
+        const ttfbEventDetails = JSON.parse(ttfbEvents[0].details);
+
+        expect(typeof fcpEventDetails.value).toBe('number');
+        expect(typeof ttfbEventDetails.value).toBe('number');
+        expect(typeof fcpEventDetails.attribution).toBe('object');
+        expect(typeof ttfbEventDetails.attribution).toBe('object');
     });
 
     test('when navigation is recorded then it is attributed to lcp', async ({

--- a/packages/core/src/plugins/utils/constant.ts
+++ b/packages/core/src/plugins/utils/constant.ts
@@ -11,6 +11,8 @@ export const LCP_EVENT_TYPE = `${RUM_AMZ_PREFIX}.largest_contentful_paint_event`
 export const FID_EVENT_TYPE = `${RUM_AMZ_PREFIX}.first_input_delay_event`;
 export const CLS_EVENT_TYPE = `${RUM_AMZ_PREFIX}.cumulative_layout_shift_event`;
 export const INP_EVENT_TYPE = `${RUM_AMZ_PREFIX}.interaction_to_next_paint_event`;
+export const FCP_EVENT_TYPE = `${RUM_AMZ_PREFIX}.first_contentful_paint_event`;
+export const TTFB_EVENT_TYPE = `${RUM_AMZ_PREFIX}.time_to_first_byte_event`;
 
 // Page load event schemas
 export const PERFORMANCE_NAVIGATION_EVENT_TYPE = `${RUM_AMZ_PREFIX}.performance_navigation_event`;


### PR DESCRIPTION
Add FCP and TTFB collection to WebVitalsPlugin using web-vitals onFCP/onTTFB, with new event schemas and event-type constants. Mirrors the existing LCP/FID/CLS/INP collection pattern.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
