### PR TITLE
chore(release): v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.2.0](https://github.com/aws-observability/aws-rum-web/compare/v3.1.0...v3.2.0) (2026-07-21)
+
+
+### Bug Fixes
+
+* include README in aws-rum-web npm package ([#840](https://github.com/aws-observability/aws-rum-web/issues/840)) ([213c5af](https://github.com/aws-observability/aws-rum-web/commit/213c5af4a0351ec256ae37a3d5f7f9cedc93f4e5))
+* **smoke:** pin @types/node to ^20 for TS 4.9 compatibility ([#865](https://github.com/aws-observability/aws-rum-web/issues/865)) ([39a2e54](https://github.com/aws-observability/aws-rum-web/commit/39a2e54f9a506894f53d304fc542f99c5b0090a9))
+* Update CI workflow configuration ([#845](https://github.com/aws-observability/aws-rum-web/issues/845)) ([9f008ba](https://github.com/aws-observability/aws-rum-web/commit/9f008ba8a3dfde647c5b153b99d23d388e1bbf48))
+
+
+### Features
+
+* collect First Contentful Paint and Time to First Byte web vitals ([#855](https://github.com/aws-observability/aws-rum-web/issues/855)) ([13e3c3d](https://github.com/aws-observability/aws-rum-web/commit/13e3c3d537de073b72b24a570b3f9745d278b978))
+
+
+
+
+
 # [3.1.0](https://github.com/aws-observability/aws-rum-web/compare/v3.0.0...v3.1.0) (2026-05-19)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
     "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "npmClient": "npm",
     "packages": ["packages/*"],
     "command": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-rum-web-monorepo",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "private": true,
     "description": "The Amazon CloudWatch RUM web client monorepo.",
     "license": "Apache-2.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.2.0](https://github.com/aws-observability/aws-rum-web/compare/v3.1.0...v3.2.0) (2026-07-21)
+
+
+### Features
+
+* collect First Contentful Paint and Time to First Byte web vitals ([#855](https://github.com/aws-observability/aws-rum-web/issues/855)) ([13e3c3d](https://github.com/aws-observability/aws-rum-web/commit/13e3c3d537de073b72b24a570b3f9745d278b978))
+
+
+
+
+
 # [3.1.0](https://github.com/aws-observability/aws-rum-web/compare/v3.0.0...v3.1.0) (2026-05-19)
 
 

--- a/packages/core/__tests__/utils/version.test.ts
+++ b/packages/core/__tests__/utils/version.test.ts
@@ -2,6 +2,6 @@ import { WEB_CLIENT_VERSION } from '../../src/utils/version';
 
 describe('version', () => {
     test('WEB_CLIENT_VERSION matches package.json version', () => {
-        expect(WEB_CLIENT_VERSION).toEqual('3.1.0');
+        expect(WEB_CLIENT_VERSION).toEqual('3.2.0');
     });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-rum/web-core",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "Core telemetry engine for the Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",
     "main": "dist/cjs/index.js",

--- a/packages/core/src/utils/version.ts
+++ b/packages/core/src/utils/version.ts
@@ -1,1 +1,1 @@
-export const WEB_CLIENT_VERSION = '3.1.0';
+export const WEB_CLIENT_VERSION = '3.2.0';

--- a/packages/slim/CHANGELOG.md
+++ b/packages/slim/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.2.0](https://github.com/aws-observability/aws-rum-web/compare/v3.1.0...v3.2.0) (2026-07-21)
+
+**Note:** Version bump only for package @aws-rum/web-slim
+
+
+
+
+
 # [3.1.0](https://github.com/aws-observability/aws-rum-web/compare/v3.0.0...v3.1.0) (2026-05-19)
 
 

--- a/packages/slim/package.json
+++ b/packages/slim/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws-rum/web-slim",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "Lightweight re-write of Amazon CloudWatch RUM web client using imperative paradigm.",
     "license": "Apache-2.0",
     "author": "Amazon CloudWatch RUM Staff <nobody@amazon.com>",
@@ -46,6 +46,6 @@
         "stats": "webpack --config webpack/webpack.stats.js"
     },
     "dependencies": {
-        "@aws-rum/web-core": "3.1.0"
+        "@aws-rum/web-core": "3.2.0"
     }
 }

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.2.0](https://github.com/aws-observability/aws-rum-web/compare/v3.1.0...v3.2.0) (2026-07-21)
+
+
+### Bug Fixes
+
+* include README in aws-rum-web npm package ([#840](https://github.com/aws-observability/aws-rum-web/issues/840)) ([213c5af](https://github.com/aws-observability/aws-rum-web/commit/213c5af4a0351ec256ae37a3d5f7f9cedc93f4e5))
+
+
+
+
+
 # [3.1.0](https://github.com/aws-observability/aws-rum-web/compare/v3.0.0...v3.1.0) (2026-05-19)
 
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-rum-web",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "The Amazon CloudWatch RUM web client.",
     "license": "Apache-2.0",
     "author": "Amazon CloudWatch RUM Staff <nobody@amazon.com>",
@@ -26,7 +26,7 @@
         "build": "npm-run-all -s build:dist:* build:webpack:prod"
     },
     "dependencies": {
-        "@aws-rum/web-core": "3.1.0",
-        "@aws-rum/web-slim": "3.1.0"
+        "@aws-rum/web-core": "3.2.0",
+        "@aws-rum/web-slim": "3.2.0"
     }
 }


### PR DESCRIPTION
## Release 3.2.0

### Bug Fixes

* include README in aws-rum-web npm package ([#840](https://github.com/aws-observability/aws-rum-web/issues/840)) ([213c5af](https://github.com/aws-observability/aws-rum-web/commit/213c5af4a0351ec256ae37a3d5f7f9cedc93f4e5))
* **smoke:** pin @types/node to ^20 for TS 4.9 compatibility ([#865](https://github.com/aws-observability/aws-rum-web/issues/865)) ([39a2e54](https://github.com/aws-observability/aws-rum-web/commit/39a2e54f9a506894f53d304fc542f99c5b0090a9))
* Update CI workflow configuration ([#845](https://github.com/aws-observability/aws-rum-web/issues/845)) ([9f008ba](https://github.com/aws-observability/aws-rum-web/commit/9f008ba8a3dfde647c5b153b99d23d388e1bbf48))


### Features

* collect First Contentful Paint and Time to First Byte web vitals ([#855](https://github.com/aws-observability/aws-rum-web/issues/855)) ([13e3c3d](https://github.com/aws-observability/aws-rum-web/commit/13e3c3d537de073b72b24a570b3f9745d278b978))

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.