### PR TITLE
fix: replace uuid dependency with native crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "@types/pako": "^2.0.4",
                 "@types/shimmer": "^1.0.2",
                 "@types/ua-parser-js": "^0.7.35",
-                "@types/uuid": "^9.0.0",
                 "@typescript-eslint/eslint-plugin": "^5.38.0",
                 "@typescript-eslint/parser": "^5.38.0",
                 "@webpack-cli/serve": "^3.0.1",
@@ -5865,13 +5864,6 @@
             "version": "0.7.39",
             "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
             "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/uuid": {
-            "version": "9.0.8",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-            "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
             "dev": true,
             "license": "MIT"
         },
@@ -22508,19 +22500,6 @@
                 "node": ">= 0.4.0"
             }
         },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -23629,7 +23608,6 @@
                 "@smithy/util-hex-encoding": "^3.0.0",
                 "rrweb": "2.0.0-alpha.4",
                 "shimmer": "^1.2.1",
-                "uuid": "^9.0.0",
                 "web-vitals": "^4.0.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
         "@types/pako": "^2.0.4",
         "@types/shimmer": "^1.0.2",
         "@types/ua-parser-js": "^0.7.35",
-        "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
         "@webpack-cli/serve": "^3.0.1",

--- a/packages/core/__tests__/sessions/SessionManager.test.ts
+++ b/packages/core/__tests__/sessions/SessionManager.test.ts
@@ -934,7 +934,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true }
         };
