### PR TITLE
fix: derive dataplane endpoint from constructor region

### DIFF
--- a/packages/web/__tests__/orchestration/Orchestration.test.ts
+++ b/packages/web/__tests__/orchestration/Orchestration.test.ts
@@ -105,25 +105,53 @@ describe('Orchestration tests', () => {
 
     test('when region is not provided then endpoint region defaults to us-west-2', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'c', undefined, {});
+        new Orchestration('a', 'c', undefined, {});
 
-        const dispatchmock = (Dispatch as any).mock;
         // Assert
         expect(Dispatch).toHaveBeenCalledTimes(1);
         expect((Dispatch as any).mock.calls[0][2]).toEqual(
             new URL('https://dataplane.rum.us-west-2.amazonaws.com/')
         );
+        expect((EventCache as any).mock.calls[0][1]).toMatchObject({
+            endpoint: 'https://dataplane.rum.us-west-2.amazonaws.com',
+            endpointUrl: new URL(
+                'https://dataplane.rum.us-west-2.amazonaws.com'
+            )
+        });
     });
 
     test('when region is provided then the endpoint uses that region', async () => {
         // Init
-        const orchestration = new Orchestration('a', 'c', 'us-east-1', {});
+        new Orchestration('a', 'c', 'eu-west-1', {});
 
         // Assert
         expect(Dispatch).toHaveBeenCalledTimes(1);
         expect((Dispatch as any).mock.calls[0][2]).toEqual(
-            new URL('https://dataplane.rum.us-east-1.amazonaws.com/')
+            new URL('https://dataplane.rum.eu-west-1.amazonaws.com/')
         );
+        expect((EventCache as any).mock.calls[0][1]).toMatchObject({
+            endpoint: 'https://dataplane.rum.eu-west-1.amazonaws.com',
+            endpointUrl: new URL(
+                'https://dataplane.rum.eu-west-1.amazonaws.com'
+            )
+        });
+    });
+
+    test('when custom endpoint is provided then it overrides the region endpoint', async () => {
+        // Init
+        new Orchestration('a', 'c', 'eu-west-1', {
+            endpoint: 'https://custom.endpoint.com'
+        });
+
+        // Assert
+        expect(Dispatch).toHaveBeenCalledTimes(1);
+        expect((Dispatch as any).mock.calls[0][2]).toEqual(
+            new URL('https://custom.endpoint.com')
+        );
+        expect((EventCache as any).mock.calls[0][1]).toMatchObject({
+            endpoint: 'https://custom.endpoint.com',
+            endpointUrl: new URL('https://custom.endpoint.com')
+        });
     });
 
     test('when enable is true in config then orchestration enables dispatch, pluginManager and event cache', async () => {

--- a/packages/web/src/orchestration/Orchestration.ts
+++ b/packages/web/src/orchestration/Orchestration.ts
@@ -61,8 +61,13 @@ export class Orchestration extends SlimOrchestration {
         region: string,
         partialConfig: PartialConfig = {}
     ) {
+        const { signing, telemetries } = defaultConfig(
+            defaultCookieAttributes()
+        );
+
         super(applicationId, applicationVersion, region, {
-            ...defaultConfig(defaultCookieAttributes()),
+            signing,
+            telemetries,
             ...partialConfig
         } as any);
 


### PR DESCRIPTION
## Summary

Fixes #854 by allowing `AwsRum` to derive the RUM dataplane endpoint from the constructor `region` when `endpoint` is not explicitly configured.

The full client now passes only its distribution-specific defaults (`signing` and `telemetries`) to the slim client. This preserves endpoint precedence:

1. Explicit `endpoint`
2. Endpoint derived from constructor `region`
3. `us-west-2` when no region is supplied

No public API changes.

## Tests

- `npx jest -c jest.unit.config.js --runInBand --no-cache --coverage=false packages/web/__tests__/orchestration/Orchestration.test.ts`
- `npm test -- --runInBand`
- `npm run build`

Added coverage for:

- Default `us-west-2` endpoint when region is omitted
- Region-derived `eu-west-1` endpoint and URL
- Explicit custom endpoint override

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.