### PR TITLE
fix(cd): pin npm to ^11 for Node 20 compatibility

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -38,7 +38,7 @@ jobs:
 
             - name: Build Release
               run: |
-                  npm install -g npm@latest
+                  npm install -g npm@^11
                   npm ci
                   npm run release
 


### PR DESCRIPTION
## Summary

The **Publish New Release** job in `cd.yaml` failed with `EBADENGINE`:

```
npm error engine Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`npm install -g npm@latest` now resolves to **npm 12**, which dropped Node 20 support. The release runner is on Node `20.x` (consistent with `.nvmrc` = v20.19.0 and all other workflow jobs).

## Fix

Pin the global npm install to `npm@^11` — the last major that supports Node 20 — instead of floating `@latest`. This keeps the whole repo standardized on Node 20 rather than special-casing this one job.

`cd.yaml` is the only place in the repo that upgrades npm globally; no other workflow or script needs this change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.