-        const cookieSessionId = uuid.v4();
+        const cookieSessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(

--- a/packages/core/__tests__/sessions/SessionManager.test.ts
+++ b/packages/core/__tests__/sessions/SessionManager.test.ts
@@ -9,7 +9,6 @@ import {
     removeCookie,
     storeCookie
 } from '@aws-rum/web-core/utils/cookies-utils';
-import * as uuid from 'uuid';
 import { navigationEvent } from '@aws-rum/web-core/test-utils/mock-data';
 import { Config } from '@aws-rum/web-core/orchestration/config';
 import * as configModule from '@aws-rum/web-core/orchestration/config';
@@ -113,7 +112,7 @@ describe('SessionManager tests', () => {
             ...{ allowCookies: true }
         };
 
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(JSON.stringify({ sessionId, record: true })),
@@ -224,7 +223,7 @@ describe('SessionManager tests', () => {
 
     test('when sessionId cookie is corrupt then getSession returns a new sessionId', async () => {
         // Init
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         const config = {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true }
@@ -276,7 +275,7 @@ describe('SessionManager tests', () => {
             ...{ allowCookies: true }
         };
 
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(JSON.stringify({ sessionId, record: true })),
@@ -315,7 +314,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true, userIdRetentionDays: 90 }
         };
-        const userId = uuid.v4();
+        const userId = crypto.randomUUID();
         storeCookie(
             USER_COOKIE_NAME,
             userId,
@@ -360,7 +359,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true, userIdRetentionDays: 90 }
         };
-        const userId = uuid.v4();
+        const userId = crypto.randomUUID();
         storeCookie(
             USER_COOKIE_NAME,
             userId,
@@ -435,7 +434,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true }
         };
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(
@@ -595,7 +594,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true }
         };
-        const sessionId = uuid.v4();
+        const sessionId = crypto.randomUUID();
         storeCookie(
             SESSION_COOKIE_NAME,
             btoa(JSON.stringify({ sessionId, record: true, eventCount: 1 })),
@@ -749,7 +748,7 @@ describe('SessionManager tests', () => {
             ...DEFAULT_CONFIG,
             ...{ allowCookies: true, userIdRetentionDays: 0 }
         };
-        const userId = uuid.v4();
+        const userId = crypto.randomUUID();
         storeCookie(
             USER_COOKIE_NAME,
             userId,

--- a/packages/core/__tests__/sessions/SessionManager.test.ts
+++ b/packages/core/__tests__/sessions/SessionManager.test.ts
@@ -308,6 +308,22 @@ describe('SessionManager tests', () => {
         expect(sessionManager.getUserId()).toEqual(userId);
     });
 
+    test('When userId does not exist in cookie, then the generated userId is written to the cookie', async () => {
+        // Init -- no user cookie exists, so initializeUser() generates one
+        const sessionManager = defaultSessionManager({
+            ...DEFAULT_CONFIG,
+            ...{ allowCookies: true, userIdRetentionDays: 90 }
+        });
+
+        // Run
+        const userId = sessionManager.getUserId();
+
+        // Assert -- the cookie carries the generated ID rather than an empty
+        // string, so the ID survives the next page load
+        expect(userId).not.toEqual('');
+        expect(getCookie(USER_COOKIE_NAME)).toEqual(userId);
+    });
+
     test('When userId exists in cookie, then it returns the same userId', async () => {
         // Init
         const config = {

--- a/packages/core/__tests__/utils/random.test.ts
+++ b/packages/core/__tests__/utils/random.test.ts
@@ -1,0 +1,185 @@
+import { generateUUID, getRandomValues } from '../../src/utils/random';
+
+const UUID_V4_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+const globals = globalThis as Record<string, unknown>;
+const originalCrypto = globals.crypto;
+
+const setCrypto = (value: unknown) => {
+    Object.defineProperty(globalThis, 'crypto', {
+        value,
+        configurable: true,
+        writable: true
+    });
+};
+
+const removeCrypto = () => {
+    delete globals.crypto;
+};
+
+/** getRandomValues() stub which fills the holder with a constant byte. */
+const fillWith = (byte: number) => (holder: Uint8Array) => holder.fill(byte);
+
+describe('random utils', () => {
+    afterEach(() => {
+        setCrypto(originalCrypto);
+        delete globals.msCrypto;
+    });
+
+    describe('getRandomValues()', () => {
+        test('when crypto is available then it delegates to crypto', async () => {
+            // Init
+            const holder = new Uint8Array(16);
+            const getRandomValuesSpy = jest.fn(fillWith(0x01));
+            setCrypto({ getRandomValues: getRandomValuesSpy });
+
+            // Run
+            const values = getRandomValues(holder);
+
+            // Assert
+            expect(getRandomValuesSpy).toHaveBeenCalledWith(holder);
+            expect(values).toEqual(new Uint8Array(16).fill(0x01));
+        });
+
+        test('when crypto is undefined then it falls back to msCrypto', async () => {
+            // Init
+            const getRandomValuesSpy = jest.fn(fillWith(0x02));
+            removeCrypto();
+            globals.msCrypto = { getRandomValues: getRandomValuesSpy };
+
+            // Run
+            const values = getRandomValues(new Uint8Array(16));
+
+            // Assert
+            expect(getRandomValuesSpy).toHaveBeenCalled();
+            expect(values).toEqual(new Uint8Array(16).fill(0x02));
+        });
+
+        test('when no crypto library is available then it throws', async () => {
+            // Init
+            removeCrypto();
+
+            // Run and Assert
+            expect(() => getRandomValues(new Uint8Array(16))).toThrow(
+                'No crypto library found.'
+            );
+        });
+
+        test('when using the platform crypto then the holder is populated', async () => {
+            // Run
+            const values = getRandomValues(new Uint8Array(16));
+
+            // Assert
+            expect(values).toHaveLength(16);
+            expect(values.some((byte) => byte !== 0)).toBe(true);
+        });
+    });
+
+    describe('generateUUID()', () => {
+        test('when crypto.randomUUID is available then it is used', async () => {
+            // Init
+            const uuid = '1b6a3d4e-8f2c-4a1b-9c3d-5e6f7a8b9c0d';
+            const randomUUID = jest.fn(() => uuid);
+            const getRandomValuesSpy = jest.fn(fillWith(0x00));
+            setCrypto({ randomUUID, getRandomValues: getRandomValuesSpy });
+
+            // Run
+            const result = generateUUID();
+
+            // Assert
+            expect(result).toEqual(uuid);
+            expect(randomUUID).toHaveBeenCalled();
+            expect(getRandomValuesSpy).not.toHaveBeenCalled();
+        });
+
+        test('when crypto.randomUUID is unavailable then a v4 UUID is generated from random bytes', async () => {
+            // Init
+            setCrypto({ getRandomValues: jest.fn(fillWith(0xab)) });
+
+            // Run
+            const result = generateUUID();
+
+            // Assert
+            expect(result).toMatch(UUID_V4_REGEX);
+            expect(result).toEqual('abababab-abab-4bab-abab-abababababab');
+        });
+
+        test('when generating from all-zero bytes then version and variant bits are set', async () => {
+            // Init
+            setCrypto({ getRandomValues: jest.fn(fillWith(0x00)) });
+
+            // Run
+            const result = generateUUID();
+
+            // Assert -- leading zeroes are preserved and bits 6/8 are stamped
+            expect(result).toEqual('00000000-0000-4000-8000-000000000000');
+        });
+
+        test('when generating from all-one bytes then version and variant bits are set', async () => {
+            // Init
+            setCrypto({ getRandomValues: jest.fn(fillWith(0xff)) });
+
+            // Run
+            const result = generateUUID();
+
+            // Assert
+            expect(result).toEqual('ffffffff-ffff-4fff-bfff-ffffffffffff');
+        });
+
+        test('when crypto is undefined then it generates a UUID using msCrypto', async () => {
+            // Init
+            removeCrypto();
+            globals.msCrypto = { getRandomValues: jest.fn(fillWith(0x10)) };
+
+            // Run
+            const result = generateUUID();
+
+            // Assert
+            expect(result).toMatch(UUID_V4_REGEX);
+        });
+
+        test('when no crypto library is available then it throws', async () => {
+            // Init
+            removeCrypto();
+
+            // Run and Assert
+            expect(() => generateUUID()).toThrow('No crypto library found.');
+        });
+
+        test('when generated repeatedly then UUIDs are valid and unique', async () => {
+            // Init
+            const uuids = new Set<string>();
+
+            // Run
+            for (let i = 0; i < 1000; i++) {
+                const uuid = generateUUID();
+                expect(uuid).toMatch(UUID_V4_REGEX);
+                uuids.add(uuid);
+            }
+
+            // Assert
+            expect(uuids.size).toEqual(1000);
+        });
+
+        test('when the random byte fallback is used repeatedly then UUIDs are valid and unique', async () => {
+            // Init
+            const platformCrypto = originalCrypto as Crypto;
+            setCrypto({
+                getRandomValues: (holder: Uint8Array) =>
+                    platformCrypto.getRandomValues(holder)
+            });
+            const uuids = new Set<string>();
+
+            // Run
+            for (let i = 0; i < 1000; i++) {
+                const uuid = generateUUID();
+                expect(uuid).toMatch(UUID_V4_REGEX);
+                uuids.add(uuid);
+            }
+
+            // Assert
+            expect(uuids.size).toEqual(1000);
+        });
+    });
+});

--- a/packages/core/__tests__/utils/random.test.ts
+++ b/packages/core/__tests__/utils/random.test.ts
@@ -139,6 +139,21 @@ describe('random utils', () => {
             expect(getRandomValuesSpy).not.toHaveBeenCalled();
         });
 
+        test('when crypto.randomUUID is not callable then the byte fallback is used', async () => {
+            // Init -- a non-callable randomUUID passes a truthiness check but
+            // throws a TypeError when invoked, so the guard must check the type
+            setCrypto({
+                randomUUID: 'not a function',
+                getRandomValues: jest.fn(fillWith(0xab))
+            });
+
+            // Run
+            const result = generateUUID();
+
+            // Assert
+            expect(result).toEqual('abababab-abab-4bab-abab-abababababab');
+        });
+
         test('when crypto.randomUUID is unavailable then a v4 UUID is generated from random bytes', async () => {
             // Init
             setCrypto({ getRandomValues: jest.fn(fillWith(0xab)) });

--- a/packages/core/__tests__/utils/random.test.ts
+++ b/packages/core/__tests__/utils/random.test.ts
@@ -35,25 +35,41 @@ describe('random utils', () => {
             setCrypto({ getRandomValues: getRandomValuesSpy });
 
             // Run
-            const values = getRandomValues(holder);
+            getRandomValues(holder);
 
             // Assert
             expect(getRandomValuesSpy).toHaveBeenCalledWith(holder);
-            expect(values).toEqual(new Uint8Array(16).fill(0x01));
+            expect(holder).toEqual(new Uint8Array(16).fill(0x01));
         });
 
         test('when crypto is undefined then it falls back to msCrypto', async () => {
             // Init
+            const holder = new Uint8Array(16);
             const getRandomValuesSpy = jest.fn(fillWith(0x02));
             removeCrypto();
             globals.msCrypto = { getRandomValues: getRandomValuesSpy };
 
             // Run
-            const values = getRandomValues(new Uint8Array(16));
+            getRandomValues(holder);
 
             // Assert
-            expect(getRandomValuesSpy).toHaveBeenCalled();
-            expect(values).toEqual(new Uint8Array(16).fill(0x02));
+            expect(getRandomValuesSpy).toHaveBeenCalledWith(holder);
+            expect(holder).toEqual(new Uint8Array(16).fill(0x02));
+        });
+
+        test('when crypto exists but getRandomValues is missing then it falls back to msCrypto', async () => {
+            // Init
+            const holder = new Uint8Array(16);
+            const getRandomValuesSpy = jest.fn(fillWith(0x03));
+            setCrypto({ randomUUID: jest.fn() });
+            globals.msCrypto = { getRandomValues: getRandomValuesSpy };
+
+            // Run
+            getRandomValues(holder);
+
+            // Assert
+            expect(getRandomValuesSpy).toHaveBeenCalledWith(holder);
+            expect(holder).toEqual(new Uint8Array(16).fill(0x03));
         });
 
         test('when no crypto library is available then it throws', async () => {
@@ -66,13 +82,43 @@ describe('random utils', () => {
             );
         });
 
-        test('when using the platform crypto then the holder is populated', async () => {
+        test('when crypto exists but getRandomValues and msCrypto are missing then it throws', async () => {
+            // Init
+            setCrypto({ randomUUID: jest.fn() });
+
+            // Run and Assert
+            expect(() => getRandomValues(new Uint8Array(16))).toThrow(
+                'No crypto library found.'
+            );
+        });
+
+        test('when the implementation returns undefined then the holder is still filled', async () => {
+            // Init -- IE11's msCrypto and most hand-rolled stubs fill in place
+            // and return undefined, so nothing may read the return value.
+            const holder = new Uint8Array(16);
+            setCrypto({
+                getRandomValues: jest.fn((h: Uint8Array) => {
+                    h.fill(0x04);
+                })
+            });
+
             // Run
-            const values = getRandomValues(new Uint8Array(16));
+            getRandomValues(holder);
 
             // Assert
-            expect(values).toHaveLength(16);
-            expect(values.some((byte) => byte !== 0)).toBe(true);
+            expect(holder).toEqual(new Uint8Array(16).fill(0x04));
+        });
+
+        test('when using the platform crypto then the holder is populated', async () => {
+            // Init
+            const holder = new Uint8Array(16);
+
+            // Run
+            getRandomValues(holder);
+
+            // Assert
+            expect(holder).toHaveLength(16);
+            expect(holder.some((byte) => byte !== 0)).toBe(true);
         });
     });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,6 @@
         "@smithy/util-hex-encoding": "^3.0.0",
         "rrweb": "2.0.0-alpha.4",
         "shimmer": "^1.2.1",
-        "uuid": "^9.0.0",
         "web-vitals": "^4.0.0"
     }
 }

--- a/packages/core/src/dispatch/Dispatch.ts
+++ b/packages/core/src/dispatch/Dispatch.ts
@@ -9,10 +9,10 @@ import { BeaconHttpHandler } from './BeaconHttpHandler';
 import { FetchHttpHandler } from './FetchHttpHandler';
 import { PutRumEventsRequest } from './dataplane';
 import { Config } from '../orchestration/config';
-import { v4 } from 'uuid';
 import { RetryHttpHandler } from './RetryHttpHandler';
 import { InternalLogger } from '../utils/InternalLogger';
 import { CRED_KEY, IDENTITY_KEY } from '../utils/constants';
+import { generateUUID } from '../utils/random';
 
 type SendFunction = (
     putRumEventsRequest: PutRumEventsRequest
@@ -325,7 +325,7 @@ export class Dispatch {
 
     private createRequest(flush = false): PutRumEventsRequest {
         return {
-            BatchId: v4(),
+            BatchId: generateUUID(),
             AppMonitorDetails: this.eventCache.getAppMonitorDetails(),
             UserDetails: this.eventCache.getUserDetails(),
             SessionMetadata: JSON.stringify(

--- a/packages/core/src/event-cache/EventCache.ts
+++ b/packages/core/src/event-cache/EventCache.ts
@@ -1,5 +1,4 @@
 import { Session, SessionManager } from '../sessions/SessionManager';
-import { v4 } from 'uuid';
 import { MetaData } from '../events/meta-data';
 import { Config } from '../orchestration/config';
 import { PageAttributes, PageManager } from '../sessions/PageManager';
@@ -17,6 +16,7 @@ import {
 } from '../plugins/types';
 import { SESSION_START_EVENT_TYPE } from '../plugins/utils/constant';
 import { InternalLogger } from '../utils/InternalLogger';
+import { generateUUID } from '../utils/random';
 
 import { WEB_CLIENT_VERSION } from '../utils/version';
 
@@ -528,7 +528,7 @@ export class EventCache {
         };
 
         const partialEvent = {
-            id: v4(),
+            id: generateUUID(),
             timestamp: new Date(),
             type
         };

--- a/packages/core/src/sessions/SessionManager.ts
+++ b/packages/core/src/sessions/SessionManager.ts
@@ -347,7 +347,7 @@ export class SessionManager {
         } else if (this.useCookies()) {
             userId = this.getUserIdCookie();
             this.userId = userId ? userId : generateUUID();
-            this.createOrRenewUserCookie(userId, this.userExpiry);
+            this.createOrRenewUserCookie(this.userId, this.userExpiry);
         } else {
             this.userId = generateUUID();
         }

--- a/packages/core/src/sessions/SessionManager.ts
+++ b/packages/core/src/sessions/SessionManager.ts
@@ -1,6 +1,5 @@
 import { storeCookie, getCookie } from '../utils/cookies-utils';
 
-import { v4 } from 'uuid';
 import { Config, userAgentDataProvider } from '../orchestration/config';
 import { Page, PageManager } from './PageManager';
 import { SESSION_COOKIE_NAME, USER_COOKIE_NAME } from '../utils/constants';
@@ -8,6 +7,7 @@ import { AppMonitorDetails } from '../dispatch/dataplane';
 import { RecordEvent } from '../plugins/types';
 import { SESSION_START_EVENT_TYPE } from '../plugins/utils/constant';
 import { InternalLogger } from '../utils/InternalLogger';
+import { generateUUID } from '../utils/random';
 
 export const NIL_UUID = '00000000-0000-0000-0000-000000000000';
 
@@ -346,10 +346,10 @@ export class SessionManager {
             this.userId = '00000000-0000-0000-0000-000000000000';
         } else if (this.useCookies()) {
             userId = this.getUserIdCookie();
-            this.userId = userId ? userId : v4();
+            this.userId = userId ? userId : generateUUID();
             this.createOrRenewUserCookie(userId, this.userExpiry);
         } else {
-            this.userId = v4();
+            this.userId = generateUUID();
         }
     }
 
@@ -414,7 +414,7 @@ export class SessionManager {
         // We ensure the nil session and new session created right after initialization have the same sampling decision.
         // Otherwise, we will always reevaluate the sample decision.
         this.session = {
-            sessionId: v4(),
+            sessionId: generateUUID(),
             record:
                 this.session.sessionId === NIL_UUID
                     ? this.session.record

--- a/packages/core/src/utils/random.ts
+++ b/packages/core/src/utils/random.ts
@@ -11,3 +11,21 @@ export const getRandomValues = (holder: Uint8Array): Uint8Array => {
         throw new Error('No crypto library found.');
     }
 };
+
+export const generateUUID = (): string => {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+        return crypto.randomUUID();
+    }
+    const bytes = getRandomValues(new Uint8Array(16));
+    // eslint-disable-next-line no-bitwise
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    // eslint-disable-next-line no-bitwise
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+        ''
+    );
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+        12,
+        16
+    )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};

--- a/packages/core/src/utils/random.ts
+++ b/packages/core/src/utils/random.ts
@@ -24,7 +24,10 @@ export const getRandomValues = (holder: Uint8Array): void => {
 };
 
 export const generateUUID = (): string => {
-    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    if (
+        typeof crypto !== 'undefined' &&
+        typeof crypto.randomUUID === 'function'
+    ) {
         return crypto.randomUUID();
     }
     const bytes = new Uint8Array(16);

--- a/packages/core/src/utils/random.ts
+++ b/packages/core/src/utils/random.ts
@@ -1,12 +1,23 @@
 declare let msCrypto:
     | undefined
-    | { getRandomValues: (holder: Uint8Array) => Uint8Array };
+    | { getRandomValues: (holder: Uint8Array) => void };
 
-export const getRandomValues = (holder: Uint8Array): Uint8Array => {
-    if (typeof crypto !== 'undefined') {
-        return crypto.getRandomValues(holder);
-    } else if (typeof msCrypto !== 'undefined') {
-        return msCrypto.getRandomValues(holder);
+// The holder is filled in place. Callers must read the array they passed in,
+// because legacy implementations such as IE11's msCrypto return undefined.
+export const getRandomValues = (holder: Uint8Array): void => {
+    // `typeof x !== 'undefined'` must come first. Optional chaining still
+    // evaluates the identifier, so `crypto?.foo` throws a ReferenceError when
+    // no `crypto` binding exists at all.
+    if (
+        typeof crypto !== 'undefined' &&
+        typeof crypto.getRandomValues === 'function'
+    ) {
+        crypto.getRandomValues(holder);
+    } else if (
+        typeof msCrypto !== 'undefined' &&
+        typeof msCrypto.getRandomValues === 'function'
+    ) {
+        msCrypto.getRandomValues(holder);
     } else {
         throw new Error('No crypto library found.');
     }
@@ -16,7 +27,8 @@ export const generateUUID = (): string => {
     if (typeof crypto !== 'undefined' && crypto.randomUUID) {
         return crypto.randomUUID();
     }
-    const bytes = getRandomValues(new Uint8Array(16));
+    const bytes = new Uint8Array(16);
+    getRandomValues(bytes);
     // eslint-disable-next-line no-bitwise
     bytes[6] = (bytes[6] & 0x0f) | 0x40;
     // eslint-disable-next-line no-bitwise

--- a/packages/core/src/utils/random.ts
+++ b/packages/core/src/utils/random.ts
@@ -3,9 +3,9 @@ declare let msCrypto:
     | { getRandomValues: (holder: Uint8Array) => Uint8Array };
 
 export const getRandomValues = (holder: Uint8Array): Uint8Array => {
-    if (crypto) {
+    if (typeof crypto !== 'undefined') {
         return crypto.getRandomValues(holder);
-    } else if (msCrypto) {
+    } else if (typeof msCrypto !== 'undefined') {
         return msCrypto.getRandomValues(holder);
     } else {
         throw new Error('No crypto library found.');


### PR DESCRIPTION
Re-lands #818, which was merged as 493469e and then reverted in b154d51. Fixes #824.

`@aws-rum/web-core` depends on `uuid` solely for `v4()`. That pulls `uuid@9.0.1` into every consumer's production tree, where `npm audit` flags [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) via `.>aws-rum-web>@aws-rum/web-core>uuid`. The advisory is a missing buffer bounds check in `v3`/`v5`/`v6` when `buf` is passed, a code path this library never calls. The practical problem is therefore a permanently dirty audit for every downstream consumer, not an exploitable defect.

This replaces the dependency with `crypto.randomUUID()`, falling back to a v4 built from `crypto.getRandomValues()` where `randomUUID` is unavailable (it requires a secure context). No runtime dependency, no advisory, smaller bundle.

Per @TrevorBurnham's [comment](https://github.com/aws-observability/aws-rum-web/issues/824#issuecomment-5330779141) on #824, the alternative is bumping to `uuid@11.1.1`. The advisory has been rescoped from `<14.0.0` to `<11.1.1`, so the ESM-only 14.x problem blocking #879 no longer applies. Removing the dependency seemed preferable to keeping one for a single `v4()` call, but the bump is a reasonable call if you'd rather not own the UUID generation.

## Addressing the re-land review conditions

**Unit tests for `generateUUID`.** `random.ts` was at 28% line coverage; it is now at 100% across lines, statements, functions, and branches, via 12 new tests. Three deterministic byte vectors pin the bit manipulation rather than just regex-matching the output:

| bytes | expected |
|---|---|
| `0x00`×16 | `00000000-0000-4000-8000-000000000000` |
| `0xff`×16 | `ffffffff-ffff-4fff-bfff-ffffffffffff` |
| `0xab`×16 | `abababab-abab-4bab-abab-abababababab` |

The all-zero vector is the important one: it's the regression test for `padStart(2, '0')`, where a hand-rolled hex encoder would otherwise drop leading zeros and silently emit a short, malformed UUID. The suite also covers the native path (asserting the byte fallback is not touched), the `msCrypto` fallback, the throw when no crypto exists, and 1000-iteration format/uniqueness loops over both the native and fallback paths.

**Hardening `getRandomValues`.** The bare truthiness checks are now `typeof` guards. This mattered more than it looks: `msCrypto` is only `declare`d and never bound, so `else if (msCrypto)` threw `ReferenceError` on precisely the legacy path it exists to serve, which made the `throw new Error('No crypto library found.')` branch unreachable in practice.

**CDN smoke run.** This one needs a maintainer, since `smoke.yml` has no `pull_request` trigger (only `push` to `main`/`release/*`, `workflow_call`, `workflow_dispatch`) and it publishes to the Gamma CDN using repository secrets. Happy to iterate if a `workflow_dispatch` run surfaces anything.

## Notes on the re-land

**A plain revert of b154d51 will not compile.** #830 added a ninth `uuid.v4()` call site to `SessionManager.test.ts` after #818 was reverted, so #818's import removal no longer covers the whole file. Combining the two yields `TS2304: Cannot find name 'uuid'`, which git won't surface as a conflict because the edits are in different regions. This PR converts that call site along with the other eight, so all nine now use `crypto.randomUUID()`.

**The original #818 left the lockfile unpruned.** It removed `uuid` from `package.json` and `packages/core/package.json` but never pruned the lock, which still carried `uuid: ^9.0.0` under `packages/core`, a root `@types/uuid`, and `node_modules/uuid` 9.0.1 entries. In-repo `npm audit` therefore kept reporting a `node_modules/uuid` node that `npm ci` doesn't even install. Removed here as 22 pure deletions.

Rebased onto v3.2.1, so the lock now inherits the `3.2.0` `version` fields that #889 wrote. The remaining `3.2.0` against `3.2.1` gap is pre-existing drift, because the v3.2.1 release commit didn't touch the lock, and syncing it here would only conflict with your next release commit.

## Verification

On a clean `npm ci`:

- Unit suite: **765 passed, 46/46 suites**, jest exit 0
- Coverage thresholds pass, with branches 87.05% (≥86), functions 88.48% (≥88), lines 93.2%, statements 93.21%
- `npm run build`: exit 0
- `npm audit --omit=dev`: no `uuid` at all. The remaining `uuid@8.3.2` nodes are nested under `nightwatch` and `sockjs`, both devDependencies
- Published `@aws-rum/web-core` declares 10 dependencies, none of them `uuid`; no built bundle references a uuid module
- eslint and prettier clean

Not verified locally: the Playwright integ matrix, since no browsers are cached in my environment. Leaving that to CI, which covers all four engines.

